### PR TITLE
Use env in service manifests for PORT

### DIFF
--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -37,6 +37,8 @@ spec:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:5050"]
           env:
+          - name: PORT
+            value: "5050"
           - name: PRODUCT_CATALOG_SERVICE_ADDR
             value: "productcatalogservice:3550"
           - name: SHIPPING_SERVICE_ADDR

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -32,6 +32,9 @@ spec:
         ports:
         - name: grpc
           containerPort: 7000
+        env:
+          - name: PORT
+            value: "7000"
         readinessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -33,8 +33,8 @@ spec:
         - name: grpc
           containerPort: 7000
         env:
-          - name: PORT
-            value: "7000"
+        - name: PORT
+          value: "7000"
         readinessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -31,6 +31,9 @@ spec:
         image: emailservice
         ports:
         - containerPort: 8080
+        env:
+          - name: PORT
+            value: "8080"
         readinessProbe:
           periodSeconds: 5
           exec:

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -32,8 +32,8 @@ spec:
         ports:
         - containerPort: 8080
         env:
-          - name: PORT
-            value: "8080"
+        - name: PORT
+          value: "8080"
         readinessProbe:
           periodSeconds: 5
           exec:

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -47,6 +47,8 @@ spec:
               - name: "Cookie"
                 value: "shop_session-id=x-liveness-probe"
           env:
+          - name: PORT
+            value: "8080"
           - name: PRODUCT_CATALOG_SERVICE_ADDR
             value: "productcatalogservice:3550"
           - name: CURRENCY_SERVICE_ADDR

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -31,6 +31,9 @@ spec:
         image: paymentservice
         ports:
         - containerPort: 50051
+        env:
+        - name: PORT
+          value: "50051"
         readinessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -31,6 +31,9 @@ spec:
         image: productcatalogservice
         ports:
         - containerPort: 3550
+        env:
+          - name: PORT
+            value: "3550"
         readinessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:3550"]

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -32,8 +32,8 @@ spec:
         ports:
         - containerPort: 3550
         env:
-          - name: PORT
-            value: "3550"
+        - name: PORT
+          value: "3550"
         readinessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:3550"]

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -40,6 +40,8 @@ spec:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:8080"]
         env:
+        - name: PORT
+          value: "8080"
         - name: PRODUCT_CATALOG_SERVICE_ADDR
           value: "productcatalogservice:3550"
         resources:

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -30,6 +30,9 @@ spec:
         image: shippingservice
         ports:
         - containerPort: 50051
+        env:
+        - name: PORT
+          value: "50051"
         readinessProbe:
           periodSeconds: 5
           exec:

--- a/src/currencyservice/server.js
+++ b/src/currencyservice/server.js
@@ -36,7 +36,7 @@ const protoLoader = require('@grpc/proto-loader');
 const MAIN_PROTO_PATH = path.join(__dirname, './proto/demo.proto');
 const HEALTH_PROTO_PATH = path.join(__dirname, './proto/grpc/health/v1/health.proto');
 
-const PORT = 7000;
+const PORT = process.env.PORT;
 
 const shopProto = _loadProto(MAIN_PROTO_PATH).hipstershop;
 const healthProto = _loadProto(HEALTH_PROTO_PATH).grpc.health.v1;

--- a/src/paymentservice/server.js
+++ b/src/paymentservice/server.js
@@ -27,7 +27,7 @@ const logger = pino({
 });
 
 class HipsterShopServer {
-  constructor (protoRoot, port = HipsterShopServer.DEFAULT_PORT) {
+  constructor (protoRoot, port = HipsterShopServer.PORT) {
     this.port = port;
 
     this.packages = {
@@ -99,6 +99,6 @@ class HipsterShopServer {
   }
 }
 
-HipsterShopServer.DEFAULT_PORT = 50051;
+HipsterShopServer.PORT = process.env.PORT;
 
 module.exports = HipsterShopServer;

--- a/src/productcatalogservice/server.go
+++ b/src/productcatalogservice/server.go
@@ -50,7 +50,7 @@ var (
 	log          *logrus.Logger
 	extraLatency time.Duration
 
-	port = flag.Int("port", 3550, "port to listen at")
+	port = "3550"
 
 	reloadCatalog bool
 )
@@ -106,13 +106,16 @@ func main() {
 		}
 	}()
 
-	log.Infof("starting grpc server at :%d", *port)
-	run(*port)
+	if os.Getenv("PORT") != "" {
+		port = os.Getenv("PORT")
+	}
+	log.Infof("starting grpc server at :%s", port)
+	run(port)
 	select {}
 }
 
-func run(port int) string {
-	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+func run(port string) string {
+	l, err := net.Listen("tcp", fmt.Sprintf(":%s", port))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/src/shippingservice/main.go
+++ b/src/shippingservice/main.go
@@ -60,7 +60,7 @@ func main() {
 	go initProfiling("shippingservice", "1.0.0")
 
 	port := defaultPort
-	if value, ok := os.LookupEnv("APP_PORT"); ok {
+	if value, ok := os.LookupEnv("PORT"); ok {
 		port = value
 	}
 	port = fmt.Sprintf(":%s", port)


### PR DESCRIPTION
Supply service ports through env PORT variable in service manifests. Fixes issue: https://github.com/GoogleCloudPlatform/microservices-demo/issues/163