### PR TITLE
hack: fix release scripts

### DIFF
--- a/hack/make-docker-images.sh
+++ b/hack/make-docker-images.sh
@@ -21,8 +21,8 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 log() { echo "$1" >&2; }
 
-TAG="${TAG?TAG env variable must be specified}"
-REPO_PREFIX="${REPO_PREFIX?REPO_PREFIX env variable must be specified}"
+TAG="${TAG:?TAG env variable must be specified}"
+REPO_PREFIX="${REPO_PREFIX:?REPO_PREFIX env variable must be specified}"
 
 while IFS= read -d $'\0' -r dir; do
     # build image

--- a/hack/make-release-artifacts.sh
+++ b/hack/make-release-artifacts.sh
@@ -23,8 +23,8 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 log() { echo "$1" >&2; }
 
-TAG="${TAG?TAG env variable must be specified}"
-REPO_PREFIX="${REPO_PREFIX?REPO_PREFIX env variable must be specified}"
+TAG="${TAG:?TAG env variable must be specified}"
+REPO_PREFIX="${REPO_PREFIX:?REPO_PREFIX env variable must be specified}"
 OUT_DIR="${OUT_DIR:-${SCRIPTDIR}/../release}"
 
 read_manifests() {


### PR DESCRIPTION
Previous release script wasn't committing/tagging in the right order.
Also made scripts resistant to:
* empty env vars
* current workdir the script is invoked from

cc: @m-okeefe 