### PR TITLE
[WIP] Fixes emailservice CrashLoop when Workload Identity is enabled

### DIFF
--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -34,8 +34,6 @@ spec:
         env:
         - name: PORT
           value: "8080"
-        - name: GCP_PROJECT_ID
-          value: "thinmint"
         - name: ENABLE_PROFILER
           value: "0"
         readinessProbe:

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -34,6 +34,10 @@ spec:
         env:
         - name: PORT
           value: "8080"
+        - name: GCP_PROJECT_ID
+          value: "thinmint"
+        - name: ENABLE_PROFILER
+          value: "0"
         readinessProbe:
           periodSeconds: 5
           exec:
@@ -42,9 +46,6 @@ spec:
           periodSeconds: 5
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:8080"]
-        env:
-        - name: ENABLE_PROFILER
-          value: "0"
         resources:
           requests:
             cpu: 100m

--- a/src/emailservice/email_server.py
+++ b/src/emailservice/email_server.py
@@ -37,7 +37,9 @@ import googlecloudprofiler
 
 try:
     sampler = always_on.AlwaysOnSampler()
-    exporter = stackdriver_exporter.StackdriverExporter()
+    exporter = stackdriver_exporter.StackdriverExporter(
+        project_id=os.environ.get('GCP_PROJECT_ID'),
+        transport=AsyncTransport)
     tracer_interceptor = server_interceptor.OpenCensusServerInterceptor(sampler, exporter)
 except:
     tracer_interceptor = server_interceptor.OpenCensusServerInterceptor()

--- a/src/emailservice/email_server.py
+++ b/src/emailservice/email_server.py
@@ -37,6 +37,9 @@ import googlecloudprofiler
 
 try:
     sampler = always_on.AlwaysOnSampler()
+    exporter = stackdriver_exporter.StackdriverExporter(
+        project_id=os.environ.get('GCP_PROJECT_ID'),
+        transport=AsyncTransport)
     exporter = stackdriver_exporter.StackdriverExporter()
     tracer_interceptor = server_interceptor.OpenCensusServerInterceptor(sampler, exporter)
 except:

--- a/src/emailservice/email_server.py
+++ b/src/emailservice/email_server.py
@@ -37,9 +37,6 @@ import googlecloudprofiler
 
 try:
     sampler = always_on.AlwaysOnSampler()
-    exporter = stackdriver_exporter.StackdriverExporter(
-        project_id=os.environ.get('GCP_PROJECT_ID'),
-        transport=AsyncTransport)
     exporter = stackdriver_exporter.StackdriverExporter()
     tracer_interceptor = server_interceptor.OpenCensusServerInterceptor(sampler, exporter)
 except:

--- a/src/recommendationservice/recommendation_server.py
+++ b/src/recommendationservice/recommendation_server.py
@@ -99,7 +99,9 @@ if __name__ == "__main__":
 
     try:
         sampler = always_on.AlwaysOnSampler()
-        exporter = stackdriver_exporter.StackdriverExporter()
+        exporter = stackdriver_exporter.StackdriverExporter(
+            project_id=os.environ.get('GCP_PROJECT_ID'),
+            transport=AsyncTransport)
         tracer_interceptor = server_interceptor.OpenCensusServerInterceptor(sampler, exporter)
     except:
         tracer_interceptor = server_interceptor.OpenCensusServerInterceptor()
@@ -123,7 +125,8 @@ if __name__ == "__main__":
     product_catalog_stub = demo_pb2_grpc.ProductCatalogServiceStub(channel)
 
     # create gRPC server
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10)) # ,interceptors=(tracer_interceptor,))
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10),
+                      interceptors=(tracer_interceptor,))
 
     # add class to gRPC server
     service = RecommendationService()


### PR DESCRIPTION
Closes #255 

- [x]  updates emailservice init tracing logic to include an explicit `PROJECT_ID` for the `stackdriver_exporter`. When this was not specified, and workload identity was enabled on the cluster, this caused an authentication error. Adding the project ID makes it work, not entirely sure why, but I think it has to do with workload identity pods being decoupled from google service accounts - so you have to be explicit about the project. 
- [x]  I noticed that recommendationservice (the other Python service) had not fully enabled tracing with the `tracer_interceptor`, uncommented it, seems to be working fine. 
- [x] also tested changes on a Kops on GCE cluster 