### PR TITLE
adservice: use the Stackdriver Logging library and OpenCensus log correlation

### DIFF
--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -54,7 +54,8 @@ dependencies {
                 "io.grpc:grpc-services:${grpcVersion}",
                 "io.prometheus:simpleclient_httpserver:${prometheusVersion}"
 
-        runtime "io.opencensus:opencensus-impl:${opencensusVersion}",
+        runtime "com.google.cloud:google-cloud-logging:1.45.0",
+                "io.opencensus:opencensus-impl:${opencensusVersion}",
                 "io.netty:netty-tcnative-boringssl-static:2.0.8.Final"
     }
 }
@@ -106,6 +107,7 @@ task adService(type: CreateStartScripts) {
     applicationName = 'AdService'
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + project.configurations.runtime
+    defaultJvmOpts = ["-Djava.util.logging.config.file=./src/main/resources/logging.properties"]
 }
 
 task adServiceClient(type: CreateStartScripts) {
@@ -113,6 +115,7 @@ task adServiceClient(type: CreateStartScripts) {
     applicationName = 'AdServiceClient'
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + project.configurations.runtime
+    defaultJvmOpts = ["-Djava.util.logging.config.file=./src/main/resources/logging.properties"]
 }
 
 applicationDistribution.into('bin') {

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -25,7 +25,7 @@ repositories {
 group = "adservice"
 version = "0.1.0-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 
-def opencensusVersion = "0.15.0" // LATEST_OPENCENSUS_RELEASE_VERSION
+def opencensusVersion = "0.16.1" // LATEST_OPENCENSUS_RELEASE_VERSION
 def grpcVersion = "1.15.0" // CURRENT_GRPC_VERSION
 def prometheusVersion = "0.3.0"
 
@@ -56,6 +56,7 @@ dependencies {
 
         runtime "com.google.cloud:google-cloud-logging:1.45.0",
                 "io.opencensus:opencensus-impl:${opencensusVersion}",
+                "io.opencensus:opencensus-contrib-log-correlation-stackdriver:${opencensusVersion}",
                 "io.netty:netty-tcnative-boringssl-static:2.0.8.Final"
     }
 }

--- a/src/adservice/src/main/resources/logging.properties
+++ b/src/adservice/src/main/resources/logging.properties
@@ -10,3 +10,5 @@ handlers=com.google.cloud.logging.LoggingHandler
 
 com.google.cloud.logging.LoggingHandler.formatter=java.util.logging.SimpleFormatter
 java.util.logging.SimpleFormatter.format=%3$s: %5$s%6$s
+
+com.google.cloud.logging.LoggingHandler.enhancers=io.opencensus.contrib.logcorrelation.stackdriver.OpenCensusTraceLoggingEnhancer

--- a/src/adservice/src/main/resources/logging.properties
+++ b/src/adservice/src/main/resources/logging.properties
@@ -1,0 +1,12 @@
+# This configuration file is based on the example at
+# https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/logging/jul/src/main/resources/logging.properties
+
+.level = INFO
+
+io.grpc.netty.level=INFO
+sun.net.level=INFO
+
+handlers=com.google.cloud.logging.LoggingHandler
+
+com.google.cloud.logging.LoggingHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=%3$s: %5$s%6$s


### PR DESCRIPTION
I was experimenting with using OpenCensus log correlation in the ad service, so I made a pull request in case that is something that would be useful to include in the demo.  This PR depends on #54.  The other commits are:

#### adservice: export logs with the Stackdriver Logging library

This commit exports logs from the adservice directly to Stackdriver using the
Stackdriver Logging library.  Using the Stackdriver Logging library instead of
unstructured logging gives more control over setting fields such as severity.
This change can also be used to enable OpenCensus log correlation
(https://github.com/census-instrumentation/opencensus-java/tree/master/contrib/log_correlation/stackdriver).

#### adservice: enable OpenCensus log correlation

OpenCensus log correlation
(https://github.com/census-instrumentation/opencensus-java/tree/master/contrib/log_correlation/stackdriver)
inserts the trace ID, span ID, and sampling decision into every log entry.  The
tracing data can be used to find all log entries associated with a single trace
or span.

This commit also upgrades OpenCensus to 0.16.1.

_____________________________________________________________

Here is a screenshot of a trace and an associated log entry:

![log-correlation](https://user-images.githubusercontent.com/19807615/46118777-1a5bbe80-c1bd-11e8-9cea-33687bf2bdc8.png)


/cc @rghetia @g-easy