### PR TITLE
Fix double shebang in loadgen.sh

### DIFF
--- a/src/loadgenerator/loadgen.sh
+++ b/src/loadgenerator/loadgen.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -eu
+#!/bin/bash
 #
 # Copyright 2018 Google LLC
 #
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
 set -e
 trap "exit" TERM
 


### PR DESCRIPTION
Fixes double shebang in loadgen script. Running this script with sh instead of bash was causing `./loadgen.sh: 21: ./loadgen.sh: [[: not found` to be printed on each run (but the service would still run successfully)

bug discovered here: https://github.com/GoogleCloudPlatform/microservices-demo/issues/283