### PR TITLE
On deploy from Cloud Build, stamp the frontend with source hash

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@
 #
 # PREREQUISITES:
 # - Cloud Build service account must have role: "Kubernetes Engine Developer"
-
+#
 # USAGE:
 # GCP zone and GKE target cluster must be specified as substitutions
 # Example invocation:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,11 +23,7 @@ steps:
 
 steps:
 - id: 'Deploy application to cluster'
-<<<<<<< HEAD
   name: 'gcr.io/k8s-skaffold/skaffold:v0.20.0'
-=======
-  name: 'gcr.io/k8s-skaffold/skaffold:v0.18.0'
->>>>>>> Uncomment cluster push
   entrypoint: 'bash'
   args: 
   - '-c'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,7 +23,11 @@ steps:
 
 steps:
 - id: 'Deploy application to cluster'
+<<<<<<< HEAD
   name: 'gcr.io/k8s-skaffold/skaffold:v0.20.0'
+=======
+  name: 'gcr.io/k8s-skaffold/skaffold:v0.18.0'
+>>>>>>> Uncomment cluster push
   entrypoint: 'bash'
   args: 
   - '-c'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@
 #
 # PREREQUISITES:
 # - Cloud Build service account must have role: "Kubernetes Engine Developer"
-#
+
 # USAGE:
 # GCP zone and GKE target cluster must be specified as substitutions
 # Example invocation:
@@ -21,7 +21,6 @@ steps:
   - "COMMIT_SHA=$COMMIT_SHA"
   - "SHORT_SHA=$SHORT_SHA"
 
-steps:
 - id: 'Deploy application to cluster'
   name: 'gcr.io/k8s-skaffold/skaffold:v0.20.0'
   entrypoint: 'bash'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,14 +10,26 @@
 # `gcloud builds submit --config=cloudbuild.yaml --substitutions=_ZONE=us-central1-b,_CLUSTER=demo-app-staging .`
 
 steps:
+- id: 'Write git commit to frontend'
+  name: 'ubuntu'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    tools/insert_git_commit_link.sh
+  env:
+  - "COMMIT_SHA=$COMMIT_SHA"
+  - "SHORT_SHA=$SHORT_SHA"
+
+steps:
 - id: 'Deploy application to cluster'
   name: 'gcr.io/k8s-skaffold/skaffold:v0.20.0'
   entrypoint: 'bash'
   args: 
   - '-c'
-  - > 
-    gcloud container clusters get-credentials --zone=$_ZONE $_CLUSTER;
-    skaffold run -f=skaffold.yaml --default-repo=gcr.io/$PROJECT_ID;
+  - |
+    gcloud container clusters get-credentials --zone=$_ZONE $_CLUSTER
+    skaffold run -f=skaffold.yaml --default-repo=gcr.io/$PROJECT_ID
 
 # Add more power, and more time, for heavy Skaffold build
 timeout: '3600s'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,8 +16,6 @@ steps:
   args:
   - '-c'
   - |
-    env
-    echo "-----------------"
     tools/insert_git_commit_link.sh
   env:
   - "COMMIT_SHA=$COMMIT_SHA"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,6 +16,8 @@ steps:
   args:
   - '-c'
   - |
+    env
+    echo "-----------------"
     tools/insert_git_commit_link.sh
   env:
   - "COMMIT_SHA=$COMMIT_SHA"

--- a/src/frontend/templates/footer.html
+++ b/src/frontend/templates/footer.html
@@ -4,7 +4,7 @@
             <p>
                 &copy; 2018 Google Inc
                 <span class="text-muted">
-                    <a href="https://github.com/GoogleCloudPlatform/microservices-demo/">(Source Code)</a>
+                    (<a href="https://github.com/GoogleCloudPlatform/microservices-demo/">Source Code</a><!--GIT_COMMIT_LINK-->)
                 </span>
             </p>
             <p>

--- a/tools/insert_git_commit_link.sh
+++ b/tools/insert_git_commit_link.sh
@@ -8,5 +8,6 @@ if [[ "$COMMIT_SHA" && "$SHORT_SHA" ]]; then
 
     sed -i'' -e "s^$target^$replace^g" src/frontend/templates/footer.html
 
-    cat src/frontend/templates/footer.html
+    # echo 'debug: contents of footer.html:'
+    # cat src/frontend/templates/footer.html
 fi

--- a/tools/insert_git_commit_link.sh
+++ b/tools/insert_git_commit_link.sh
@@ -1,0 +1,12 @@
+# when project is built by Cloud Build from a source trigger, the 
+# commit SHA will be available as an env var
+
+if [[ "$COMMIT_SHA" && "$SHORT_SHA" ]]; then
+    target="<!--GIT_COMMIT_LINK-->"
+    replace=" [<a href='https://github.com/GoogleCloudPlatform/microservices-demo/commit/${COMMIT_SHA}'\
+             style='font-size:80%'>${SHORT_SHA}</a>]#"
+
+    sed -i'' -e "s^$target^$replace^g" src/frontend/templates/footer.html
+
+    cat src/frontend/templates/footer.html
+fi

--- a/tools/insert_git_commit_link.sh
+++ b/tools/insert_git_commit_link.sh
@@ -4,7 +4,7 @@
 if [[ "$COMMIT_SHA" && "$SHORT_SHA" ]]; then
     target="<!--GIT_COMMIT_LINK-->"
     replace=" [<a href='https://github.com/GoogleCloudPlatform/microservices-demo/commit/${COMMIT_SHA}'\
-             style='font-size:80%'>${SHORT_SHA}</a>]#"
+             style='font-size:80%'>${SHORT_SHA}</a>]"
 
     sed -i'' -e "s^$target^$replace^g" src/frontend/templates/footer.html
 


### PR DESCRIPTION
Hey Ahmet, we discussed this a while back... it will help with CICD if we can easily trace the currently-deployed version back to its source. This is a small script that stamps the git hash into the frontend, by replacing a comment in the footer HTML source.

(For local development, this has no effect -- the comment simply remains as a comment.)