### PR TITLE
Update container build instructions

### DIFF
--- a/src/adservice/README.md
+++ b/src/adservice/README.md
@@ -20,9 +20,9 @@ If you need to upgrade the version of gradle then run
 
 ## Building docker image
 
-From the repository root, run:
+From `src/adservice/`, run:
 
 ```
-docker build --file src/adservice/Dockerfile .
+docker build ./
 ```
 

--- a/src/shippingservice/README.md
+++ b/src/shippingservice/README.md
@@ -10,10 +10,10 @@ Run the following command to restore dependencies to `vendor/` directory:
 
 ## Build
 
-From repository root, run:
+From `src/shippingservice`, run:
 
 ```
-docker build --file src/shippingservice/Dockerfile .
+docker build ./
 ```
 
 ## Test


### PR DESCRIPTION
Update the instructions for how to build docker image in services with misleading READMEs

addresses https://github.com/GoogleCloudPlatform/microservices-demo/issues/292