### PR TITLE
adservice: use Stackdriver special field to set sampling decision in log entries

### DIFF
--- a/src/adservice/src/main/resources/log4j2.xml
+++ b/src/adservice/src/main/resources/log4j2.xml
@@ -4,12 +4,15 @@
     <Console name="STDOUT" target="SYSTEM_OUT">
 
       <!-- This is a JSON format that can be read by the Stackdriver Logging agent. The trace ID,
-           span ID, and timestamp are interpreted by Stackdriver, and "traceSampled" is a custom
-           field. -->
+           span ID, sampling decision, and timestamp are interpreted by Stackdriver. It uses the
+           special JSON keys that the Stackdriver Logging agent converts to "trace", "spanId",
+           "traceSampled", and "timestamp" in the Stackdriver LogEntry
+           (https://cloud.google.com/logging/docs/agent/configuration#special-fields). -->
+
       <JsonLayout compact="true" eventEol="true">
         <KeyValuePair key="logging.googleapis.com/trace" value="$${ctx:traceId}"/>
         <KeyValuePair key="logging.googleapis.com/spanId" value="$${ctx:spanId}"/>
-        <KeyValuePair key="traceSampled" value="$${ctx:traceSampled}"/>
+        <KeyValuePair key="logging.googleapis.com/traceSampled" value="$${ctx:traceSampled}"/>
         <KeyValuePair key="time" value="$${date:yyyy-MM-dd}T$${date:HH:mm:ss.SSS}Z"/>
      </JsonLayout>
 


### PR DESCRIPTION
This commit sets the new sampling decision field that is recognized by the
Stackdriver Logging agent, "logging.googleapis.com/traceSampled".  The sampling
decision field was added in
https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/297, and
it won't be available until the new version of fluent-plugin-google-cloud is
used in GKE.

/cc @rghetia