### PR TITLE
Update GCB to use skaffold builder v0.20.0 (to support newer skaffold config)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,7 +11,7 @@
 
 steps:
 - id: 'Deploy application to cluster'
-  name: 'gcr.io/k8s-skaffold/skaffold:v0.18.0'
+  name: 'gcr.io/k8s-skaffold/skaffold:v0.20.0'
   entrypoint: 'bash'
   args: 
   - '-c'


### PR DESCRIPTION
Currently, Cloud Build invocations are failing due to mismatch between builder image 0.18.0 and newer skaffold config version. This patch fixes that.