### PR TITLE
adservice: upgrade grpc-java to 1.15.0

### DIFF
--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -26,7 +26,7 @@ group = "adservice"
 version = "0.1.0-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 
 def opencensusVersion = "0.15.0" // LATEST_OPENCENSUS_RELEASE_VERSION
-def grpcVersion = "1.10.1" // CURRENT_GRPC_VERSION
+def grpcVersion = "1.15.0" // CURRENT_GRPC_VERSION
 def prometheusVersion = "0.3.0"
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
Upgrading grpc-java fixed an error that I encountered when I tried modifying the adservice to write logs to Stackdriver with google-cloud-logging ("`com.google.cloud.logging.LoggingException: io.grpc.StatusRuntimeException: UNAUTHENTICATED: Credentials require channel with PRIVACY_AND_INTEGRITY security level. Observed security level: NONE`").