### PR TITLE
use python 3.7, as python:3-slim is now using python 3.8.

### DIFF
--- a/src/emailservice/Dockerfile
+++ b/src/emailservice/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim as base
+FROM python:3.7-slim as base
 
 FROM base as builder
 


### PR DESCRIPTION
The email service fails to build because it requires python 3.7, not 3.8. python:3-slim now ships with 3.8.