### PR TITLE
Add Jaeger support for Adservice.

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -31,6 +31,10 @@ spec:
         env:
         - name: PORT
           value: "9555"
+        - name: JAEGER_ENABLED
+          value: "false"
+        - name: PROMETHEUS_ENABLED
+          value: "false"
         resources:
           requests:
             cpu: 200m

--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -33,8 +33,6 @@ spec:
           value: "9555"
         - name: JAEGER_ENABLED
           value: "false"
-        - name: PROMETHEUS_ENABLED
-          value: "false"
         resources:
           requests:
             cpu: 200m

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -28,7 +28,6 @@ version = "0.1.0-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 def opencensusVersion = "0.17.0" // LATEST_OPENCENSUS_RELEASE_VERSION
 def grpcVersion = "1.15.0" // CURRENT_GRPC_VERSION
 def jacksonVersion = "2.9.6"
-def prometheusVersion = "0.3.0"
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = '1.8'
@@ -46,7 +45,6 @@ dependencies {
     } else {
         compile "com.google.api.grpc:proto-google-common-protos:1.11.0",
                 "io.opencensus:opencensus-exporter-trace-jaeger:${opencensusVersion}",
-                "io.opencensus:opencensus-exporter-stats-prometheus:${opencensusVersion}",
                 "io.opencensus:opencensus-exporter-stats-stackdriver:${opencensusVersion}",
                 "io.opencensus:opencensus-exporter-trace-stackdriver:${opencensusVersion}",
                 "io.opencensus:opencensus-exporter-trace-logging:${opencensusVersion}",
@@ -54,7 +52,6 @@ dependencies {
                 "io.grpc:grpc-stub:${grpcVersion}",
                 "io.grpc:grpc-netty:${grpcVersion}",
                 "io.grpc:grpc-services:${grpcVersion}",
-                "io.prometheus:simpleclient_httpserver:${prometheusVersion}",
                 "org.apache.logging.log4j:log4j-core:2.11.1"
 
         runtime "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -45,6 +45,7 @@ dependencies {
         compile fileTree(dir: offlineCompile, include: '*.jar')
     } else {
         compile "com.google.api.grpc:proto-google-common-protos:1.11.0",
+                "io.opencensus:opencensus-exporter-trace-jaeger:${opencensusVersion}",
                 "io.opencensus:opencensus-exporter-stats-prometheus:${opencensusVersion}",
                 "io.opencensus:opencensus-exporter-stats-stackdriver:${opencensusVersion}",
                 "io.opencensus:opencensus-exporter-trace-stackdriver:${opencensusVersion}",

--- a/src/adservice/src/main/java/hipstershop/AdService.java
+++ b/src/adservice/src/main/java/hipstershop/AdService.java
@@ -31,7 +31,6 @@ import io.grpc.services.*;
 import io.opencensus.common.Duration;
 import io.opencensus.common.Scope;
 import io.opencensus.contrib.grpc.metrics.RpcViews;
-import io.opencensus.exporter.stats.prometheus.PrometheusStatsCollector;
 import io.opencensus.exporter.trace.jaeger.JaegerTraceExporter;
 import io.opencensus.exporter.trace.logging.LoggingTraceExporter;
 import io.opencensus.exporter.stats.stackdriver.StackdriverStatsConfiguration;
@@ -44,11 +43,9 @@ import io.opencensus.trace.SpanBuilder;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
 import io.opencensus.trace.samplers.Samplers;
-import io.prometheus.client.exporter.HTTPServer;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -251,17 +248,6 @@ public class AdService {
     }
   }
 
-  static void initPrometheus() throws IOException {
-    boolean enabled = Boolean.parseBoolean(System.getenv("PROMETHEUS_ENABLED"));
-    if (enabled) {
-      PrometheusStatsCollector.createAndRegister();
-      HTTPServer prometheusServer = new HTTPServer(9090, true);
-      logger.info("Prometheus initialization complete.");
-    } else {
-      logger.info("Prometheus initialization disabled.");
-    }
-  }
-
   /** Main launches the server from the command line. */
   public static void main(String[] args) throws IOException, InterruptedException {
     // Add final keyword to pass checkStyle.
@@ -277,9 +263,6 @@ public class AdService {
         initStackdriver();
       }
     }).start();
-
-    // Register Prometheus exporters and export metrics to a Prometheus HTTPServer.
-    initPrometheus();
 
     // Register Jaeger
     initJaeger();


### PR DESCRIPTION
This is the first service that exports to jaeger. Others to follow.
Requires jaeger to be instantiated using 

- helm install --name jaeger stable/jaeger-operator
- kubectl apply -f jaeger.yaml

=== jaeger.yaml Content ===
apiVersion: io.jaegertracing/v1alpha1
kind: Jaeger
metadata:
  name: jaeger

Above steps will be added to README in subsequent PR.