### PR TITLE
Fix Local CartStore emptycart()

### DIFF
--- a/src/cartservice/Program.cs
+++ b/src/cartservice/Program.cs
@@ -56,7 +56,7 @@ namespace cartservice
                     Console.WriteLine($"Trying to start a grpc server at  {host}:{port}");
                     Server server = new Server
                     {
-                        Services = 
+                        Services =
                         {
                             // Cart Service Endpoint
                              Hipstershop.CartService.BindService(new CartServiceImpl(cartStore)),
@@ -99,7 +99,7 @@ namespace cartservice
             {
                 case "start":
                     Parser.Default.ParseArguments<ServerOptions>(args).MapResult(
-                        (ServerOptions options) => 
+                        (ServerOptions options) =>
                         {
                             Console.WriteLine($"Started as process with id {System.Diagnostics.Process.GetCurrentProcess().Id}");
 
@@ -127,7 +127,7 @@ namespace cartservice
                                     Console.WriteLine($"{CART_SERVICE_PORT} environment variable was not set. Setting the port to 8080");
                                     port = 8080;
                                 }
-                                else    
+                                else
                                 {
                                     port = int.Parse(portStr);
                                 }

--- a/src/cartservice/cartstore/LocalCartStore.cs
+++ b/src/cartservice/cartstore/LocalCartStore.cs
@@ -65,7 +65,7 @@ namespace cartservice.cartstore
         public Task EmptyCartAsync(string userId)
         {
             Console.WriteLine($"EmptyCartAsync called with userId={userId}");
-            userCartItems[userId] = emptyCart;
+            userCartItems[userId] = new Hipstershop.Cart();
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
When using a local cart store, the emptyCart function does not seem to work --  and  the loadgen keeps adding items, causing the cart total to exponentially increase. 
<img width="1118" alt="Screen Shot 2020-01-28 at 8 51 52 AM" src="https://user-images.githubusercontent.com/3137106/73277602-6c995f00-41b8-11ea-9dbc-ba5385464e0b.png">

I'm not 100% sure, but I think the `emptyCart` variable being passed around / reassigned, on emptyCart() was the issue. When I changed the emptyCart() function to instead initialize a clean `Hipstershop.Cart`, the problem went away. 