### PR TITLE
cartservice: fix health Check() method signature

### DIFF
--- a/src/cartservice/HealthImpl.cs
+++ b/src/cartservice/HealthImpl.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Threading.Tasks;
 using cartservice.interfaces;
+using Grpc.Core;
 using Grpc.Health.V1;
 using StackExchange.Redis;
 using static Grpc.Health.V1.Health;
@@ -11,12 +13,12 @@ namespace cartservice {
             this.dependency = dependency;
         }
 
-        public HealthCheckResponse Check (HealthCheckRequest request) {
+        public override Task<HealthCheckResponse> Check(HealthCheckRequest request, ServerCallContext context){
             Console.WriteLine ("Checking CartService Health");
 
-            return new HealthCheckResponse {
+            return Task.FromResult(new HealthCheckResponse {
                 Status = dependency.Ping() ? HealthCheckResponse.Types.ServingStatus.Serving : HealthCheckResponse.Types.ServingStatus.NotServing
-            };
+            });
         }
     }
 }

--- a/src/cartservice/cartservice.csproj
+++ b/src/cartservice/cartservice.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.6.1" />
     <PackageReference Include="Google.Protobuf.Tools" Version="3.5.1" />
     <PackageReference Include="grpc" Version="1.12.0" />
-    <PackageReference Include="Grpc.HealthCheck" Version="1.15.0" />
+    <PackageReference Include="Grpc.HealthCheck" Version="1.12.0" />
     <PackageReference Include="grpc.tools" Version="1.12.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />


### PR DESCRIPTION
- Use the method provided in HealthBase
- Use the same version of GrpcHealth as Grpc core.

Fixes #50.