### PR TITLE
Fix Stackdriver Logging errors

### DIFF
--- a/src/emailservice/logger.py
+++ b/src/emailservice/logger.py
@@ -37,4 +37,5 @@ def getJSONLogger(name):
   handler.setFormatter(formatter)
   logger.addHandler(handler)
   logger.setLevel(logging.INFO)
+  logger.propagate = False
   return logger

--- a/src/loadgenerator/loadgen.sh
+++ b/src/loadgenerator/loadgen.sh
@@ -24,4 +24,4 @@ if [[ -z "${FRONTEND_ADDR}" ]]; then
 fi
 
 set -x
-locust --host="http://${FRONTEND_ADDR}" --no-web -c "${USERS:-10}"
+locust --host="http://${FRONTEND_ADDR}" --no-web -c "${USERS:-10}" 2>&1

--- a/src/recommendationservice/logger.py
+++ b/src/recommendationservice/logger.py
@@ -37,4 +37,5 @@ def getJSONLogger(name):
   handler.setFormatter(formatter)
   logger.addHandler(handler)
   logger.setLevel(logging.INFO)
+  logger.propagate = False
   return logger


### PR DESCRIPTION
Stackdriver Logging was reporting certain logs as errors for some services. This fixes the issue (related: https://github.com/GoogleCloudPlatform/microservices-demo/issues/101)

- for Python services, `logger.propagate = False` prevents the service from logging twice. The second log was appearing as an ERROR in Stackdriver Logging
- `loadgen.sh` was sending logs to stderr, which was showing up as errors in Stackdriver. I redirected stderr to stdout, and now logs show up as INFO instead of ERROR. (The problem with this is real errors will also show up as INFO, but I think we'd prefer that to the current situation)