### PR TITLE
[cartservice] Increases health check timeout

### DIFF
--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -392,7 +392,6 @@ spec:
       containers:
       - name: server
         image: gcr.io/google-samples/microservices-demo/cartservice:v0.1.1
-        imagePullPolicy: Always
         ports:
         - containerPort: 7070
         env:

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -391,7 +391,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/mokeefe/cartservice:august
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.1.1
         imagePullPolicy: Always
         ports:
         - containerPort: 7070

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -391,7 +391,8 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.1.1
+        image: gcr.io/mokeefe/cartservice:august
+        imagePullPolicy: Always
         ports:
         - containerPort: 7070
         env:
@@ -411,12 +412,12 @@ spec:
         readinessProbe:
           initialDelaySeconds: 15
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=:7070"]
+            command: ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
         livenessProbe:
           initialDelaySeconds: 15
           periodSeconds: 10
           exec:
-            command: ["/bin/grpc_health_probe", "-addr=:7070"]
+            command: ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
 ---
 apiVersion: v1
 kind: Service

--- a/src/cartservice/HealthImpl.cs
+++ b/src/cartservice/HealthImpl.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using static System.Diagnostics.Stopwatch;
 using cartservice.interfaces;
 using Grpc.Core;
 using Grpc.Health.V1;
@@ -14,11 +15,14 @@ namespace cartservice {
         }
 
         public override Task<HealthCheckResponse> Check(HealthCheckRequest request, ServerCallContext context){
-            Console.WriteLine ("Checking CartService Health");
-
-            return Task.FromResult(new HealthCheckResponse {
+            var watch = StartNew();
+            var result = Task.FromResult(new HealthCheckResponse {
                 Status = dependency.Ping() ? HealthCheckResponse.Types.ServingStatus.Serving : HealthCheckResponse.Types.ServingStatus.NotServing
             });
+            watch.Stop();
+            var elapsedMs = watch.ElapsedMilliseconds;
+            Console.WriteLine ("✅ Health Check took " + elapsedMs + "ms");
+            return result;
         }
     }
 }

--- a/src/cartservice/HealthImpl.cs
+++ b/src/cartservice/HealthImpl.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using static System.Diagnostics.Stopwatch;
 using cartservice.interfaces;
 using Grpc.Core;
 using Grpc.Health.V1;
@@ -15,13 +14,9 @@ namespace cartservice {
         }
 
         public override Task<HealthCheckResponse> Check(HealthCheckRequest request, ServerCallContext context){
-            var watch = StartNew();
             var result = Task.FromResult(new HealthCheckResponse {
                 Status = dependency.Ping() ? HealthCheckResponse.Types.ServingStatus.Serving : HealthCheckResponse.Types.ServingStatus.NotServing
             });
-            watch.Stop();
-            var elapsedMs = watch.ElapsedMilliseconds;
-            Console.WriteLine ("✅ Health Check took " + elapsedMs + "ms");
             return result;
         }
     }

--- a/src/cartservice/HealthImpl.cs
+++ b/src/cartservice/HealthImpl.cs
@@ -14,10 +14,10 @@ namespace cartservice {
         }
 
         public override Task<HealthCheckResponse> Check(HealthCheckRequest request, ServerCallContext context){
-            var result = Task.FromResult(new HealthCheckResponse {
+            Console.WriteLine ("Checking CartService Health");
+            return Task.FromResult(new HealthCheckResponse {
                 Status = dependency.Ping() ? HealthCheckResponse.Types.ServingStatus.Serving : HealthCheckResponse.Types.ServingStatus.NotServing
             });
-            return result;
         }
     }
 }

--- a/src/cartservice/cartservice.csproj
+++ b/src/cartservice/cartservice.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="grpc.tools" Version="1.12.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
+    <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/cartservice/cartstore/RedisCartStore.cs
+++ b/src/cartservice/cartstore/RedisCartStore.cs
@@ -45,13 +45,13 @@ namespace cartservice.cartstore
             var cart = new Hipstershop.Cart();
             emptyCartBytes = cart.ToByteArray();
             connectionString = $"{redisAddress},ssl=false,allowAdmin=true,connectRetry=5";
-            
+
             redisConnectionOptions = ConfigurationOptions.Parse(connectionString);
 
             // Try to reconnect if first retry failed (up to 5 times with exponential backoff)
             redisConnectionOptions.ConnectRetry = REDIS_RETRY_NUM;
             redisConnectionOptions.ReconnectRetryPolicy = new ExponentialRetry(100);
-            
+
             redisConnectionOptions.KeepAlive = 180;
         }
 
@@ -78,11 +78,11 @@ namespace cartservice.cartstore
 
                 Console.WriteLine("Connecting to Redis: " + connectionString);
                 redis = ConnectionMultiplexer.Connect(redisConnectionOptions);
-                
+
                 if (redis == null || !redis.IsConnected)
                 {
                     Console.WriteLine("Wasn't able to connect to redis");
-                    
+
                     // We weren't able to connect to redis despite 5 retries with exponential backoff
                     throw new ApplicationException("Wasn't able to connect to redis");
                 }
@@ -96,14 +96,14 @@ namespace cartservice.cartstore
                 Console.WriteLine($"Small test result: {res}");
 
                 redis.InternalError += (o, e) => { Console.WriteLine(e.Exception); };
-                redis.ConnectionRestored += (o, e) => 
+                redis.ConnectionRestored += (o, e) =>
                 {
                     isRedisConnectionOpened = true;
-                    Console.WriteLine("Connection to redis was retored successfully"); 
+                    Console.WriteLine("Connection to redis was retored successfully");
                 };
-                redis.ConnectionFailed += (o, e) => 
+                redis.ConnectionFailed += (o, e) =>
                 {
-                    Console.WriteLine("Connection failed. Disposing the object"); 
+                    Console.WriteLine("Connection failed. Disposing the object");
                     isRedisConnectionOpened = false;
                 };
 
@@ -118,9 +118,9 @@ namespace cartservice.cartstore
             try
             {
                 EnsureRedisConnected();
-                
+
                 var db = redis.GetDatabase();
-                
+
                 // Access the cart from the cache
                 var value = await db.HashGetAsync(userId, CART_FIELD_NAME);
 
@@ -202,7 +202,6 @@ namespace cartservice.cartstore
         {
             try
             {
-                var redis = ConnectionMultiplexer.Connect(redisConnectionOptions);
                 var cache = redis.GetDatabase();
                 var res = cache.Ping();
                 return res != TimeSpan.Zero;


### PR DESCRIPTION
Closes #74 

**Problem**: CartService restarts repeatedly due to failed liveness and readiness probes (the redis PING completes, but it takes > 1 second). Isolated the problem to the .NET StackExchange/Redis client library -- unclear if it's a timeout or connection pool issue.

**Solution for now**:

1. Increase the timeout on both the liveness/readiness probes from 1 second to 5 seconds 
2. Re-use the existing cartservice redis client in the health check, rather than initialize a new client (this just adds more time) 
3. Upgrade the Redis .NET library to the [latest version](https://www.nuget.org/packages/StackExchange.Redis/)
