### PR TITLE
loadgenerator: check curl install

### DIFF
--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -28,7 +28,7 @@ spec:
       initContainers:
       - name: wait-frontend
         image: alpine:3.6
-        command: ['sh', '-c', 'set -x;  apk add --no-cache curl; 
+        command: ['sh', '-c', 'set -x;  apk add --no-cache curl && 
           until timeout -t 2 curl -f "http://${FRONTEND_ADDR}"; do 
             echo "waiting for http://${FRONTEND_ADDR}"; 
             sleep 2;


### PR DESCRIPTION
without &&, load generator startup was failing intermittently when it fails
to install curl from apk-add.