### PR TITLE
Adservice: Add libc6-compat runtime dependency

### DIFF
--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -11,6 +11,8 @@ RUN ./gradlew installDist
 
 FROM openjdk:8-alpine
 
+RUN apk add --no-cache libc6-compat
+
 RUN GRPC_HEALTH_PROBE_VERSION=v0.2.0 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe


### PR DESCRIPTION
Fixes #89 
