### PR TITLE
k8s/adservice: bump memory limits for adservice

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -34,10 +34,10 @@ spec:
         resources:
           requests:
             cpu: 200m
-            memory: 64Mi
+            memory: 180Mi
           limits:
             cpu: 300m
-            memory: 128Mi
+            memory: 300Mi
         readinessProbe:
           tcpSocket:
             port: 9555


### PR DESCRIPTION
adservice has beeing OOMkill'ed over the weekend. it looks like the memory
goes up to ~130MiB and then gets killed.

![image](https://user-images.githubusercontent.com/159209/44678176-9f03c300-a9ec-11e8-951f-1c417f8ebf28.png)
