### PR TITLE
Fixing ./gradlew: Permission denied problem on Dockerfile

### DIFF
--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -4,16 +4,18 @@ WORKDIR /app
 
 COPY ["build.gradle", "gradlew", "./"]
 COPY gradle gradle
+RUN chmod +x gradlew
 RUN ./gradlew downloadRepos
 
 COPY . .
+RUN chmod +x gradlew
 RUN ./gradlew installDist
 
 FROM openjdk:8-alpine
 
 RUN apk add --no-cache libc6-compat
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.2.0 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.2.1 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
 


### PR DESCRIPTION
When /src/cartservice image is building, an exception is occurred. I am also updating GRPC_HEALTH_PROBE_VERSION env variable from v0.2.0 to v0.2.1.

![image](https://user-images.githubusercontent.com/15161296/52862201-be7edb80-3145-11e9-8ded-9104c2d44a39.png)