### PR TITLE
remove gcr repo name from images

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,24 +103,17 @@ Find **Protocol Buffers Descriptions** at the [`./pb` directory](./pb).
 
         kubectl get nodes
 
-2. Enable Google Container Registry (GCR) on your GCP project and configure the
+1. Enable Google Container Registry (GCR) on your GCP project and configure the
    `docker` CLI to authenticate to GCR:
 
        gcloud services enable containerregistry.googleapis.com
 
        gcloud auth configure-docker -q
 
-3. Set your project ID on image names:
-
-    - Edit `skaffold.yaml`, update the `imageName:` fields that look like
-      `gcr.io/[PROJECT_ID]` with your own GCP project ID.
-
-    - Similarly, edit all Kubernetes Deployment manifests in the
-      [`./kubernetes-manifests`](./kubernetes-manifests) directory. Find the
-      `image:` fields with `gcr.io/[...]` and change them to your own GCP project
-      ID.
-
-5. Run `skaffold run` from the root of this repository. This command:
+1. In the root of this repository, run `skaffold run --default-repo=gcr.io/[PROJECT_ID]`,
+   where [PROJECT_ID] is your GCP project ID.
+   
+   This command:
    - builds the container images
    - pushes them to GCR
    - applies the `./kubernetes-manifests` deploying the application to
@@ -128,9 +121,9 @@ Find **Protocol Buffers Descriptions** at the [`./pb` directory](./pb).
 
    **Troubleshooting:** If you get "No space left on device" error on Google Cloud Shell,
    you can build the images on Google Cloud Build:
