### PR TITLE
Fix local clusters

### DIFF
--- a/src/emailservice/email_server.py
+++ b/src/emailservice/email_server.py
@@ -22,6 +22,7 @@ import time
 import grpc
 from jinja2 import Environment, FileSystemLoader, select_autoescape, TemplateError
 from google.api_core.exceptions import GoogleAPICallError
+from google.auth.exceptions import DefaultCredentialsError
 
 import demo_pb2
 import demo_pb2_grpc
@@ -189,7 +190,7 @@ if __name__ == '__main__':
         project_id=os.environ.get('GCP_PROJECT_ID'),
         transport=AsyncTransport)
       tracer_interceptor = server_interceptor.OpenCensusServerInterceptor(sampler, exporter)
-  except KeyError:
+  except (KeyError, DefaultCredentialsError):
       logger.info("Tracing disabled.")
       tracer_interceptor = server_interceptor.OpenCensusServerInterceptor()
 

--- a/src/recommendationservice/recommendation_server.py
+++ b/src/recommendationservice/recommendation_server.py
@@ -22,6 +22,7 @@ from concurrent import futures
 
 import googleclouddebugger
 import googlecloudprofiler
+from google.auth.exceptions import DefaultCredentialsError
 import grpc
 from opencensus.trace.exporters import print_exporter
 from opencensus.trace.exporters import stackdriver_exporter
@@ -108,7 +109,7 @@ if __name__ == "__main__":
           project_id=os.environ.get('GCP_PROJECT_ID'),
           transport=AsyncTransport)
         tracer_interceptor = server_interceptor.OpenCensusServerInterceptor(sampler, exporter)
-    except KeyError:
+    except (KeyError, DefaultCredentialsError):
         logger.info("Tracing disabled.")
         tracer_interceptor = server_interceptor.OpenCensusServerInterceptor()
 


### PR DESCRIPTION
On local clusters, emailservice and recommendationservice were throwing an uncaught exception when they couldn't find the GCP project. Now, we catch the exception and disable tracing so the app can function as normal

fixes https://github.com/GoogleCloudPlatform/microservices-demo/issues/316 and https://github.com/GoogleCloudPlatform/microservices-demo/pull/318
