### PR TITLE
Improve startup using InitContainers

### DIFF
--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -26,6 +26,13 @@ spec:
         app: cartservice
     spec:
       terminationGracePeriodSeconds: 5
+      initContainers:
+      - name: init-db-ready
+        image:  redis:alpine
+        command: ['/bin/sh', '-c']
+        args:
+          - until redis-cli -h redis-cart -p 6379 ping; do echo waiting for redis-cart; sleep 2; done
+          #- for i in {1..100}; do sleep 1; if redis-cli -h redis-cart -p 6379 ping; then exit 0; fi; done; exit 1
       containers:
       - name: server
         image: cartservice

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -32,7 +32,6 @@ spec:
         command: ['/bin/sh', '-c']
         args:
           - until redis-cli -h redis-cart -p 6379 ping; do echo waiting for redis-cart; sleep 2; done
-          #- for i in {1..100}; do sleep 1; if redis-cli -h redis-cart -p 6379 ping; then exit 0; fi; done; exit 1
       containers:
       - name: server
         image: cartservice

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -32,7 +32,9 @@ spec:
       initContainers:
       - name: init-frontend-ready
         image: busybox:1.28
-        command: ['sh', '-c', 'until  [[ "$(wget --spider -S http://frontend 2>&1 | grep HTTP/)" == "  HTTP/1.1 200 OK" ]]; do echo waiting for frontend; sleep 2; done;']
+        command: ['/bin/sh', '-c']
+        args:
+          - until  [[ "$(wget --spider -S http://frontend 2>&1 | grep HTTP/)" == "  HTTP/1.1 200 OK" ]]; do echo waiting for frontend; sleep 2; done
       containers:
       - name: main
         image: loadgenerator

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -29,6 +29,10 @@ spec:
     spec:
       terminationGracePeriodSeconds: 5
       restartPolicy: Always
+      initContainers:
+      - name: init-frontend-ready
+        image: busybox:1.28
+        command: ['sh', '-c', 'until  [[ "$(wget --spider -S http://frontend 2>&1 | grep HTTP/)" == "  HTTP/1.1 200 OK" ]]; do echo waiting for frontend; sleep 2; done;']
       containers:
       - name: main
         image: loadgenerator

--- a/kubernetes-manifests/redis.yaml
+++ b/kubernetes-manifests/redis.yaml
@@ -31,6 +31,7 @@ spec:
         ports:
         - containerPort: 6379
         readinessProbe:
+          periodSeconds: 5
           exec:
             command: ['/bin/sh', '-c', 'redis-cli -h $(hostname) ping']
         livenessProbe:

--- a/kubernetes-manifests/redis.yaml
+++ b/kubernetes-manifests/redis.yaml
@@ -31,9 +31,11 @@ spec:
         ports:
         - containerPort: 6379
         readinessProbe:
-          periodSeconds: 5
-          tcpSocket:
-            port: 6379
+          exec:
+            command:
+            - sh
+            - -c
+            - "redis-cli -h $(hostname) ping"
         livenessProbe:
           periodSeconds: 5
           tcpSocket:

--- a/kubernetes-manifests/redis.yaml
+++ b/kubernetes-manifests/redis.yaml
@@ -32,10 +32,7 @@ spec:
         - containerPort: 6379
         readinessProbe:
           exec:
-            command:
-            - sh
-            - -c
-            - "redis-cli -h $(hostname) ping"
+            command: ['/bin/sh', '-c', 'redis-cli -h $(hostname) ping']
         livenessProbe:
           periodSeconds: 5
           tcpSocket:


### PR DESCRIPTION
Some users were confused by the crashes in cartservice and loadgenerator as they wait for the redis-cart service to be ready (https://github.com/GoogleCloudPlatform/microservices-demo/issues/283). This PR fixes that using InitContainers to block pod creation until dependencies are ready

I also improved the readiness probe of the redis-cart, so it only shows as ready when it can respond to a redis-cli ping