-   [Enable the Cloud Build API](https://console.cloud.google.com/flows/enableapi?apiid=cloudbuild.googleapis.com), then run `skaffold run -p gcb` instead.
+   [Enable the Cloud Build API](https://console.cloud.google.com/flows/enableapi?apiid=cloudbuild.googleapis.com), then run `skaffold run -p gcb  --default-repo=gcr.io/[PROJECT_ID]` instead.
 
-6.  Find the IP address of your application, then visit the application on your
+1.  Find the IP address of your application, then visit the application on your
     browser to confirm installation.
 
         kubectl get service frontend-external
@@ -168,7 +161,7 @@ Find **Protocol Buffers Descriptions** at the [`./pb` directory](./pb).
 
     This is required only once.
 
-5. Deploy the application with `skaffold run`.
+5. Deploy the application with `skaffold run --default-repo=gcr.io/[PROJECT_ID]`.
 
 6. Run `kubectl get pods` to see pods are in a healthy and ready state.
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,44 +1,23 @@
 # Cloudbuild.yaml to deploy to staging
 #
 # PREREQUISITES:
-# - Cloud Build service account must have roles: "Kubernetes Engine Developer", "Storage Object Creator", \
-#   "Storage Object"
+# - Cloud Build service account must have roles: "Kubernetes Engine 
+# Developer", "Storage Object Creator", "Storage Object"
+
+# USAGE:
+# GCP zone and GKE target cluster must be specified as substitutions
+# Example invocation:
+# `gcloud builds submit --config=cloudbuild.yaml --substitutions=_ZONE=us-central1-b,_CLUSTER=demo-app-staging .`
 
 steps:
-
-# authenticate to GKE cluster
-- id: 'Get GKE credentials'
-  name: gcr.io/cloud-builders/gcloud
-  args: ['container','clusters','get-credentials','demo-app-staging']
-  env:
-  - 'CLOUDSDK_COMPUTE_ZONE=us-central1-b'
-
-# make latest version of the Skaffold community builder available in this project
-- id: 'clone community builders repo'
-  name: gcr.io/cloud-builders/git
-  args: ['clone','https://github.com/GoogleCloudPlatform/cloud-builders-community']
-
-- id: 'build Skaffold builder'
-  name: gcr.io/cloud-builders/docker
+- id: 'Deploy to app'
+  name: 'gcr.io/k8s-skaffold/skaffold'
+  entrypoint: 'bash'
   args: 
-    [
-      'build',
-      '--tag', 'skaffold',
-      '/workspace/cloud-builders-community/skaffold/.',
-    ]
-
-# push app code to cluster
-- id: 'Deploy to staging'
-  name: skaffold
-  args: 
-    [
-      'run', 
-      '-f=skaffold.yaml',
-      '--default-repo','gcr.io/$PROJECT_ID',
-    ]
-  env:
-  - 'CLOUDSDK_COMPUTE_ZONE=us-central1-b'
-  - 'CLOUDSDK_CONTAINER_CLUSTER=demo-app-staging'
+  - '-c'
+  - > 
+    gcloud container clusters get-credentials --zone=$_ZONE $_CLUSTER;
+    skaffold run -f=skaffold.yaml --default-repo=gcr.io/$PROJECT_ID;
 
 # Add more power, and more time, for heavy Skaffold build
 timeout: '3600s'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,15 +4,7 @@
 # - Cloud Build service account must have roles: "Kubernetes Engine Developer", "Storage Object Creator", \
 #   "Storage Object"
 
-# steps:
-# # modify skaffold config to deploy to cluster in *current* GCP project
-# - id: 'Patch Skaffold config'
-#   name: ubuntu
-#   args:
-#     - 'sed'
-#     - '-i'
-#     - 's/microservices-demo-app/$PROJECT_ID/g'
-#     - 'skaffold.yaml'
+steps:
 
 # authenticate to GKE cluster
 - id: 'Get GKE credentials'
@@ -44,6 +36,6 @@
   - 'CLOUDSDK_CONTAINER_CLUSTER=demo-app-staging'
 
 # Add more power, and more time, for heavy Skaffold build
-timeout: 3600s
+timeout: '3600s'
 options:
   machineType: 'N1_HIGHCPU_8'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,15 +4,15 @@
 # - Cloud Build service account must have roles: "Kubernetes Engine Developer", "Storage Object Creator", \
 #   "Storage Object"
 
-steps:
-# modify skaffold config to deploy to cluster in *current* GCP project
-- id: 'Patch Skaffold config'
-  name: ubuntu
-  args:
-    - 'sed'
-    - '-i'
-    - 's/microservices-demo-app/$PROJECT_ID/g'
-    - 'skaffold.yaml'
+# steps:
+# # modify skaffold config to deploy to cluster in *current* GCP project
+# - id: 'Patch Skaffold config'
+#   name: ubuntu
+#   args:
+#     - 'sed'
+#     - '-i'
+#     - 's/microservices-demo-app/$PROJECT_ID/g'
+#     - 'skaffold.yaml'
 
 # authenticate to GKE cluster
 - id: 'Get GKE credentials'
@@ -39,6 +39,7 @@ steps:
   name: gcr.io/$PROJECT_ID/skaffold
   args: ['run', '-f=skaffold.yaml']
   env:
+  - 'SKAFFOLD_DEFAULT_REPO=gcr.io/hipstershop-cicd'
   - 'CLOUDSDK_COMPUTE_ZONE=us-central1-b'
   - 'CLOUDSDK_CONTAINER_CLUSTER=demo-app-staging'
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,10 +21,11 @@ steps:
 - id: 'build Skaffold builder'
   name: gcr.io/cloud-builders/docker
   args: 
-    - 'build'
-    - '-t' 
-    - 'gcr.io/$PROJECT_ID/skaffold'
-    - '/workspace/cloud-builders-community/skaffold/.'
+    [
+      'build',
+      '--tag', 'gcr.io/$PROJECT_ID/skaffold',
+      '/workspace/cloud-builders-community/skaffold/.',
+    ]
 
 # push app code to cluster
 - id: 'Deploy to staging'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,9 +30,13 @@ steps:
 # push app code to cluster
 - id: 'Deploy to staging'
   name: skaffold
-  args: ['run', '-f=skaffold.yaml']
+  args: 
+    [
+      'run', 
+      '-f=skaffold.yaml',
+      '--default-repo','gcr.io/$PROJECT_ID',
+    ]
   env:
-  - 'SKAFFOLD_DEFAULT_REPO=gcr.io/$PROJECT_ID'
   - 'CLOUDSDK_COMPUTE_ZONE=us-central1-b'
   - 'CLOUDSDK_CONTAINER_CLUSTER=demo-app-staging'
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,17 +1,48 @@
-# This file is used to build and deploy the app into a GKE cluster using Google
-# Cloud Build.
+# Cloudbuild.yaml to deploy to staging
 #
-# Requirements:
-# - Give the Google Cloud Build service account "Kubernetes Engine Developer"
-#   IAM role on the GCP project.
-# - Set up Google Cloud Build trigger on Cloud Console.
+# PREREQUISITES:
+# - Cloud Build service account must have roles: "Kubernetes Engine Developer", "Storage Object Creator", \
+#   "Storage Object"
 
 steps:
-- name: gcr.io/k8s-skaffold/skaffold:v0.16.0
-  args: ['skaffold', 'run', '-f=skaffold.yaml']
+# modify skaffold config to deploy to cluster in *current* GCP project
+- id: 'Patch Skaffold config'
+  name: ubuntu
+  args:
+    - 'sed'
+    - '-i'
+    - 's/microservices-demo-app/$PROJECT_ID/g'
+    - 'skaffold.yaml'
+
+# authenticate to GKE cluster
+- id: 'Get GKE credentials'
+  name: gcr.io/cloud-builders/gcloud
+  args: ['container','clusters','get-credentials','demo-app-staging']
+  env:
+  - 'CLOUDSDK_COMPUTE_ZONE=us-central1-b'
+
+# make latest version of the Skaffold community builder available in this project
+- id: 'clone community builders repo'
+  name: gcr.io/cloud-builders/git
+  args: ['clone','https://github.com/GoogleCloudPlatform/cloud-builders-community']
+
+- id: 'build Skaffold builder'
+  name: gcr.io/cloud-builders/docker
+  args: 
+    - 'build'
+    - '-t' 
+    - 'gcr.io/$PROJECT_ID/skaffold'
+    - '/workspace/cloud-builders-community/skaffold/.'
+
+# push app code to cluster
+- id: 'Deploy to staging'
+  name: gcr.io/$PROJECT_ID/skaffold
+  args: ['run', '-f=skaffold.yaml']
   env:
   - 'CLOUDSDK_COMPUTE_ZONE=us-central1-b'
   - 'CLOUDSDK_CONTAINER_CLUSTER=demo-app-staging'
-timeout: 1800s
-options: # Add more power, and more time, for heavy Skaffold build
+
+# Add more power, and more time, for heavy Skaffold build
+timeout: 3600s
+options:
   machineType: 'N1_HIGHCPU_8'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,8 +1,7 @@
 # Cloudbuild.yaml to deploy to staging
 #
 # PREREQUISITES:
-# - Cloud Build service account must have roles: "Kubernetes Engine 
-# Developer", "Storage Object Creator", "Storage Object"
+# - Cloud Build service account must have role: "Kubernetes Engine Developer"
 
 # USAGE:
 # GCP zone and GKE target cluster must be specified as substitutions
@@ -11,7 +10,7 @@
 
 steps:
 - id: 'Deploy application to cluster'
-  name: 'gcr.io/k8s-skaffold/skaffold'
+  name: 'gcr.io/k8s-skaffold/skaffold:v0.18.0'
   entrypoint: 'bash'
   args: 
   - '-c'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,16 +23,16 @@ steps:
   args: 
     [
       'build',
-      '--tag', 'gcr.io/$PROJECT_ID/skaffold',
+      '--tag', 'skaffold',
       '/workspace/cloud-builders-community/skaffold/.',
     ]
 
 # push app code to cluster
 - id: 'Deploy to staging'
-  name: gcr.io/$PROJECT_ID/skaffold
+  name: skaffold
   args: ['run', '-f=skaffold.yaml']
   env:
-  - 'SKAFFOLD_DEFAULT_REPO=gcr.io/hipstershop-cicd'
+  - 'SKAFFOLD_DEFAULT_REPO=gcr.io/$PROJECT_ID'
   - 'CLOUDSDK_COMPUTE_ZONE=us-central1-b'
   - 'CLOUDSDK_CONTAINER_CLUSTER=demo-app-staging'
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,7 @@
 # `gcloud builds submit --config=cloudbuild.yaml --substitutions=_ZONE=us-central1-b,_CLUSTER=demo-app-staging .`
 
 steps:
-- id: 'Deploy to app'
+- id: 'Deploy application to cluster'
   name: 'gcr.io/k8s-skaffold/skaffold'
   entrypoint: 'bash'
   args: 

--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/microservices-demo-app/adservice
+        image: adservice
         ports:
         - containerPort: 9555
         env:

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/microservices-demo-app/cartservice
+        image: cartservice
         ports:
         - containerPort: 7070
         env:

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: gcr.io/microservices-demo-app/checkoutservice
+          image: checkoutservice
           ports:
           - containerPort: 5050
           readinessProbe:

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/microservices-demo-app/currencyservice
+        image: currencyservice
         ports:
         - name: grpc
           containerPort: 7000

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/microservices-demo-app/emailservice
+        image: emailservice
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: gcr.io/microservices-demo-app/frontend
+          image: frontend
           ports:
           - containerPort: 8080
           readinessProbe:

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -38,7 +38,7 @@ spec:
           value: "frontend:80"
       containers:
       - name: main
-        image: gcr.io/microservices-demo-app/loadgenerator
+        image: loadgenerator
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/microservices-demo-app/paymentservice
+        image: paymentservice
         ports:
         - containerPort: 50051
         readinessProbe:

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/microservices-demo-app/productcatalogservice
+        image: productcatalogservice
         ports:
         - containerPort: 3550
         readinessProbe:

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/microservices-demo-app/recommendationservice
+        image: recommendationservice
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: gcr.io/microservices-demo-app/shippingservice
+        image: shippingservice
         ports:
         - containerPort: 50051
         readinessProbe:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -16,27 +16,31 @@ apiVersion: skaffold/v1alpha5
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/microservices-demo-app/emailservice
+  # image tags are relative; to specify an image repo (e.g. GCR), you
+  # must provide a "default repo" using one of the methods described 
+  # here:
+  # https://github.com/GoogleContainerTools/skaffold/blob/master/docs/concepts.adoc#2-push
+  - image: emailservice
     context: src/emailservice
-  - image: gcr.io/microservices-demo-app/productcatalogservice
+  - image: productcatalogservice
     context: src/productcatalogservice
-  - image: gcr.io/microservices-demo-app/recommendationservice
+  - image: recommendationservice
     context: src/recommendationservice
-  - image: gcr.io/microservices-demo-app/shippingservice
+  - image: shippingservice
     context: src/shippingservice
-  - image: gcr.io/microservices-demo-app/checkoutservice
+  - image: checkoutservice
     context: src/checkoutservice
-  - image: gcr.io/microservices-demo-app/paymentservice
+  - image: paymentservice
     context: src/paymentservice
-  - image: gcr.io/microservices-demo-app/currencyservice
+  - image: currencyservice
     context: src/currencyservice
-  - image: gcr.io/microservices-demo-app/cartservice
+  - image: cartservice
     context: src/cartservice
-  - image: gcr.io/microservices-demo-app/frontend
+  - image: frontend
     context: src/frontend
-  - image: gcr.io/microservices-demo-app/loadgenerator
+  - image: loadgenerator
     context: src/loadgenerator
-  - image: gcr.io/microservices-demo-app/adservice
+  - image: adservice
     context: src/adservice
   tagPolicy:
     gitCommit: {}

--- a/src/frontend/templates/header.html
+++ b/src/frontend/templates/header.html
@@ -14,7 +14,7 @@
         <div class="navbar navbar-dark bg-dark box-shadow">
             <div class="container d-flex justify-content-between">
                 <a href="/" class="navbar-brand d-flex align-items-center">
-                    Hipster Shop. NOICE!
+                    Hipster Shop
                 </a>
                 {{ if $.currencies }}
                 <form class="form-inline ml-auto" method="POST" action="/setCurrency" id="currency_form">

--- a/src/frontend/templates/header.html
+++ b/src/frontend/templates/header.html
@@ -14,7 +14,7 @@
         <div class="navbar navbar-dark bg-dark box-shadow">
             <div class="container d-flex justify-content-between">
                 <a href="/" class="navbar-brand d-flex align-items-center">
-                    Hipster Shop
+                    Hipster Shop. NOICE!
                 </a>
                 {{ if $.currencies }}
                 <form class="form-inline ml-auto" method="POST" action="/setCurrency" id="currency_form">


### PR DESCRIPTION
This removes hardcoded GCP project name from images and requires an explicit repository flag to skaffold. Also updating the cloudbuild.yaml for staging with the gcr.io/k8s-skaffold/skaffold image.

Fixes #17.