### PR TITLE
adservice: Add "time" field to JSON log entries.

### DIFF
--- a/src/adservice/src/main/resources/log4j2.xml
+++ b/src/adservice/src/main/resources/log4j2.xml
@@ -3,12 +3,14 @@
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">
 
-      <!-- This is a JSON format that can be read by the Stackdriver Logging agent. The trace and
-           span IDs are interpreted by Stackdriver, and "traceSampled" is a custom field. -->
+      <!-- This is a JSON format that can be read by the Stackdriver Logging agent. The trace ID,
+           span ID, and timestamp are interpreted by Stackdriver, and "traceSampled" is a custom
+           field. -->
       <JsonLayout compact="true" eventEol="true">
         <KeyValuePair key="logging.googleapis.com/trace" value="$${ctx:traceId}"/>
         <KeyValuePair key="logging.googleapis.com/spanId" value="$${ctx:spanId}"/>
         <KeyValuePair key="traceSampled" value="$${ctx:traceSampled}"/>
+        <KeyValuePair key="time" value="$${date:yyyy-MM-dd}T$${date:HH:mm:ss.SSS}Z"/>
      </JsonLayout>
 
     </Console>


### PR DESCRIPTION
The Log4j JsonLayout puts the log entry timestamp in a field named "instant" by
default, but the Stackdriver Logging agent does not understand that field.  The
logging agent instead uses the time that it received the log entry, which is
less accurate and has only second-level precision.

This commit adds a key-value pair to the JsonLayout pattern that can be
understood by the logging agent.  It uses a "time" key as described in
https://cloud.google.com/logging/docs/agent/configuration#timestamp-processing
and formats the timestamp as described in the Protocol Buffer JSON mapping,
https://developers.google.com/protocol-buffers/docs/proto3#json.

Allowing the Stackdriver Logging agent to read the more accurate timestamps
inserted by Log4j is especially important in the adservice, because the logs are
correlated with traces, and it is important to see where each message was logged
on the timeline of the trace.

/cc @rghetia
