### PR TITLE
Kind instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,17 +135,16 @@ We offer the following installation methods:
 1. Run `kubectl get pods` to verify the Pods are ready and running.
 
 1. Access the web frontend through your browser
-    - **Minikube** requires you to run a command to access the service:
+    - **Minikube** requires you to run a command to access the frontend service:
     ```shell
     minikube service frontend-external
     ```
-    - **Docker For Desktop** should automatically provide a port mapping for the LoadBalancer. =
-      You can access the frontend at http://localhost:80
-    - **Kind** does not provision an IP address for the service. You must first run a port-forwarding process:
+    - **Docker For Desktop** should automatically provide the frontend at http://localhost:80
+    - **Kind** does not provision an IP address for the service. 
+      You must run a port-forwarding process to access the frontend at http://localhost:8080:
     ```shell
     kubectl port-forward deployment/frontend 8080:8080
     ```
-    You should now be able to access the frontend at http://localhost:8080
 
 ### Option 2: Running on Google Kubernetes Engine (GKE)
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ We offer the following installation methods:
        local Kubernetes cluster has at least:
         - 4 CPU's
         - 4.0 GiB memory
+
       ```shell
       minikube start --cpus=4 --memory 4096
       ```
@@ -121,10 +122,11 @@ We offer the following installation methods:
         - set CPUs to at least 3, and Memory to at least 6.0 GiB
         - on the "Disk" tab, set at least 32 GB disk space
 
-    - to Launch a **Kind** cluster:
-        ```shell
-        kind create cluster
-        ```
+    - To Launch a **Kind** cluster:
+
+      ```shell
+      kind create cluster
+      ```
 
 1. Run `kubectl get nodes` to verify you're connected to “Kubernetes on Docker”.
 
@@ -136,12 +138,16 @@ We offer the following installation methods:
 
 1. Access the web frontend through your browser
     - **Minikube** requires you to run a command to access the frontend service:
+
     ```shell
     minikube service frontend-external
     ```
+
     - **Docker For Desktop** should automatically provide the frontend at http://localhost:80
-    - **Kind** does not provision an IP address for the service. 
+
+    - **Kind** does not provision an IP address for the service.
       You must run a port-forwarding process to access the frontend at http://localhost:8080:
+
     ```shell
     kubectl port-forward deployment/frontend 8080:8080
     ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ We offer the following installation methods:
      Linux hosts (also supports Mac/Windows).
    - [Docker for Desktop](https://www.docker.com/products/docker-desktop).
      Recommended for Mac/Windows.
-   - [Kind](https://www.docker.com/products/docker-desktop) (supports Mac/Windows/Linux)
+   - [Kind](https://www.docker.com/products/docker-desktop). Supports Mac/Windows/Linux.
 
 1. **Running on Google Kubernetes Engine (GKE)”** (~30 minutes) You will build,
    upload and deploy the container images to a Kubernetes cluster on Google
@@ -112,9 +112,6 @@ We offer the following installation methods:
        local Kubernetes cluster has at least:
         - 4 CPU's
         - 4.0 GiB memory
-
-        To run a Kubernetes cluster with Minikube using the described configuration, please run:
-
       ```shell
       minikube start --cpus=4 --memory 4096
       ```
@@ -124,7 +121,7 @@ We offer the following installation methods:
         - set CPUs to at least 3, and Memory to at least 6.0 GiB
         - on the "Disk" tab, set at least 32 GB disk space
 
-    - Launch a Kind cluster
+    - Launch a Kind cluster:
         ```shell
         kind create cluster
         ```

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ We offer the following installation methods:
         - set CPUs to at least 3, and Memory to at least 6.0 GiB
         - on the "Disk" tab, set at least 32 GB disk space
 
-    - To Launch a **Kind** cluster:
+    - To launch a **Kind** cluster:
 
       ```shell
       kind create cluster

--- a/README.md
+++ b/README.md
@@ -72,12 +72,13 @@ We offer the following installation methods:
 
 1. **Running locally** (~20 minutes) You will build
    and deploy microservices images to a single-node Kubernetes cluster running
-   on your development machine. There are two options to run a Kubernetes
+   on your development machine. There are three options to run a Kubernetes
    cluster locally for this demo:
