### PR TITLE
adservice: upgrade opencensus-java to 0.17.0.

### DIFF
--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -25,7 +25,7 @@ repositories {
 group = "adservice"
 version = "0.1.0-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 
-def opencensusVersion = "0.16.1" // LATEST_OPENCENSUS_RELEASE_VERSION
+def opencensusVersion = "0.17.0" // LATEST_OPENCENSUS_RELEASE_VERSION
 def grpcVersion = "1.15.0" // CURRENT_GRPC_VERSION
 def jacksonVersion = "2.9.6"
 def prometheusVersion = "0.3.0"

--- a/src/adservice/src/main/resources/log4j2.xml
+++ b/src/adservice/src/main/resources/log4j2.xml
@@ -6,9 +6,9 @@
       <!-- This is a JSON format that can be read by the Stackdriver Logging agent. The trace and
            span IDs are interpreted by Stackdriver, and "traceSampled" is a custom field. -->
       <JsonLayout compact="true" eventEol="true">
-        <KeyValuePair key="logging.googleapis.com/trace" value="$${ctx:opencensusTraceId}"/>
-        <KeyValuePair key="logging.googleapis.com/spanId" value="$${ctx:opencensusSpanId}"/>
-        <KeyValuePair key="traceSampled" value="$${ctx:opencensusTraceSampled}"/>
+        <KeyValuePair key="logging.googleapis.com/trace" value="$${ctx:traceId}"/>
+        <KeyValuePair key="logging.googleapis.com/spanId" value="$${ctx:spanId}"/>
+        <KeyValuePair key="traceSampled" value="$${ctx:traceSampled}"/>
      </JsonLayout>
 
     </Console>


### PR DESCRIPTION
0.17.0 is the first stable version of opencensus-contrib-log-correlation-log4j2.
This commit also updates log4j2.xml to work with the new version.

/cc @rghetia 