### PR TITLE
Standardizes loadgen behavior for Istio mTLS=STRICT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,3 @@ pkg/
 .idea
 .skaffold-*.yaml
 .kubernetes-manifests-*/
-istio-1.*/
-install-istio.sh
-mtls.yaml
-istio.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ pkg/
 .idea
 .skaffold-*.yaml
 .kubernetes-manifests-*/
+istio-1.*/
+install-istio.sh
+mtls.yaml
+istio.yaml

--- a/README.md
+++ b/README.md
@@ -212,35 +212,28 @@ by deploying the [release manifest](./release) directly to an existing cluster.
        --istio-config=auth=MTLS_PERMISSIVE
    ```
 
-   > NOTE: If you need to enable `MTLS_STRICT` mode, you will need to update
-   > several manifest files:
-   >
-   > - `kubernetes-manifests/frontend.yaml`: delete "livenessProbe" and
-   >   "readinessProbe" fields.
-   > - `kubernetes-manifests/loadgenerator.yaml`: delete "initContainers" field.
-
-1. (Optional) Enable Stackdriver Tracing/Logging with Istio Stackdriver Adapter
+2. (Optional) Enable Stackdriver Tracing/Logging with Istio Stackdriver Adapter
    by [following this guide](https://cloud.google.com/istio/docs/istio-on-gke/installing#enabling_tracing_and_logging).
 
-1. Install the automatic sidecar injection (annotate the `default` namespace
+3. Install the automatic sidecar injection (annotate the `default` namespace
    with the label):
 
    ```sh
    kubectl label namespace default istio-injection=enabled
    ```
 
-1. Apply the manifests in [`./istio-manifests`](./istio-manifests) directory.
+4. Apply the manifests in [`./istio-manifests`](./istio-manifests) directory.
    (This is required only once.)
 
    ```sh
    kubectl apply -f ./istio-manifests
    ```
 
-1. Deploy the application with `skaffold run --default-repo=gcr.io/[PROJECT_ID]`.
+5. Deploy the application with `skaffold run --default-repo=gcr.io/[PROJECT_ID]`.
 
-1. Run `kubectl get pods` to see pods are in a healthy and ready state.
+6. Run `kubectl get pods` to see pods are in a healthy and ready state.
 
-1. Find the IP address of your Istio gateway Ingress or Service, and visit the
+7. Find the IP address of your Istio gateway Ingress or Service, and visit the
    application.
 
    ```sh

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -24,6 +24,8 @@ spec:
     metadata:
       labels:
         app: frontend
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       containers:
         - name: server

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,9 +29,6 @@ spec:
     spec:
       terminationGracePeriodSeconds: 5
       restartPolicy: Always
-        env:
-        - name: FRONTEND_ADDR
-          value: "frontend:80"
       containers:
       - name: main
         image: loadgenerator

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -25,17 +25,11 @@ spec:
     metadata:
       labels:
         app: loadgenerator
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       terminationGracePeriodSeconds: 5
       restartPolicy: Always