-   - [Minikube](https://github.com/kubernetes/minikube). Recommended for the
+   - [Minikube](https://github.com/kubernetes/minikube). Recommended for
      Linux hosts (also supports Mac/Windows).
    - [Docker for Desktop](https://www.docker.com/products/docker-desktop).
      Recommended for Mac/Windows.
+   - [Kind](https://www.docker.com/products/docker-desktop) (supports Mac/Windows/Linux)
 
 1. **Running on Google Kubernetes Engine (GKE)”** (~30 minutes) You will build,
    upload and deploy the container images to a Kubernetes cluster on Google
@@ -98,9 +99,11 @@ We offer the following installation methods:
    - kubectl (can be installed via `gcloud components install kubectl`)
    - Local Kubernetes cluster deployment tool:
         - [Minikube (recommended for
-         Linux)](https://kubernetes.io/docs/setup/minikube/).
-        - Docker for Desktop (recommended for Mac/Windows): It provides Kubernetes support as [noted
-     here](https://docs.docker.com/docker-for-mac/kubernetes/).
+         Linux)](https://kubernetes.io/docs/setup/minikube/)
+        - [Docker for Desktop (recommended for Mac/Windows)](https://www.docker.com/products/docker-desktop)
+          - It provides Kubernetes support as [noted
+     here](https://docs.docker.com/docker-for-mac/kubernetes/)
+        - [Kind](https://github.com/kubernetes-sigs/kind)
    - [skaffold]( https://skaffold.dev/docs/install/) (ensure version ≥v0.20)
 
 1. Launch the local Kubernetes cluster with one of the following tools:
@@ -112,14 +115,19 @@ We offer the following installation methods:
 
         To run a Kubernetes cluster with Minikube using the described configuration, please run:
 
-    ```shell
-    minikube start --cpus=4 --memory 4096
-    ```
-    
+      ```shell
+      minikube start --cpus=4 --memory 4096
+      ```
+
     - Launch “Docker for Desktop” (tested with Mac/Windows). Go to Preferences:
         - choose “Enable Kubernetes”,
         - set CPUs to at least 3, and Memory to at least 6.0 GiB
         - on the "Disk" tab, set at least 32 GB disk space
+
+    - Launch a Kind cluster
+        ```shell
+        kind create cluster
+        ```
 
 1. Run `kubectl get nodes` to verify you're connected to “Kubernetes on Docker”.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ We offer the following installation methods:
 
 1. Launch the local Kubernetes cluster with one of the following tools:
 
-    - Launch Minikube (tested with Ubuntu Linux). Please, ensure that the
+    - To launch **Minikube** (tested with Ubuntu Linux). Please, ensure that the
        local Kubernetes cluster has at least:
         - 4 CPU's
         - 4.0 GiB memory
@@ -116,12 +116,12 @@ We offer the following installation methods:
       minikube start --cpus=4 --memory 4096
       ```
 
-    - Launch “Docker for Desktop” (tested with Mac/Windows). Go to Preferences:
+    - To launch **Docker for Desktop** (tested with Mac/Windows). Go to Preferences:
         - choose “Enable Kubernetes”,
         - set CPUs to at least 3, and Memory to at least 6.0 GiB
         - on the "Disk" tab, set at least 32 GB disk space
 
-    - Launch a Kind cluster:
+    - to Launch a **Kind** cluster:
         ```shell
         kind create cluster
         ```
@@ -132,9 +132,20 @@ We offer the following installation methods:
    This will build and deploy the application. If you need to rebuild the images
    automatically as you refactor the code, run `skaffold dev` command.
 
-1. Run `kubectl get pods` to verify the Pods are ready and running. The
-   application frontend should be available at http://localhost:80 on your
-   machine.
+1. Run `kubectl get pods` to verify the Pods are ready and running.
+
+1. Access the web frontend through your browser
+    - **Minikube** requires you to run a command to access the service:
+    ```shell
+    minikube service frontend-external
+    ```
+    - **Docker For Desktop** should automatically provide a port mapping for the LoadBalancer. =
+      You can access the frontend at http://localhost:80
+    - **Kind** does not provision an IP address for the service. You must first run a port-forwarding process:
+    ```shell
+    kubectl port-forward deployment/frontend 8080:8080
+    ```
+    You should now be able to access the frontend at http://localhost:8080
 
 ### Option 2: Running on Google Kubernetes Engine (GKE)
 


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/microservices-demo/issues/308:
- adds Kind to the list of supported local clusters
- improve instructions for accessing the local frontend