### PR TITLE
Follow OWASP best practices on CC presentation on checkout form

### DIFF
--- a/src/frontend/templates/cart.html
+++ b/src/frontend/templates/cart.html
@@ -95,8 +95,7 @@
                                 <div class="form-row">
                                     <div class="col-md-6 mb-3">
                                         <label for="credit_card_number">Credit Card Number</label>
-                                        <input type="password" class="form-control" id="credit_card_number"
-                                            autocomplete="off"
+                                        <input type="text" class="form-control" id="credit_card_number"
                                             name="credit_card_number"
                                             placeholder="0000-0000-0000-0000"
                                             value="4432-8015-6152-0454"

--- a/src/frontend/templates/cart.html
+++ b/src/frontend/templates/cart.html
@@ -95,7 +95,8 @@
                                 <div class="form-row">
                                     <div class="col-md-6 mb-3">
                                         <label for="credit_card_number">Credit Card Number</label>
-                                        <input type="text" class="form-control" id="credit_card_number"
+                                        <input type="password" class="form-control" id="credit_card_number"
+                                            autocomplete="off"
                                             name="credit_card_number"
                                             placeholder="0000-0000-0000-0000"
                                             value="4432-8015-6152-0454"
@@ -132,7 +133,8 @@
                                         </div>
                                     <div class="col-md-2 mb-3">
                                         <label for="credit_card_cvv">CVV</label>
-                                        <input type="text" class="form-control" id="credit_card_cvv"
+                                        <input type="password" class="form-control" id="credit_card_cvv"
+                                            autocomplete="off"
                                             name="credit_card_cvv" value="672" required pattern="\d{3}">
                                     </div>
                                 </div>


### PR DESCRIPTION
It seems innocuous for a demo like this but unmasked CVV and CC number fields can raise a few eyebrows from PCI-minded folks. I think it's best just to take care of it

See OWASP recommendations here:
<https://www.owasp.org/index.php/Handling_E-Commerce_Payments#Displaying_portions_of_the_credit_card>