-      initContainers:
-      - name: wait-frontend
-        image: alpine:3.6
-        command: ['sh', '-c', 'set -x;  apk add --no-cache curl && 
-          until timeout -t 2 curl -f "http://${FRONTEND_ADDR}"; do 
-            echo "waiting for http://${FRONTEND_ADDR}"; 
-            sleep 2;
-          done;']
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -451,22 +451,9 @@ spec:
     spec:
       terminationGracePeriodSeconds: 5
       restartPolicy: Always
-      # initContainers:
-      # - name: wait-frontend
-      #   image: alpine:3.6
-      #   command: ['sh', '-c', 'set -x;  apk add --no-cache curl &&
-      #     until timeout -t 2 curl -f "http://${FRONTEND_ADDR}"; do
-      #       echo "waiting for http://${FRONTEND_ADDR}";
-      #       sleep 2;
-      #     done;']
-      #   env:
-      #   - name: FRONTEND_ADDR
-      #     value: "frontend:80"
       containers:
       - name: main
-#        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.1.2
         image: gcr.io/megandemo/loadgen:failcurl
-        imagePullPolicy: Always
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -453,7 +453,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: main
-        image: gcr.io/megandemo/loadgen:failcurl
+        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.1.2
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -199,6 +199,8 @@ spec:
     metadata:
       labels:
         app: frontend
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       containers:
         - name: server
@@ -444,23 +446,27 @@ spec:
     metadata:
       labels:
         app: loadgenerator
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       terminationGracePeriodSeconds: 5
       restartPolicy: Always
-      initContainers:
-      - name: wait-frontend
-        image: alpine:3.6
-        command: ['sh', '-c', 'set -x;  apk add --no-cache curl && 
-          until timeout -t 2 curl -f "http://${FRONTEND_ADDR}"; do 
-            echo "waiting for http://${FRONTEND_ADDR}"; 
-            sleep 2;
-          done;']
-        env:
-        - name: FRONTEND_ADDR
-          value: "frontend:80"
+      # initContainers:
+      # - name: wait-frontend
+      #   image: alpine:3.6
+      #   command: ['sh', '-c', 'set -x;  apk add --no-cache curl &&
+      #     until timeout -t 2 curl -f "http://${FRONTEND_ADDR}"; do
+      #       echo "waiting for http://${FRONTEND_ADDR}";
+      #       sleep 2;
+      #     done;']
+      #   env:
+      #   - name: FRONTEND_ADDR
+      #     value: "frontend:80"
       containers:
       - name: main
-        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.1.2
+#        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.1.2
+        image: gcr.io/megandemo/loadgen:failcurl
+        imagePullPolicy: Always
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -199,8 +199,6 @@ spec:
     metadata:
       labels:
         app: frontend
-      annotations:
-        sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       containers:
         - name: server
@@ -446,11 +444,20 @@ spec:
     metadata:
       labels:
         app: loadgenerator
-      annotations:
-        sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       terminationGracePeriodSeconds: 5
       restartPolicy: Always
+      initContainers:
+      - name: wait-frontend
+        image: alpine:3.6
+        command: ['sh', '-c', 'set -x;  apk add --no-cache curl &&
+          until timeout -t 2 curl -f "http://${FRONTEND_ADDR}"; do
+            echo "waiting for http://${FRONTEND_ADDR}";
+            sleep 2;
+          done;']
+        env:
+        - name: FRONTEND_ADDR
+          value: "frontend:80"
       containers:
       - name: main
         image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.1.2

--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -15,4 +15,7 @@ COPY --from=builder /install /usr/local
 
 COPY . .
 RUN chmod +x ./loadgen.sh
+RUN apt-get -qq update \
+    && apt-get install -y --no-install-recommends \
+        curl
 ENTRYPOINT ./loadgen.sh

--- a/src/loadgenerator/loadgen.sh
+++ b/src/loadgenerator/loadgen.sh
@@ -18,10 +18,19 @@
 set -e
 trap "exit" TERM
 
-if [[ -z "${FRONTEND_ADDR}" ]]; then
+if [ -z "${FRONTEND_ADDR}" ]; then
     echo >&2 "FRONTEND_ADDR not specified"
     exit 1
 fi
 
 set -x
+
+# if one request to the frontend fails, then exit
+STATUSCODE=$(curl --silent --output /dev/stderr --write-out "%{http_code}" http://${FRONTEND_ADDR})
+if test $STATUSCODE -ne 200; then
+    echo "Error: cannot reach frontend, exiting"
+    exit 1
+fi
+
+# else, run loadgen
 locust --host="http://${FRONTEND_ADDR}" --no-web -c "${USERS:-10}" 2>&1

--- a/src/loadgenerator/loadgen.sh
+++ b/src/loadgenerator/loadgen.sh
@@ -18,7 +18,7 @@
 set -e
 trap "exit" TERM
 
-if [ -z "${FRONTEND_ADDR}" ]; then
+if [[ -z "${FRONTEND_ADDR}" ]]; then
     echo >&2 "FRONTEND_ADDR not specified"
     exit 1
 fi
@@ -28,7 +28,7 @@ set -x
 # if one request to the frontend fails, then exit
 STATUSCODE=$(curl --silent --output /dev/stderr --write-out "%{http_code}" http://${FRONTEND_ADDR})
 if test $STATUSCODE -ne 200; then
-    echo "Error: cannot reach frontend, exiting"
+    echo "Error: Could not reach frontend - Status code: ${STATUSCODE}"
     exit 1
 fi
 


### PR DESCRIPTION
Closes #211, #269 

### Changelog 

Updates the loadgen and frontend when Istio mTLS is set to `STRICT`.

1. Fixes the case where the loadgen tries to call the frontend before the client-side Envoy starts, causing non mTLS traffic --> curl fails --> loadgen never starts. Now, loadgen init container logic (curl frontend) moved into the first line of the `main` script, before locust starts. This way, the loadgen will `CrashLoop` if it can't reach the frontend, and will retry instead of getting stuck. 
1. Added pod annotations for frontend, loadgen for [`sidecar.istio.io/rewriteAppHTTPProbers: "true"`](https://istio.io/docs/ops/configuration/mesh/app-health-check/#use-annotations-on-pod) -- this will rewrite HTTP probes to be TLS, to work when mTLS is set to STRICT.    
1. Updates README instructions to remove liveness/readiness probes for mTLS -- these manifests should now work with any Istio mTLS settings. 

### How to test 

1. Create a regular GKE cluster (I used 4 nodes, n1-standard-4)
2. Install OSS Istio. I used [this script](https://gist.github.com/askmeegs/bdc283dc8e39b167795aac4b90ea5918), and set `ISTIO_VERSION` to 1.4.2 
3. Enable mesh-wide STRICT mtls -- apply [this yaml](https://gist.github.com/askmeegs/30ee3256de606646388b80184e2bb1c5)
4. update `kubernetes-manifests/` loadgen image to`gcr.io/megandemo/loadgen:failcurl` 
5. deploy hipstershop on the cluster. everything should start normally, liveness/readiness probes should work, locust starts 
6. Trigger the failing state: `kubectl delete deployment frontend` 
7. delete the loadgen pod to re-kick 
8. `kubectl logs <loadgen-pod> -c main`. You should see: `Error: Loadgen cannot reach frontend, exiting`  