### PR TITLE
Improve smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
         kubectl get nodes
     - name: Deploy From Source
       run: |
-        skaffold run
+        skaffold config set --global local-cluster true
+        skaffold run --default-repo local
     - name: Wait For Pods
       timeout-minutes: 20
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
         REQUEST_COUNT="0"
         while [[ "$REQUEST_COUNT"  -lt "50"  ]]; do
             sleep 5
-            REQUEST_COUNT=$(kubectl logs -l app=loadgenerator | grep Total | awk '{print $2}')
+            REQUEST_COUNT=$(kubectl logs -l app=loadgenerator | grep Aggregated | awk '{print $2}')
         done
         # ensure there are no errors hitting endpoints
-        ERROR_COUNT=$(kubectl logs -l app=loadgenerator | grep Total | awk '{print $3}' | sed "s/[(][^)]*[)]//g")
+        ERROR_COUNT=$(kubectl logs -l app=loadgenerator | grep Aggregated | awk '{print $3}' | sed "s/[(][^)]*[)]//g")
         if [[ "$ERROR_COUNT" -gt "0" ]]; then
           exit 1
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,16 @@ jobs:
       timeout-minutes: 5
       run: |
         set -x
-        RESULT=" "
-        while [[ "$RESULT" != "  HTTP/1.1 200 OK" ]]; do
-          sleep 1
-          RESULT=$(kubectl exec deployments/frontend -- sh -c "wget --spider -S "http://frontend" 2>&1 | grep 'HTTP/'")
-          echo "front end response: $RESULT"
+        # start fresh loadgenerator pod
+        kubectl delete pod -l app=loadgenerator
+        # wait for requests to come in
+        REQUEST_COUNT="0"
+        while [[ "$REQUEST_COUNT"  -lt "50"  ]]; do
+            sleep 5
+            REQUEST_COUNT=$(kubectl logs -l app=loadgenerator | grep Total | awk '{print $2}')
         done
-        if [[ "$RESULT" != "  HTTP/1.1 200 OK" ]]; then 
+        # ensure there are no errors hitting endpoints
+        ERROR_COUNT=$(kubectl logs -l app=loadgenerator | grep Total | awk '{print $3}' | sed "s/[(][^)]*[)]//g")
+        if [[ "$ERROR_COUNT" -gt "0" ]]; then
           exit 1
         fi


### PR DESCRIPTION
Smoke test would previously just check for a 200 status at http://frontend. This would miss serious errors in other services

Now, the test checks the output of loadgenerator for errors, ensuring a number of endpoints are queried without fail. This should be a better metric to ensure the app as a whole is healthy

Note: This is expected to fail until https://github.com/GoogleCloudPlatform/microservices-demo/pull/318 is merged