### PR TITLE
Update skaffold.yaml to add gcb build

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -17,8 +17,6 @@ kind: Config
 build:
   tagPolicy:
     gitCommit: {}
-  googleCloudBuild:
-    diskSizeGb: 300
   artifacts:
   - imageName: gcr.io/microservices-demo-app/emailservice
     workspace: src/emailservice
@@ -44,3 +42,9 @@ deploy:
   kubectl:
     manifests:
     - ./kubernetes-manifests/**.yaml
+profiles:
+  - name: gcb
+    build:
+      googleCloudBuild:
+        diskSizeGb: 300
+        machineType: "N1_HIGHCPU_32"

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -42,6 +42,15 @@ deploy:
   kubectl:
     manifests:
     - ./kubernetes-manifests/**.yaml
+    
+# "gcb" profile allows building and pushing the images
+# on Google Container Builder without requiring docker
+# installed on the developer machine. However, note that
+# since GCB does not cache the builds, each build will
+# start from scratch and therefore take a long time.
+#
+# This is not used by default. To use it, run:
+#     skaffold run -p gcb
 profiles:
   - name: gcb
     build:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -17,6 +17,8 @@ kind: Config
 build:
   tagPolicy:
     gitCommit: {}
+  googleCloudBuild:
+    diskSizeGb: 300
   artifacts:
   - imageName: gcr.io/microservices-demo-app/emailservice
     workspace: src/emailservice


### PR DESCRIPTION
`skaffold run` will fail while building the `cartservice` with a 'No Space Left on Device Error'
Increasing the disk allocated for the build (default 200GB) to get rid of this error.