### PR TITLE
README: Point to Skaffold's website rather than repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Find **Protocol Buffers Descriptions** at the [`./pb` directory](./pb).
   addition to these, using Istio enables features like Request/Response
   **Metrics** and **Context Graph** out of the box. When it is running out of
   Google Cloud, this code path remains inactive.
-- **[Skaffold](https://github.com/GoogleContainerTools/skaffold):** Application
+- **[Skaffold](https://skaffold.dev):** Application
   is deployed to Kubernetes with a single command using Skaffold.
 - **Synthetic Load Generation:** The application demo comes with a background
   job that creates realistic usage patterns on the website using


### PR DESCRIPTION
All mentioned projects (Kubernetes, Istio, etc.) point to their websites expect for Skaffold that points to its source code repository.

The website should be a better entry point to understand the big picture, access the quickstart guides and more in-depth howtos.