### PR TITLE
Removed deprecated left-pad module dependency.

### DIFF
--- a/src/currencyservice/client.js
+++ b/src/currencyservice/client.js
@@ -46,7 +46,7 @@ const request = {
 };
 
 function _moneyToString (m) {
-  return `${m.units}.${leftPad(m.nanos, 9, '0')} ${m.currency_code}`;
+  return `${m.units}.${m.nanos.toString().padStart(9,'0')} ${m.currency_code}`;
 }
 
 client.getSupportedCurrencies({}, (err, response) => {

--- a/src/currencyservice/package.json
+++ b/src/currencyservice/package.json
@@ -16,7 +16,6 @@
     "async": "^1.5.2",
     "google-protobuf": "^3.0.0",
     "grpc": "^1.0.0",
-    "left-pad": "^1.3.0",
     "pino": "^5.6.2",
     "request": "^2.87.0",
     "xml2js": "^0.4.19"


### PR DESCRIPTION
In this PR I have removed the dependency of left-pad npm module, we no longer need to use due to following reasons.

1. https://www.npmjs.com/package/left-pad , This package has been deprecated and author suggested to use native String.prototype.padStart() javascript method.

2. It doesnt make sense to install a new module to perform just a single line of operation. In our case we were doing return `${m.units}.${m.nanos.toString().padStart(9,'0')} ${m.currency_code}`; instead of ${m.units}.${m.nanos.padStart(9,'0')} ${m.currency_code} .