### PR TITLE
Update the latest version of Stackdriver Exporter

### DIFF
--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.1.4
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.2.0
         ports:
         - containerPort: 8080
         env:
@@ -86,7 +86,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.1.4
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.2.0
           ports:
           - containerPort: 5050
           readinessProbe:
@@ -110,12 +110,12 @@ spec:
             value: "currencyservice:7000"
           - name: CART_SERVICE_ADDR
             value: "cartservice:7070"
-          # - name: DISABLE_STATS
-          #   value: "1"
-          # - name: DISABLE_TRACING
-          #   value: "1"
-          # - name: DISABLE_PROFILER
-          #   value: "1"
+        #   - name: DISABLE_STATS
+        #     value: "1"
+        #   - name: DISABLE_TRACING
+        #     value: "1"
+          - name: DISABLE_PROFILER
+            value: "1"
           # - name: JAEGER_SERVICE_ADDR
           #   value: "jaeger-collector:14268"
           resources:
@@ -155,7 +155,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.1.4
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.2.0
         ports:
         - containerPort: 8080
         readinessProbe:
@@ -173,10 +173,10 @@ spec:
           value: "productcatalogservice:3550"
         # - name: DISABLE_TRACING
         #   value: "1"
-        # - name: DISABLE_PROFILER
-        #   value: "1"
-        # - name: DISABLE_DEBUGGER
-        #   value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
         resources:
           requests:
             cpu: 100m
@@ -215,7 +215,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.1.4
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.2.0
           ports:
           - containerPort: 8080
           readinessProbe:
@@ -251,10 +251,12 @@ spec:
             value: "checkoutservice:5050"
           - name: AD_SERVICE_ADDR
             value: "adservice:9555"
-          # - name: DISABLE_TRACING
-          #   value: "1"
-          # - name: DISABLE_PROFILER
-          #   value: "1"
+          - name: ENV_PLATFORM
+            value: "gcp"
+        #   - name: DISABLE_TRACING
+        #     value: "1"
+          - name: DISABLE_PROFILER
+            value: "1"
           # - name: JAEGER_SERVICE_ADDR
           #   value: "jaeger-collector:14268"
           resources:
@@ -307,7 +309,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.1.4
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.2.0
         ports:
         - containerPort: 50051
         env:
@@ -356,7 +358,9 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.1.4
+        # image: gcr.io/qwiklab-gke-debugging/productcatalogservice:v0.1.0
+        image: gcr.io/cloud-ops-demo-app/productservice:latest
+        # imagePullPolicy: Always
         ports:
         - containerPort: 3550
         env:
@@ -366,8 +370,12 @@ spec:
         #   value: "1"
         # - name: DISABLE_TRACING
         #   value: "1"
-        # - name: DISABLE_PROFILER
-        #   value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: ENABLE_RELOAD
+          value: "1"
+        - name: LATENCY_SPIKE
+          value: "100"          
         # - name: JAEGER_SERVICE_ADDR
         #   value: "jaeger-collector:14268"
         readinessProbe:
@@ -413,7 +421,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.1.4
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.2.0
         ports:
         - containerPort: 7070
         env:
@@ -473,7 +481,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: main
-        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.1.4
+        image: gcr.io/qwiklab-gke-debugging/loadgenerator:v0.1.0
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"
@@ -486,6 +494,19 @@ spec:
           limits:
             cpu: 500m
             memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loadgenerator-external
+spec:
+  type: LoadBalancer
+  selector:
+    app: loadgenerator
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8089
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -503,7 +524,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.1.4
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.2.0
         ports:
         - name: grpc
           containerPort: 7000
@@ -512,10 +533,10 @@ spec:
           value: "7000"
         # - name: DISABLE_TRACING
         #   value: "1"
-        # - name: DISABLE_PROFILER
-        #   value: "1"
-        # - name: DISABLE_DEBUGGER
-        #   value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
         readinessProbe:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]
@@ -558,7 +579,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.1.4
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.2.0
         ports:
         - containerPort: 50051
         env:
@@ -568,8 +589,8 @@ spec:
         #   value: "1"
         # - name: DISABLE_TRACING
         #   value: "1"
-        # - name: DISABLE_PROFILER
-        #   value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
         # - name: JAEGER_SERVICE_ADDR
         #   value: "jaeger-collector:14268"
         readinessProbe:
@@ -669,7 +690,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/adservice:v0.1.4
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.2.0
         ports:
         - containerPort: 9555
         env:

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -374,8 +374,8 @@ spec:
           value: "1"
         - name: ENABLE_RELOAD
           value: "1"
-        - name: LATENCY_SPIKE
-          value: "100"          
+        # - name: LATENCY_SPIKE
+        #   value: "100"          
         # - name: JAEGER_SERVICE_ADDR
         #   value: "jaeger-collector:14268"
         readinessProbe:

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -360,7 +360,6 @@ spec:
       - name: server
         # image: gcr.io/qwiklab-gke-debugging/productcatalogservice:v0.1.0
         image: gcr.io/cloud-ops-demo-app/productservice:latest
-        # imagePullPolicy: Always
         ports:
         - containerPort: 3550
         env:
@@ -374,8 +373,8 @@ spec:
           value: "1"
         - name: ENABLE_RELOAD
           value: "1"
-        # - name: LATENCY_SPIKE
-        #   value: "1"          
+        - name: LATENCY_SPIKE
+          value: "1"
         # - name: JAEGER_SERVICE_ADDR
         #   value: "jaeger-collector:14268"
         readinessProbe:

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -375,7 +375,7 @@ spec:
         - name: ENABLE_RELOAD
           value: "1"
         # - name: LATENCY_SPIKE
-        #   value: "100"          
+        #   value: "1"          
         # - name: JAEGER_SERVICE_ADDR
         #   value: "jaeger-collector:14268"
         readinessProbe:

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -255,8 +255,8 @@ spec:
             value: "gcp"
         #   - name: DISABLE_TRACING
         #     value: "1"
-          - name: DISABLE_PROFILER
-            value: "1"
+        #   - name: DISABLE_PROFILER
+        #     value: "1"
           # - name: JAEGER_SERVICE_ADDR
           #   value: "jaeger-collector:14268"
           resources:
@@ -360,6 +360,7 @@ spec:
       - name: server
         # image: gcr.io/qwiklab-gke-debugging/productcatalogservice:v0.1.0
         image: gcr.io/cloud-ops-demo-app/productservice:latest
+        # imagePullPolicy: Always
         ports:
         - containerPort: 3550
         env:
@@ -369,12 +370,12 @@ spec:
         #   value: "1"
         # - name: DISABLE_TRACING
         #   value: "1"
-        - name: DISABLE_PROFILER
-          value: "1"
-        - name: ENABLE_RELOAD
-          value: "1"
-        - name: LATENCY_SPIKE
-          value: "1"
+        # - name: DISABLE_PROFILER
+        #   value: "1"
+        # - name: ENABLE_RELOAD
+        #   value: "1"
+        # - name: LATENCY_SPIKE
+        #   value: "1"
         # - name: JAEGER_SERVICE_ADDR
         #   value: "jaeger-collector:14268"
         readinessProbe:

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -360,6 +360,8 @@ spec:
       - name: server
         # image: gcr.io/qwiklab-gke-debugging/productcatalogservice:v0.1.0
         image: gcr.io/cloud-ops-demo-app/productservice:latest
+        # image: gcr.io/cloud-trace-demo/productservicecatalog:latest
+        # image: gcr.io/cloud-ops-demo-app/productservice@sha256:aa755c26b3a7b2e1da1c1cd3741d97af1c877ec7d572fa46187044b3334b9f45
         # imagePullPolicy: Always
         ports:
         - containerPort: 3550

--- a/src/frontend/Gopkg.lock
+++ b/src/frontend/Gopkg.lock
@@ -2,10 +2,11 @@
 
 
 [[projects]]
-  digest = "1:cd61c288406d5d80572967f908a23a1f0ffbf460e926269672e955f4a88b79bc"
+  digest = "1:9097d59af752a760c8967f4b4fca96bb99780659f8e65852869315f64afbf698"
   name = "cloud.google.com/go"
   packages = [
     "compute/metadata",
+    "container/apiv1",
     "internal/version",
     "monitoring/apiv3",
     "profiler",
@@ -16,21 +17,15 @@
   version = "v0.40.0"
 
 [[projects]]
-  digest = "1:4b96dcd8534bc6450a922bd16a76360ba3381f0d1daf40abbaec91c053fbfeb5"
+  digest = "1:fc98782bece7d3f842d991c4ce3f44dd893f9dc521a1d5fd895be9ad271e579f"
   name = "contrib.go.opencensus.io/exporter/stackdriver"
-  packages = ["."]
+  packages = [
+    ".",
+    "monitoredresource",
+  ]
   pruneopts = "UT"
-  revision = "37aa2801fbf0205003e15636096ebf0373510288"
-  version = "v0.5.0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:a85b0dc359de4812d383ee6670f0dae595cfcb8b13ff6b872bdb013a18c37b07"
-  name = "git.apache.org/thrift.git"
-  packages = ["lib/go/thrift"]
-  pruneopts = "UT"
-  revision = "286eee16b147a302ddc7b10740c5e5401ebbec17"
-  source = "github.com/apache/thrift"
+  revision = "ab68e2a40809b13b9e06ac2135d2549a6a984d62"
+  version = "v0.13.0"
 
 [[projects]]
   digest = "1:c4f0a05580fb5d27e1cc8f5723a8d33fd97590a931e845f23b104e05c02ea80b"
@@ -40,11 +35,75 @@
     "src/frontend/money",
   ]
   pruneopts = "UT"
-  revision = "27df445fc20f048c1c31e429f6c29075119fe454"
-  version = "v0.1.1"
+  revision = "d66cbdd27f73bb1ffa7479a3527f55dec070baa0"
+  version = "v0.1.4"
 
 [[projects]]
-  digest = "1:1d3ad0f6a57c08e2168089a64c34313930571fcbe5359d71c608a97ce504f7ca"
+  digest = "1:5736b824700c1e7a7374bc691b546c1a71463cb3ae654475d2c4ea3e760f1fd1"
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
+    "aws/credentials/stscreds",
+    "aws/csm",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/context",
+    "internal/ini",
+    "internal/sdkio",
+    "internal/sdkmath",
+    "internal/sdkrand",
+    "internal/sdkuri",
+    "internal/shareddefaults",
+    "internal/strings",
+    "internal/sync/singleflight",
+    "private/protocol",
+    "private/protocol/json/jsonutil",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/sts",
+    "service/sts/stsiface",
+  ]
+  pruneopts = "UT"
+  revision = "58185ee8739458b8e055d931218349b2b6b974c2"
+  version = "v1.29.30"
+
+[[projects]]
+  digest = "1:e7d26760c4e7d67a443b082153c4b473ad0b8f7388302a2f788b1360f751abb8"
+  name = "github.com/census-instrumentation/opencensus-proto"
+  packages = [
+    "gen-go/agent/common/v1",
+    "gen-go/metrics/v1",
+    "gen-go/resource/v1",
+  ]
+  pruneopts = "UT"
+  revision = "d89fa54de508111353cb0b06403c00569be780d8"
+  version = "v0.2.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:b7cb6054d3dff43b38ad2e92492f220f57ae6087ee797dca298139776749ace8"
+  name = "github.com/golang/groupcache"
+  packages = ["lru"]
+  pruneopts = "UT"
+  revision = "8c9f03a8e57eb486e42badaed3fb287da51807ba"
+
+[[projects]]
+  digest = "1:56b3126ac15d478fa10928937c085b50be29cb29c32f069dcceeceac9423a327"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -58,16 +117,30 @@
     "ptypes/wrappers",
   ]
   pruneopts = "UT"
-  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
-  version = "v1.3.1"
+  revision = "84668698ea25b64748563aa20726db66a6b8d299"
+  version = "v1.3.5"
+
+[[projects]]
+  digest = "1:0aeda02073125667ac6c9df50c7921cb22c08a4accdc54589c697a7e76be65c2"
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/internal/diff",
+    "cmp/internal/flags",
+    "cmp/internal/function",
+    "cmp/internal/value",
+  ]
+  pruneopts = "UT"
+  revision = "5a6f75716e1203a923a78c9efb94089d857df0f6"
+  version = "v0.4.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:dcb1edb161b1b1cac9aedf2a17b9b2c7829e242624968875a3c1b97dd9f4ef00"
+  digest = "1:5e64b431df7defcd21c77487d88d727600f343490e668312853bfbb63b3dc41f"
   name = "github.com/google/pprof"
   packages = ["profile"]
   pruneopts = "UT"
-  revision = "54271f7e092ff31b10b7626fee166cbc6304e350"
+  revision = "1ebb73c60ed3b70bd749d4f798d7ae427263e2c5"
 
 [[projects]]
   digest = "1:582b704bebaa06b48c29b0cec224a6058a09c86883aaddabde889cd1a5f73e1b"
@@ -86,12 +159,19 @@
   version = "v2.0.5"
 
 [[projects]]
-  digest = "1:cbec35fe4d5a4fba369a656a8cd65e244ea2c743007d8f6c1ccb132acf9d1296"
+  digest = "1:25ebe6496abb289ef977c081b2d49f56dd97c32db4ca083d37f95923909ced02"
   name = "github.com/gorilla/mux"
   packages = ["."]
   pruneopts = "UT"
-  revision = "00bdffe0f3c77e27d2cf6f5c70232a2d3e4d9c15"
-  version = "v1.7.3"
+  revision = "75dcda0896e109a2a22c9315bca3bb21b87b2ba5"
+  version = "v1.7.4"
+
+[[projects]]
+  digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c2b33e84"
 
 [[projects]]
   digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
@@ -110,25 +190,29 @@
   version = "v0.8.1"
 
 [[projects]]
-  digest = "1:04457f9f6f3ffc5fea48e71d62f2ca256637dee0a04d710288e27e05c8b41976"
+  digest = "1:0599141a8403114d34f1e546604ad6c5361b70dfa80e80c635f438cdbf71b43a"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
-  version = "v1.4.2"
+  revision = "d417be0fe654de640a82370515129985b407c7e3"
+  version = "v1.5.0"
 
 [[projects]]
-  digest = "1:a5154dfd6b37bef5a3eab759e13296348e639dc8c7604f538368167782b08ccd"
+  digest = "1:d0d90c1767b8e8a44b9bb1c5982a71e3edfd566adf49120d34f90d78a98ee362"
   name = "go.opencensus.io"
   packages = [
     ".",
-    "exporter/jaeger",
-    "exporter/jaeger/internal/gen-go/jaeger",
+    "examples/exporter",
     "internal",
     "internal/tagencoding",
+    "metric/metricdata",
+    "metric/metricexport",
+    "metric/metricproducer",
     "plugin/ocgrpc",
     "plugin/ochttp",
     "plugin/ochttp/propagation/b3",
+    "resource",
+    "resource/resourcekeys",
     "stats",
     "stats/internal",
     "stats/view",
@@ -139,12 +223,12 @@
     "trace/tracestate",
   ]
   pruneopts = "UT"
-  revision = "b11f239c032624b045c4c2bfd3d1287b4012ce89"
-  version = "v0.16.0"
+  revision = "d835ff86be02193d324330acdb7d65546b05f814"
+  version = "v0.22.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:2f357867bf425774d35beca5be718402a4488b8b23b1563ce8c5bb91d09285a7"
+  digest = "1:a103d9c7d2edf2294696edf9d65c5a587e228a4409fee53e38c9b087fb147508"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -157,11 +241,11 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "da137c7871d730100384dbcf36e6f8fa493aef5b"
+  revision = "118fecf932d8fea033f3b7aca66fba22cfdd517d"
 
 [[projects]]
   branch = "master"
-  digest = "1:31e33f76456ccf54819ab4a646cf01271d1a99d7712ab84bf1a9e7b61cd2031b"
+  digest = "1:79edde3241bb55de9f4143d5083bfcff722e550c3cb8db94084eab50d0e440b5"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -171,23 +255,23 @@
     "jwt",
   ]
   pruneopts = "UT"
-  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
+  revision = "bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"
 
 [[projects]]
   branch = "master"
-  digest = "1:382bb5a7fb4034db3b6a2d19e5a4a6bcf52f4750530603c01ca18a172fa3089b"
+  digest = "1:4692f916cb72b2c295f04841036d85a3f13e96d1cc9e8e4c2c30edebac518053"
   name = "golang.org/x/sync"
   packages = ["semaphore"]
   pruneopts = "UT"
-  revision = "112230192c580c3556b8cee6403af37a4fc5f28c"
+  revision = "43a5402ce75a95522677f77c619865d66b8c57ab"
 
 [[projects]]
   branch = "master"
-  digest = "1:730ba27cd66db3b98ec8f51a6f20d45ec277d490cca36b1f54e31d3fcaf4840e"
+  digest = "1:4a1984ad1b48641ef91f73689012cdba27ed1eb94aeee1aa0b421e2208530a17"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "04f50cda93cbb67f2afa353c52f342100e80e625"
+  revision = "328b4cd54aaeaba222936f16d417999f7e521f7b"
 
 [[projects]]
   digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
@@ -215,8 +299,7 @@
   version = "v0.3.2"
 
 [[projects]]
-  branch = "master"
-  digest = "1:bc06b12d8436550fccc0212037e9281a7e4d53db25c2349eb3cc6c3457e0406b"
+  digest = "1:0ad0d6252a07813a9a12fee0ffca6df06fef08c5a03bbcaa0271dc59b88f97e5"
   name = "google.golang.org/api"
   packages = [
     "googleapi/transport",
@@ -225,15 +308,17 @@
     "option",
     "support/bundler",
     "transport",
+    "transport/cert",
     "transport/grpc",
     "transport/http",
     "transport/http/internal/propagation",
   ]
   pruneopts = "UT"
-  revision = "aae1d1b89c27132abe4fa22731a2a61e7089079c"
+  revision = "c24765c18bb761c90df819dcdfdd62f9a7f6fa22"
+  version = "v0.20.0"
 
 [[projects]]
-  digest = "1:2c26b1c47556c0e5e73cdb05d8361c463737eee4baac35d38b40c728c3074a94"
+  digest = "1:c98e9b93e6d178378530b920fe6e1aa4b3dd4972872111e83827746aa1f33ded"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -250,12 +335,12 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "b2f4a3cf3c67576a2ee09e1fe62656a5086ce880"
-  version = "v1.6.1"
+  revision = "971852bfffca25b069c31162ae8f247a3dba083b"
+  version = "v1.6.5"
 
 [[projects]]
   branch = "master"
-  digest = "1:cb0f37e3cdf50a27abbf33a48797b30786239d4fd69dbfbbc63cfa19d400d3ce"
+  digest = "1:ebd714d33041c5b3b18a05aa83cf836e95e092d7d0b58d76124f151687cb9b58"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api",
@@ -264,21 +349,25 @@
     "googleapis/api/label",
     "googleapis/api/metric",
     "googleapis/api/monitoredres",
+    "googleapis/container/v1",
     "googleapis/devtools/cloudprofiler/v2",
     "googleapis/devtools/cloudtrace/v2",
     "googleapis/monitoring/v3",
     "googleapis/rpc/errdetails",
     "googleapis/rpc/status",
+    "googleapis/type/calendarperiod",
     "protobuf/field_mask",
   ]
   pruneopts = "UT"
-  revision = "3bdd9d9f5532d75d09efb230bd767d265245cfe5"
+  revision = "3f67cca344726c97b3e8e967f95b8041980129bd"
 
 [[projects]]
-  digest = "1:94dd3fb42315b97533bb74fe15498905734bc3a3c6e692dc7839fec749d44d26"
+  digest = "1:c5cb55dc71404526bd9002c7b0f63c8910f51b19751248e15dcba2c46210662a"
   name = "google.golang.org/grpc"
   packages = [
     ".",
+    "attributes",
+    "backoff",
     "balancer",
     "balancer/base",
     "balancer/grpclb",
@@ -305,10 +394,15 @@
     "internal/backoff",
     "internal/balancerload",
     "internal/binarylog",
+    "internal/buffer",
     "internal/channelz",
     "internal/envconfig",
+    "internal/grpclog",
     "internal/grpcrand",
     "internal/grpcsync",
+    "internal/grpcutil",
+    "internal/resolver/dns",
+    "internal/resolver/passthrough",
     "internal/syscall",
     "internal/transport",
     "keepalive",
@@ -316,16 +410,14 @@
     "naming",
     "peer",
     "resolver",
-    "resolver/dns",
-    "resolver/passthrough",
     "serviceconfig",
     "stats",
     "status",
     "tap",
   ]
   pruneopts = "UT"
-  revision = "1d89a3c832915b2314551c1d2a506874d62e53f7"
-  version = "v1.22.0"
+  revision = "142182889d38b76209f1d9f1d8e91d7608aff542"
+  version = "v1.28.0"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -333,6 +425,7 @@
   input-imports = [
     "cloud.google.com/go/profiler",
     "contrib.go.opencensus.io/exporter/stackdriver",
+    "contrib.go.opencensus.io/exporter/stackdriver/monitoredresource",
     "github.com/GoogleCloudPlatform/microservices-demo/src/frontend/genproto",
     "github.com/GoogleCloudPlatform/microservices-demo/src/frontend/money",
     "github.com/golang/protobuf/proto",
@@ -340,7 +433,7 @@
     "github.com/gorilla/mux",
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
-    "go.opencensus.io/exporter/jaeger",
+    "go.opencensus.io/examples/exporter",
     "go.opencensus.io/plugin/ocgrpc",
     "go.opencensus.io/plugin/ochttp",
     "go.opencensus.io/plugin/ochttp/propagation/b3",

--- a/src/frontend/Gopkg.toml
+++ b/src/frontend/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "contrib.go.opencensus.io/exporter/stackdriver"
-  version = "0.5.0"
+  version = "0.13.0"
 
 [[constraint]]
   name = "github.com/golang/protobuf"
@@ -55,7 +55,7 @@
 
 [[constraint]]
   name = "go.opencensus.io"
-  version = "0.16.0"
+  version = "0.22.3"
 
 [[constraint]]
   branch = "master"

--- a/src/productcatalogservice/Gopkg.lock
+++ b/src/productcatalogservice/Gopkg.lock
@@ -17,26 +17,28 @@
   version = "v0.40.0"
 
 [[projects]]
-  digest = "1:fc98782bece7d3f842d991c4ce3f44dd893f9dc521a1d5fd895be9ad271e579f"
+  digest = "1:254b3303d840245570de7ebf8c0081b1cda0b36e166a1c1fd29ffc45406b2bc8"
   name = "contrib.go.opencensus.io/exporter/stackdriver"
   packages = [
     ".",
     "monitoredresource",
+    "monitoredresource/aws",
+    "monitoredresource/gcp",
   ]
   pruneopts = "UT"
-  revision = "ab68e2a40809b13b9e06ac2135d2549a6a984d62"
-  version = "v0.13.0"
+  revision = "366afe7b1d81a1faaa8c58e725aaeb77344b343e"
+  version = "v0.13.2"
 
 [[projects]]
   digest = "1:9370265bab17bdc207051ccedc34535484a12622a329839e580059c79236c1e3"
   name = "github.com/GoogleCloudPlatform/microservices-demo"
   packages = ["src/productcatalogservice/genproto"]
   pruneopts = "UT"
-  revision = "27df445fc20f048c1c31e429f6c29075119fe454"
-  version = "v0.1.1"
+  revision = "c2095a7d4b8abd538251b705325d6a493a23e009"
+  version = "v0.2.0"
 
 [[projects]]
-  digest = "1:ab38300d0d784fd866aa476ba641be5910a5e98dcf5662cd7a9153beeae58db0"
+  digest = "1:ce16a46e99c4efe6a64b0048c68b305a85fe4c6a59f74eee2f60caaf0f48b0b3"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -76,8 +78,8 @@
     "service/sts/stsiface",
   ]
   pruneopts = "UT"
-  revision = "b10ba9d2bd8ef2b0602dc19c779b558ed96171d9"
-  version = "v1.29.28"
+  revision = "46dac1fc0ad8a1b3a2079f8c2af343b5044b9938"
+  version = "v1.33.7"
 
 [[projects]]
   digest = "1:e7d26760c4e7d67a443b082153c4b473ad0b8f7388302a2f788b1360f751abb8"
@@ -100,7 +102,7 @@
   revision = "8c9f03a8e57eb486e42badaed3fb287da51807ba"
 
 [[projects]]
-  digest = "1:fd0a0705475581c7eb965259d417706cb49f42bde408502c3b53f139b7253d67"
+  digest = "1:9d2705f9d2e7da697c24b2ab104567b155107b2aad26ca615973c0a8f02f757a"
   name = "github.com/golang/protobuf"
   packages = [
     "jsonpb",
@@ -115,8 +117,8 @@
     "ptypes/wrappers",
   ]
   pruneopts = "UT"
-  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
-  version = "v1.3.1"
+  revision = "d04d7b157bb510b1e0c10132224b616ac0e26b17"
+  version = "v1.4.2"
 
 [[projects]]
   digest = "1:2e3c336fc7fde5c984d2841455a658a6d626450b1754a854b3b32e7a8f49a07a"
@@ -133,11 +135,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:dcb1edb161b1b1cac9aedf2a17b9b2c7829e242624968875a3c1b97dd9f4ef00"
+  digest = "1:7f49181edc3aa34ec3145a0050ce4af901a9c3238774f362784ce39227bc1f3a"
   name = "github.com/google/pprof"
   packages = ["profile"]
   pruneopts = "UT"
-  revision = "54271f7e092ff31b10b7626fee166cbc6304e350"
+  revision = "1a94d8640e99342fa76ae6296aaa921d08ac451f"
 
 [[projects]]
   digest = "1:766102087520f9d54f2acc72bd6637045900ac735b4a419b128d216f0c5c4876"
@@ -155,23 +157,23 @@
   revision = "c2b33e84"
 
 [[projects]]
-  digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
+  digest = "1:09cb61dc19af93deae01587e2fdb1c081e0bf48f1a5ad5fa24f48750dc57dce8"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
   pruneopts = "UT"
-  revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
-  version = "v1.0.2"
+  revision = "edb144dfd453055e1e49a3d8b410a660b5a87613"
+  version = "v1.0.3"
 
 [[projects]]
-  digest = "1:04457f9f6f3ffc5fea48e71d62f2ca256637dee0a04d710288e27e05c8b41976"
+  digest = "1:05eebdd5727fea23083fce0d98d307d70c86baed644178e81608aaa9f09ea469"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
-  version = "v1.4.2"
+  revision = "60c74ad9be0d874af0ab0daef6ab07c5c5911f0d"
+  version = "v1.6.0"
 
 [[projects]]
-  digest = "1:d0d90c1767b8e8a44b9bb1c5982a71e3edfd566adf49120d34f90d78a98ee362"
+  digest = "1:7363ffcd2b7c045e9cb767df5171e3b3457f80645446c91633cb17a23a0e1d3c"
   name = "go.opencensus.io"
   packages = [
     ".",
@@ -196,12 +198,12 @@
     "trace/tracestate",
   ]
   pruneopts = "UT"
-  revision = "d835ff86be02193d324330acdb7d65546b05f814"
-  version = "v0.22.3"
+  revision = "5fa069b99bc903d713add0295c7e0a55d34ae573"
+  version = "v0.22.4"
 
 [[projects]]
   branch = "master"
-  digest = "1:2f357867bf425774d35beca5be718402a4488b8b23b1563ce8c5bb91d09285a7"
+  digest = "1:8922e4fce64437e4c0a4a8709f3625cf4c24858439e483b382d14c8bfcf36d97"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -214,11 +216,11 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "da137c7871d730100384dbcf36e6f8fa493aef5b"
+  revision = "ab34263943818b32f575efc978a3d24e80b04bd7"
 
 [[projects]]
   branch = "master"
-  digest = "1:31e33f76456ccf54819ab4a646cf01271d1a99d7712ab84bf1a9e7b61cd2031b"
+  digest = "1:79edde3241bb55de9f4143d5083bfcff722e550c3cb8db94084eab50d0e440b5"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -228,26 +230,29 @@
     "jwt",
   ]
   pruneopts = "UT"
-  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
+  revision = "bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"
 
 [[projects]]
   branch = "master"
-  digest = "1:382bb5a7fb4034db3b6a2d19e5a4a6bcf52f4750530603c01ca18a172fa3089b"
+  digest = "1:4692f916cb72b2c295f04841036d85a3f13e96d1cc9e8e4c2c30edebac518053"
   name = "golang.org/x/sync"
   packages = ["semaphore"]
   pruneopts = "UT"
-  revision = "112230192c580c3556b8cee6403af37a4fc5f28c"
+  revision = "6e8e738ad208923de99951fe0b48239bfd864f28"
 
 [[projects]]
   branch = "master"
-  digest = "1:730ba27cd66db3b98ec8f51a6f20d45ec277d490cca36b1f54e31d3fcaf4840e"
+  digest = "1:de18db9b6b884884bbb43eafaee3c72a06c8d4ac69d87411c52b5801a5e814f7"
   name = "golang.org/x/sys"
-  packages = ["unix"]
+  packages = [
+    "internal/unsafeheader",
+    "unix",
+  ]
   pruneopts = "UT"
-  revision = "04f50cda93cbb67f2afa353c52f342100e80e625"
+  revision = "ddb9806d33aed8dbaac1cd6f1cba58952e87f933"
 
 [[projects]]
-  digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
+  digest = "1:fa940333c48808b0d86ef21f412ffcfd0e5084a82f13905c028a404803b1908f"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -268,12 +273,11 @@
     "unicode/rangetable",
   ]
   pruneopts = "UT"
-  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
-  version = "v0.3.2"
+  revision = "23ae387dee1f90d29a23c0e87ee0b46038fbed0e"
+  version = "v0.3.3"
 
 [[projects]]
-  branch = "master"
-  digest = "1:bc06b12d8436550fccc0212037e9281a7e4d53db25c2349eb3cc6c3457e0406b"
+  digest = "1:9bdce94cdfc3cefbf5808d7d92a8866b5e68f0a9e0f83991e0a0c2b72f28b5da"
   name = "google.golang.org/api"
   packages = [
     "googleapi/transport",
@@ -282,15 +286,17 @@
     "option",
     "support/bundler",
     "transport",
+    "transport/cert",
     "transport/grpc",
     "transport/http",
     "transport/http/internal/propagation",
   ]
   pruneopts = "UT"
-  revision = "aae1d1b89c27132abe4fa22731a2a61e7089079c"
+  revision = "cb1f45ca288bfafb52ab824361c939d908e525ad"
+  version = "v0.29.0"
 
 [[projects]]
-  digest = "1:2c26b1c47556c0e5e73cdb05d8361c463737eee4baac35d38b40c728c3074a94"
+  digest = "1:9a3c550c85a5a62ccc4cadd8525497b99554094a1adecc560c97bebc231ca81b"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -307,12 +313,12 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "b2f4a3cf3c67576a2ee09e1fe62656a5086ce880"
-  version = "v1.6.1"
+  revision = "553959209a20f3be281c16dd5be5c740a893978f"
+  version = "v1.6.6"
 
 [[projects]]
   branch = "master"
-  digest = "1:06a1b664fc7b1273b1b92d62da7660c0ece22be782a6004d3d42e5116b67ee25"
+  digest = "1:7f6df40f4bbd03f7cd7a33ef73c084bbce424d3b4ac38efe18434ba1c5020d9f"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api",
@@ -327,20 +333,24 @@
     "googleapis/monitoring/v3",
     "googleapis/rpc/errdetails",
     "googleapis/rpc/status",
+    "googleapis/type/calendarperiod",
     "protobuf/field_mask",
   ]
   pruneopts = "UT"
-  revision = "3bdd9d9f5532d75d09efb230bd767d265245cfe5"
+  revision = "1244ee217b7ef50797c0e4206d3b4b641901d48a"
 
 [[projects]]
-  digest = "1:f379776e36e55e5b5cbf7187ea58280812785071de53046230006e47894650b6"
+  digest = "1:fb8882a84cbfd9f1446487010a419eff7b36187df62a465d9be49877c13ec348"
   name = "google.golang.org/grpc"
   packages = [
     ".",
+    "attributes",
+    "backoff",
     "balancer",
     "balancer/base",
     "balancer/grpclb",
     "balancer/grpclb/grpc_lb_v1",
+    "balancer/grpclb/state",
     "balancer/roundrobin",
     "binarylog/grpc_binarylog_v1",
     "codes",
@@ -364,27 +374,76 @@
     "internal/backoff",
     "internal/balancerload",
     "internal/binarylog",
+    "internal/buffer",
     "internal/channelz",
     "internal/envconfig",
+    "internal/grpclog",
     "internal/grpcrand",
     "internal/grpcsync",
+    "internal/grpcutil",
+    "internal/resolver/dns",
+    "internal/resolver/passthrough",
+    "internal/serviceconfig",
+    "internal/status",
     "internal/syscall",
     "internal/transport",
     "keepalive",
     "metadata",
-    "naming",
     "peer",
     "resolver",
-    "resolver/dns",
-    "resolver/passthrough",
     "serviceconfig",
     "stats",
     "status",
     "tap",
   ]
   pruneopts = "UT"
-  revision = "1d89a3c832915b2314551c1d2a506874d62e53f7"
-  version = "v1.22.0"
+  revision = "1f47ba4663831f2a9c28a62a7de3ff8bc45078f0"
+  version = "v1.30.0"
+
+[[projects]]
+  digest = "1:4a0202ad403c5a9c79ae7d6673aabb8e4ae2163654167229a49cc0155687effa"
+  name = "google.golang.org/protobuf"
+  packages = [
+    "encoding/protojson",
+    "encoding/prototext",
+    "encoding/protowire",
+    "internal/descfmt",
+    "internal/descopts",
+    "internal/detrand",
+    "internal/encoding/defval",
+    "internal/encoding/json",
+    "internal/encoding/messageset",
+    "internal/encoding/tag",
+    "internal/encoding/text",
+    "internal/errors",
+    "internal/fieldsort",
+    "internal/filedesc",
+    "internal/filetype",
+    "internal/flags",
+    "internal/genid",
+    "internal/impl",
+    "internal/mapsort",
+    "internal/pragma",
+    "internal/set",
+    "internal/strs",
+    "internal/version",
+    "proto",
+    "reflect/protoreflect",
+    "reflect/protoregistry",
+    "runtime/protoiface",
+    "runtime/protoimpl",
+    "types/descriptorpb",
+    "types/known/anypb",
+    "types/known/durationpb",
+    "types/known/emptypb",
+    "types/known/fieldmaskpb",
+    "types/known/structpb",
+    "types/known/timestamppb",
+    "types/known/wrapperspb",
+  ]
+  pruneopts = "UT"
+  revision = "3f7a61f89bb6813f89d981d1870ed68da0b3c3f1"
+  version = "v1.25.0"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -392,7 +451,6 @@
   input-imports = [
     "cloud.google.com/go/profiler",
     "contrib.go.opencensus.io/exporter/stackdriver",
-    "contrib.go.opencensus.io/exporter/stackdriver/monitoredresource",
     "github.com/GoogleCloudPlatform/microservices-demo/src/productcatalogservice/genproto",
     "github.com/golang/protobuf/jsonpb",
     "github.com/golang/protobuf/proto",

--- a/src/productcatalogservice/Gopkg.lock
+++ b/src/productcatalogservice/Gopkg.lock
@@ -2,10 +2,11 @@
 
 
 [[projects]]
-  digest = "1:cd61c288406d5d80572967f908a23a1f0ffbf460e926269672e955f4a88b79bc"
+  digest = "1:9097d59af752a760c8967f4b4fca96bb99780659f8e65852869315f64afbf698"
   name = "cloud.google.com/go"
   packages = [
     "compute/metadata",
+    "container/apiv1",
     "internal/version",
     "monitoring/apiv3",
     "profiler",
@@ -16,21 +17,15 @@
   version = "v0.40.0"
 
 [[projects]]
-  digest = "1:4b96dcd8534bc6450a922bd16a76360ba3381f0d1daf40abbaec91c053fbfeb5"
+  digest = "1:fc98782bece7d3f842d991c4ce3f44dd893f9dc521a1d5fd895be9ad271e579f"
   name = "contrib.go.opencensus.io/exporter/stackdriver"
-  packages = ["."]
+  packages = [
+    ".",
+    "monitoredresource",
+  ]
   pruneopts = "UT"
-  revision = "37aa2801fbf0205003e15636096ebf0373510288"
-  version = "v0.5.0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:a85b0dc359de4812d383ee6670f0dae595cfcb8b13ff6b872bdb013a18c37b07"
-  name = "git.apache.org/thrift.git"
-  packages = ["lib/go/thrift"]
-  pruneopts = "UT"
-  revision = "286eee16b147a302ddc7b10740c5e5401ebbec17"
-  source = "github.com/apache/thrift"
+  revision = "ab68e2a40809b13b9e06ac2135d2549a6a984d62"
+  version = "v0.13.0"
 
 [[projects]]
   digest = "1:9370265bab17bdc207051ccedc34535484a12622a329839e580059c79236c1e3"
@@ -39,6 +34,70 @@
   pruneopts = "UT"
   revision = "27df445fc20f048c1c31e429f6c29075119fe454"
   version = "v0.1.1"
+
+[[projects]]
+  digest = "1:ab38300d0d784fd866aa476ba641be5910a5e98dcf5662cd7a9153beeae58db0"
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
+    "aws/credentials/stscreds",
+    "aws/csm",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/context",
+    "internal/ini",
+    "internal/sdkio",
+    "internal/sdkmath",
+    "internal/sdkrand",
+    "internal/sdkuri",
+    "internal/shareddefaults",
+    "internal/strings",
+    "internal/sync/singleflight",
+    "private/protocol",
+    "private/protocol/json/jsonutil",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/sts",
+    "service/sts/stsiface",
+  ]
+  pruneopts = "UT"
+  revision = "b10ba9d2bd8ef2b0602dc19c779b558ed96171d9"
+  version = "v1.29.28"
+
+[[projects]]
+  digest = "1:e7d26760c4e7d67a443b082153c4b473ad0b8f7388302a2f788b1360f751abb8"
+  name = "github.com/census-instrumentation/opencensus-proto"
+  packages = [
+    "gen-go/agent/common/v1",
+    "gen-go/metrics/v1",
+    "gen-go/resource/v1",
+  ]
+  pruneopts = "UT"
+  revision = "d89fa54de508111353cb0b06403c00569be780d8"
+  version = "v0.2.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:b7cb6054d3dff43b38ad2e92492f220f57ae6087ee797dca298139776749ace8"
+  name = "github.com/golang/groupcache"
+  packages = ["lru"]
+  pruneopts = "UT"
+  revision = "8c9f03a8e57eb486e42badaed3fb287da51807ba"
 
 [[projects]]
   digest = "1:fd0a0705475581c7eb965259d417706cb49f42bde408502c3b53f139b7253d67"
@@ -89,6 +148,13 @@
   version = "v2.0.5"
 
 [[projects]]
+  digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c2b33e84"
+
+[[projects]]
   digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
@@ -105,17 +171,21 @@
   version = "v1.4.2"
 
 [[projects]]
-  digest = "1:a5154dfd6b37bef5a3eab759e13296348e639dc8c7604f538368167782b08ccd"
+  digest = "1:d0d90c1767b8e8a44b9bb1c5982a71e3edfd566adf49120d34f90d78a98ee362"
   name = "go.opencensus.io"
   packages = [
     ".",
-    "exporter/jaeger",
-    "exporter/jaeger/internal/gen-go/jaeger",
+    "examples/exporter",
     "internal",
     "internal/tagencoding",
+    "metric/metricdata",
+    "metric/metricexport",
+    "metric/metricproducer",
     "plugin/ocgrpc",
     "plugin/ochttp",
     "plugin/ochttp/propagation/b3",
+    "resource",
+    "resource/resourcekeys",
     "stats",
     "stats/internal",
     "stats/view",
@@ -126,8 +196,8 @@
     "trace/tracestate",
   ]
   pruneopts = "UT"
-  revision = "b11f239c032624b045c4c2bfd3d1287b4012ce89"
-  version = "v0.16.0"
+  revision = "d835ff86be02193d324330acdb7d65546b05f814"
+  version = "v0.22.3"
 
 [[projects]]
   branch = "master"
@@ -242,7 +312,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:cb0f37e3cdf50a27abbf33a48797b30786239d4fd69dbfbbc63cfa19d400d3ce"
+  digest = "1:06a1b664fc7b1273b1b92d62da7660c0ece22be782a6004d3d42e5116b67ee25"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api",
@@ -251,6 +321,7 @@
     "googleapis/api/label",
     "googleapis/api/metric",
     "googleapis/api/monitoredres",
+    "googleapis/container/v1",
     "googleapis/devtools/cloudprofiler/v2",
     "googleapis/devtools/cloudtrace/v2",
     "googleapis/monitoring/v3",
@@ -321,12 +392,13 @@
   input-imports = [
     "cloud.google.com/go/profiler",
     "contrib.go.opencensus.io/exporter/stackdriver",
+    "contrib.go.opencensus.io/exporter/stackdriver/monitoredresource",
     "github.com/GoogleCloudPlatform/microservices-demo/src/productcatalogservice/genproto",
     "github.com/golang/protobuf/jsonpb",
     "github.com/golang/protobuf/proto",
     "github.com/google/go-cmp/cmp",
     "github.com/sirupsen/logrus",
-    "go.opencensus.io/exporter/jaeger",
+    "go.opencensus.io/examples/exporter",
     "go.opencensus.io/plugin/ocgrpc",
     "go.opencensus.io/stats/view",
     "go.opencensus.io/trace",

--- a/src/productcatalogservice/Gopkg.toml
+++ b/src/productcatalogservice/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "contrib.go.opencensus.io/exporter/stackdriver"
-  version = "0.5.0"
+  version = "0.13.0"
 
 [[constraint]]
   name = "github.com/golang/protobuf"
@@ -47,7 +47,7 @@
 
 [[constraint]]
   name = "go.opencensus.io"
-  version = "0.16.0"
+  version = "0.22.3"
 
 [[constraint]]
   branch = "master"

--- a/src/productcatalogservice/server.go
+++ b/src/productcatalogservice/server.go
@@ -33,11 +33,9 @@ import (
 
 	"cloud.google.com/go/profiler"
     "contrib.go.opencensus.io/exporter/stackdriver"
-    "contrib.go.opencensus.io/exporter/stackdriver/monitoredresource"
     "go.opencensus.io/examples/exporter"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/sirupsen/logrus"
-	// "go.opencensus.io/exporter/jaeger"
 	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
@@ -150,31 +148,10 @@ func run(port string) string {
 	return l.Addr().String()
 }
 
-// func initJaegerTracing() {
-// 	svcAddr := os.Getenv("JAEGER_SERVICE_ADDR")
-// 	if svcAddr == "" {
-// 		log.Info("jaeger initialization disabled.")
-// 		return
-// 	}
-// 	// Register the Jaeger exporter to be able to retrieve
-// 	// the collected spans.
-// 	exporter, err := jaeger.NewExporter(jaeger.Options{
-// 		Endpoint: fmt.Sprintf("http://%s", svcAddr),
-// 		Process: jaeger.Process{
-// 			ServiceName: "productcatalogservice",
-// 		},
-// 	})
-// 	if err != nil {
-// 		log.Fatal(err)
-// 	}
-// 	trace.RegisterExporter(exporter)
-// 	log.Info("jaeger initialization completed.")
-// }
 
 func initStats(exporter *stackdriver.Exporter) {
     view.SetReportingPeriod(60 * time.Second)
     exporter.StartMetricsExporter()
-    // view.RegisterExporter(exporter) X
 	if err := view.Register(ocgrpc.DefaultServerViews...); err != nil {
 		log.Info("Error registering default server views")
 	} else {
@@ -187,15 +164,11 @@ func initStackdriverTracing() {
 	// since they are not sharing packages.
 	for i := 1; i <= 3; i++ {
         view.RegisterExporter(&exporter.PrintExporter{})
-		exporter, err := stackdriver.NewExporter(stackdriver.Options{
-            ProjectID:         "test-exemplar-project", // Google Cloud Console project ID for stackdriver.
-            MonitoredResource: monitoredresource.Autodetect(),
-        })
-        trace.RegisterExporter(exporter)
+		exporter, err := stackdriver.NewExporter(stackdriver.Options{})
 		if err != nil {
 			log.Warnf("failed to initialize Stackdriver exporter: %+v", err)
 		} else {
-			// trace.RegisterExporter(exporter)
+			trace.RegisterExporter(exporter)
 			trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 			log.Info("registered Stackdriver tracing")
 
@@ -211,7 +184,6 @@ func initStackdriverTracing() {
 }
 
 func initTracing() {
-	// initJaegerTracing()
 	initStackdriverTracing()
 }
 

--- a/src/productcatalogservice/server.go
+++ b/src/productcatalogservice/server.go
@@ -28,7 +28,7 @@ import (
 	// "syscall"
     "time"
     "math/rand"
-    // "strconv"
+    "strconv"
 
 	pb "github.com/GoogleCloudPlatform/microservices-demo/src/productcatalogservice/genproto"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -76,6 +76,7 @@ func init() {
 }
 
 func main() {
+    
 	if os.Getenv("DISABLE_TRACING") == "" {
 		log.Info("Tracing enabled.")
 		go initTracing()
@@ -111,6 +112,8 @@ func main() {
 	} else {
 		extraLatency = time.Duration(0)
 	}
+
+    rand.Seed(time.Now().UnixNano())
 
 	if os.Getenv("PORT") != "" {
 		port = os.Getenv("PORT")
@@ -242,12 +245,10 @@ func (p *productCatalog) Watch(req *healthpb.HealthCheckRequest, ws healthpb.Hea
 func (p *productCatalog) ListProducts(context.Context, *pb.Empty) (*pb.ListProductsResponse, error) {
     time.Sleep(extraLatency)
 	if s := os.Getenv("LATENCY_SPIKE"); s != "" {
-		// v, err := strconv.Atoi(s)
-		// if err != nil {
-		// 	log.Fatalf("faigit chaled to parse EXTRA_LATENCY (%s) as int: %+v", v, err)
-		// }
-        // rand.Seed(time.Now().UnixNano())
-        n := 3 + rand.Intn(25) // n will be between 0 and v
+        now := time.Now()
+        secs := now.Unix()
+        i, _ := strconv.Atoi(s)
+        n := rand.Float64() * rand.Float64() * float64(i) * float64(int(secs / 15) % 5) + 1 // n will be between 0 and v
         time.Sleep(time.Duration(n)*time.Second)           
 		log.Infof("extra latency enabled (duration: %v)", extraLatency)
 	} else {
@@ -258,7 +259,10 @@ func (p *productCatalog) ListProducts(context.Context, *pb.Empty) (*pb.ListProdu
 
 func (p *productCatalog) GetProduct(ctx context.Context, req *pb.GetProductRequest) (*pb.Product, error) {
 	if s := os.Getenv("LATENCY_SPIKE"); s != "" {
-        n := 3 + rand.Intn(25) // n will be between 0 and v
+        i, _ := strconv.Atoi(s)
+        now := time.Now()
+        secs := now.Unix()        
+        n := rand.Float64() * rand.Float64() * float64(i) * float64(int(secs / 15) % 5) + 1 // n will be between 0 and v
         time.Sleep(time.Duration(n)*time.Second)
 		log.Infof("extra latency enabled (duration: %v)", extraLatency)
 	} else {

--- a/src/productcatalogservice/server.go
+++ b/src/productcatalogservice/server.go
@@ -28,7 +28,7 @@ import (
 	// "syscall"
     "time"
     "math/rand"
-    "strconv"
+    // "strconv"
 
 	pb "github.com/GoogleCloudPlatform/microservices-demo/src/productcatalogservice/genproto"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
@@ -249,12 +249,12 @@ func (p *productCatalog) ListProducts(context.Context, *pb.Empty) (*pb.ListProdu
 
 func (p *productCatalog) GetProduct(ctx context.Context, req *pb.GetProductRequest) (*pb.Product, error) {
 	if s := os.Getenv("LATENCY_SPIKE"); s != "" {
-		v, err := strconv.Atoi(s)
-		if err != nil {
-			log.Fatalf("faigit chaled to parse EXTRA_LATENCY (%s) as int: %+v", v, err)
-		}
-        rand.Seed(time.Now().UnixNano())
-        n := 3 * (1 + rand.Intn(v)) // n will be between 0 and v
+		// v, err := strconv.Atoi(s)
+		// if err != nil {
+		// 	log.Fatalf("faigit chaled to parse EXTRA_LATENCY (%s) as int: %+v", v, err)
+		// }
+        // rand.Seed(time.Now().UnixNano())
+        n := 3 * (1 + rand.Intn(10)) // n will be between 0 and v
         time.Sleep(time.Duration(n)*time.Second)           
 		log.Infof("extra latency enabled (duration: %v)", extraLatency)
 	} else {

--- a/src/productcatalogservice/server.go
+++ b/src/productcatalogservice/server.go
@@ -241,25 +241,29 @@ func (p *productCatalog) Watch(req *healthpb.HealthCheckRequest, ws healthpb.Hea
 
 func (p *productCatalog) ListProducts(context.Context, *pb.Empty) (*pb.ListProductsResponse, error) {
     time.Sleep(extraLatency)
-    rand.Seed(time.Now().UnixNano())
-    n := 3 * (1 + rand.Intn(20)) // n will be between 0 and v
-    time.Sleep(time.Duration(n)*time.Second)           
-	return &pb.ListProductsResponse{Products: parseCatalog()}, nil
-}
-
-func (p *productCatalog) GetProduct(ctx context.Context, req *pb.GetProductRequest) (*pb.Product, error) {
 	if s := os.Getenv("LATENCY_SPIKE"); s != "" {
 		// v, err := strconv.Atoi(s)
 		// if err != nil {
 		// 	log.Fatalf("faigit chaled to parse EXTRA_LATENCY (%s) as int: %+v", v, err)
 		// }
         // rand.Seed(time.Now().UnixNano())
-        n := 3 * (1 + rand.Intn(10)) // n will be between 0 and v
+        n := 3 + rand.Intn(25) // n will be between 0 and v
         time.Sleep(time.Duration(n)*time.Second)           
 		log.Infof("extra latency enabled (duration: %v)", extraLatency)
 	} else {
 		time.Sleep(extraLatency)
-	}    
+	}       
+	return &pb.ListProductsResponse{Products: parseCatalog()}, nil
+}
+
+func (p *productCatalog) GetProduct(ctx context.Context, req *pb.GetProductRequest) (*pb.Product, error) {
+	if s := os.Getenv("LATENCY_SPIKE"); s != "" {
+        n := 3 + rand.Intn(25) // n will be between 0 and v
+        time.Sleep(time.Duration(n)*time.Second)
+		log.Infof("extra latency enabled (duration: %v)", extraLatency)
+	} else {
+		time.Sleep(extraLatency)
+	}
 	var found *pb.Product
 	for i := 0; i < len(parseCatalog()); i++ {
 		if req.Id == parseCatalog()[i].Id {

--- a/src/productcatalogservice/server.go
+++ b/src/productcatalogservice/server.go
@@ -32,10 +32,12 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	"cloud.google.com/go/profiler"
-	"contrib.go.opencensus.io/exporter/stackdriver"
+    "contrib.go.opencensus.io/exporter/stackdriver"
+    "contrib.go.opencensus.io/exporter/stackdriver/monitoredresource"
+    "go.opencensus.io/examples/exporter"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/sirupsen/logrus"
-	"go.opencensus.io/exporter/jaeger"
+	// "go.opencensus.io/exporter/jaeger"
 	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
@@ -148,30 +150,31 @@ func run(port string) string {
 	return l.Addr().String()
 }
 
-func initJaegerTracing() {
-	svcAddr := os.Getenv("JAEGER_SERVICE_ADDR")
-	if svcAddr == "" {
-		log.Info("jaeger initialization disabled.")
-		return
-	}
-	// Register the Jaeger exporter to be able to retrieve
-	// the collected spans.
-	exporter, err := jaeger.NewExporter(jaeger.Options{
-		Endpoint: fmt.Sprintf("http://%s", svcAddr),
-		Process: jaeger.Process{
-			ServiceName: "productcatalogservice",
-		},
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-	trace.RegisterExporter(exporter)
-	log.Info("jaeger initialization completed.")
-}
+// func initJaegerTracing() {
+// 	svcAddr := os.Getenv("JAEGER_SERVICE_ADDR")
+// 	if svcAddr == "" {
+// 		log.Info("jaeger initialization disabled.")
+// 		return
+// 	}
+// 	// Register the Jaeger exporter to be able to retrieve
+// 	// the collected spans.
+// 	exporter, err := jaeger.NewExporter(jaeger.Options{
+// 		Endpoint: fmt.Sprintf("http://%s", svcAddr),
+// 		Process: jaeger.Process{
+// 			ServiceName: "productcatalogservice",
+// 		},
+// 	})
+// 	if err != nil {
+// 		log.Fatal(err)
+// 	}
+// 	trace.RegisterExporter(exporter)
+// 	log.Info("jaeger initialization completed.")
+// }
 
 func initStats(exporter *stackdriver.Exporter) {
-	view.SetReportingPeriod(60 * time.Second)
-	view.RegisterExporter(exporter)
+    view.SetReportingPeriod(60 * time.Second)
+    exporter.StartMetricsExporter()
+    // view.RegisterExporter(exporter) X
 	if err := view.Register(ocgrpc.DefaultServerViews...); err != nil {
 		log.Info("Error registering default server views")
 	} else {
@@ -183,11 +186,15 @@ func initStackdriverTracing() {
 	// TODO(ahmetb) this method is duplicated in other microservices using Go
 	// since they are not sharing packages.
 	for i := 1; i <= 3; i++ {
-		exporter, err := stackdriver.NewExporter(stackdriver.Options{})
+        view.RegisterExporter(&exporter.PrintExporter{})
+		exporter, err := stackdriver.NewExporter(stackdriver.Options{
+            ProjectID:         "test-exemplar-project", // Google Cloud Console project ID for stackdriver.
+            MonitoredResource: monitoredresource.Autodetect(),
+        })
 		if err != nil {
 			log.Warnf("failed to initialize Stackdriver exporter: %+v", err)
 		} else {
-			trace.RegisterExporter(exporter)
+			// trace.RegisterExporter(exporter)
 			trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 			log.Info("registered Stackdriver tracing")
 
@@ -203,7 +210,7 @@ func initStackdriverTracing() {
 }
 
 func initTracing() {
-	initJaegerTracing()
+	// initJaegerTracing()
 	initStackdriverTracing()
 }
 

--- a/src/productcatalogservice/server.go
+++ b/src/productcatalogservice/server.go
@@ -191,6 +191,7 @@ func initStackdriverTracing() {
             ProjectID:         "test-exemplar-project", // Google Cloud Console project ID for stackdriver.
             MonitoredResource: monitoredresource.Autodetect(),
         })
+        trace.RegisterExporter(exporter)
 		if err != nil {
 			log.Warnf("failed to initialize Stackdriver exporter: %+v", err)
 		} else {

--- a/src/shippingservice/Gopkg.lock
+++ b/src/shippingservice/Gopkg.lock
@@ -2,10 +2,11 @@
 
 
 [[projects]]
-  digest = "1:cd61c288406d5d80572967f908a23a1f0ffbf460e926269672e955f4a88b79bc"
+  digest = "1:9097d59af752a760c8967f4b4fca96bb99780659f8e65852869315f64afbf698"
   name = "cloud.google.com/go"
   packages = [
     "compute/metadata",
+    "container/apiv1",
     "internal/version",
     "monitoring/apiv3",
     "profiler",
@@ -16,32 +17,90 @@
   version = "v0.40.0"
 
 [[projects]]
-  digest = "1:4b96dcd8534bc6450a922bd16a76360ba3381f0d1daf40abbaec91c053fbfeb5"
+  digest = "1:fc98782bece7d3f842d991c4ce3f44dd893f9dc521a1d5fd895be9ad271e579f"
   name = "contrib.go.opencensus.io/exporter/stackdriver"
-  packages = ["."]
+  packages = [
+    ".",
+    "monitoredresource",
+  ]
   pruneopts = "UT"
-  revision = "37aa2801fbf0205003e15636096ebf0373510288"
-  version = "v0.5.0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:a85b0dc359de4812d383ee6670f0dae595cfcb8b13ff6b872bdb013a18c37b07"
-  name = "git.apache.org/thrift.git"
-  packages = ["lib/go/thrift"]
-  pruneopts = "UT"
-  revision = "286eee16b147a302ddc7b10740c5e5401ebbec17"
-  source = "github.com/apache/thrift"
+  revision = "ab68e2a40809b13b9e06ac2135d2549a6a984d62"
+  version = "v0.13.0"
 
 [[projects]]
   digest = "1:f47f56c0975afe777b239cc03631011db2667a51e59b177bf318748724d4455b"
   name = "github.com/GoogleCloudPlatform/microservices-demo"
   packages = ["src/shippingservice/genproto"]
   pruneopts = "UT"
-  revision = "27df445fc20f048c1c31e429f6c29075119fe454"
-  version = "v0.1.1"
+  revision = "d66cbdd27f73bb1ffa7479a3527f55dec070baa0"
+  version = "v0.1.4"
 
 [[projects]]
-  digest = "1:1d3ad0f6a57c08e2168089a64c34313930571fcbe5359d71c608a97ce504f7ca"
+  digest = "1:5736b824700c1e7a7374bc691b546c1a71463cb3ae654475d2c4ea3e760f1fd1"
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
+    "aws/credentials/stscreds",
+    "aws/csm",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/context",
+    "internal/ini",
+    "internal/sdkio",
+    "internal/sdkmath",
+    "internal/sdkrand",
+    "internal/sdkuri",
+    "internal/shareddefaults",
+    "internal/strings",
+    "internal/sync/singleflight",
+    "private/protocol",
+    "private/protocol/json/jsonutil",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/sts",
+    "service/sts/stsiface",
+  ]
+  pruneopts = "UT"
+  revision = "58185ee8739458b8e055d931218349b2b6b974c2"
+  version = "v1.29.30"
+
+[[projects]]
+  digest = "1:e7d26760c4e7d67a443b082153c4b473ad0b8f7388302a2f788b1360f751abb8"
+  name = "github.com/census-instrumentation/opencensus-proto"
+  packages = [
+    "gen-go/agent/common/v1",
+    "gen-go/metrics/v1",
+    "gen-go/resource/v1",
+  ]
+  pruneopts = "UT"
+  revision = "d89fa54de508111353cb0b06403c00569be780d8"
+  version = "v0.2.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:b7cb6054d3dff43b38ad2e92492f220f57ae6087ee797dca298139776749ace8"
+  name = "github.com/golang/groupcache"
+  packages = ["lru"]
+  pruneopts = "UT"
+  revision = "8c9f03a8e57eb486e42badaed3fb287da51807ba"
+
+[[projects]]
+  digest = "1:56b3126ac15d478fa10928937c085b50be29cb29c32f069dcceeceac9423a327"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -55,16 +114,30 @@
     "ptypes/wrappers",
   ]
   pruneopts = "UT"
-  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
-  version = "v1.3.1"
+  revision = "84668698ea25b64748563aa20726db66a6b8d299"
+  version = "v1.3.5"
+
+[[projects]]
+  digest = "1:0aeda02073125667ac6c9df50c7921cb22c08a4accdc54589c697a7e76be65c2"
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/internal/diff",
+    "cmp/internal/flags",
+    "cmp/internal/function",
+    "cmp/internal/value",
+  ]
+  pruneopts = "UT"
+  revision = "5a6f75716e1203a923a78c9efb94089d857df0f6"
+  version = "v0.4.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:dcb1edb161b1b1cac9aedf2a17b9b2c7829e242624968875a3c1b97dd9f4ef00"
+  digest = "1:5e64b431df7defcd21c77487d88d727600f343490e668312853bfbb63b3dc41f"
   name = "github.com/google/pprof"
   packages = ["profile"]
   pruneopts = "UT"
-  revision = "54271f7e092ff31b10b7626fee166cbc6304e350"
+  revision = "1ebb73c60ed3b70bd749d4f798d7ae427263e2c5"
 
 [[projects]]
   digest = "1:766102087520f9d54f2acc72bd6637045900ac735b4a419b128d216f0c5c4876"
@@ -75,6 +148,13 @@
   version = "v2.0.5"
 
 [[projects]]
+  digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c2b33e84"
+
+[[projects]]
   digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
@@ -83,25 +163,29 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:04457f9f6f3ffc5fea48e71d62f2ca256637dee0a04d710288e27e05c8b41976"
+  digest = "1:0599141a8403114d34f1e546604ad6c5361b70dfa80e80c635f438cdbf71b43a"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
-  version = "v1.4.2"
+  revision = "d417be0fe654de640a82370515129985b407c7e3"
+  version = "v1.5.0"
 
 [[projects]]
-  digest = "1:a5154dfd6b37bef5a3eab759e13296348e639dc8c7604f538368167782b08ccd"
+  digest = "1:d0d90c1767b8e8a44b9bb1c5982a71e3edfd566adf49120d34f90d78a98ee362"
   name = "go.opencensus.io"
   packages = [
     ".",
-    "exporter/jaeger",
-    "exporter/jaeger/internal/gen-go/jaeger",
+    "examples/exporter",
     "internal",
     "internal/tagencoding",
+    "metric/metricdata",
+    "metric/metricexport",
+    "metric/metricproducer",
     "plugin/ocgrpc",
     "plugin/ochttp",
     "plugin/ochttp/propagation/b3",
+    "resource",
+    "resource/resourcekeys",
     "stats",
     "stats/internal",
     "stats/view",
@@ -112,12 +196,12 @@
     "trace/tracestate",
   ]
   pruneopts = "UT"
-  revision = "b11f239c032624b045c4c2bfd3d1287b4012ce89"
-  version = "v0.16.0"
+  revision = "d835ff86be02193d324330acdb7d65546b05f814"
+  version = "v0.22.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:2f357867bf425774d35beca5be718402a4488b8b23b1563ce8c5bb91d09285a7"
+  digest = "1:a103d9c7d2edf2294696edf9d65c5a587e228a4409fee53e38c9b087fb147508"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -130,11 +214,11 @@
     "trace",
   ]
   pruneopts = "UT"
-  revision = "da137c7871d730100384dbcf36e6f8fa493aef5b"
+  revision = "118fecf932d8fea033f3b7aca66fba22cfdd517d"
 
 [[projects]]
   branch = "master"
-  digest = "1:31e33f76456ccf54819ab4a646cf01271d1a99d7712ab84bf1a9e7b61cd2031b"
+  digest = "1:79edde3241bb55de9f4143d5083bfcff722e550c3cb8db94084eab50d0e440b5"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -144,23 +228,23 @@
     "jwt",
   ]
   pruneopts = "UT"
-  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
+  revision = "bf48bf16ab8d622ce64ec6ce98d2c98f916b6303"
 
 [[projects]]
   branch = "master"
-  digest = "1:382bb5a7fb4034db3b6a2d19e5a4a6bcf52f4750530603c01ca18a172fa3089b"
+  digest = "1:4692f916cb72b2c295f04841036d85a3f13e96d1cc9e8e4c2c30edebac518053"
   name = "golang.org/x/sync"
   packages = ["semaphore"]
   pruneopts = "UT"
-  revision = "112230192c580c3556b8cee6403af37a4fc5f28c"
+  revision = "43a5402ce75a95522677f77c619865d66b8c57ab"
 
 [[projects]]
   branch = "master"
-  digest = "1:730ba27cd66db3b98ec8f51a6f20d45ec277d490cca36b1f54e31d3fcaf4840e"
+  digest = "1:4a1984ad1b48641ef91f73689012cdba27ed1eb94aeee1aa0b421e2208530a17"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "04f50cda93cbb67f2afa353c52f342100e80e625"
+  revision = "328b4cd54aaeaba222936f16d417999f7e521f7b"
 
 [[projects]]
   digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
@@ -188,8 +272,7 @@
   version = "v0.3.2"
 
 [[projects]]
-  branch = "master"
-  digest = "1:bc06b12d8436550fccc0212037e9281a7e4d53db25c2349eb3cc6c3457e0406b"
+  digest = "1:0ad0d6252a07813a9a12fee0ffca6df06fef08c5a03bbcaa0271dc59b88f97e5"
   name = "google.golang.org/api"
   packages = [
     "googleapi/transport",
@@ -198,15 +281,17 @@
     "option",
     "support/bundler",
     "transport",
+    "transport/cert",
     "transport/grpc",
     "transport/http",
     "transport/http/internal/propagation",
   ]
   pruneopts = "UT"
-  revision = "aae1d1b89c27132abe4fa22731a2a61e7089079c"
+  revision = "c24765c18bb761c90df819dcdfdd62f9a7f6fa22"
+  version = "v0.20.0"
 
 [[projects]]
-  digest = "1:2c26b1c47556c0e5e73cdb05d8361c463737eee4baac35d38b40c728c3074a94"
+  digest = "1:c98e9b93e6d178378530b920fe6e1aa4b3dd4972872111e83827746aa1f33ded"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -223,12 +308,12 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "b2f4a3cf3c67576a2ee09e1fe62656a5086ce880"
-  version = "v1.6.1"
+  revision = "971852bfffca25b069c31162ae8f247a3dba083b"
+  version = "v1.6.5"
 
 [[projects]]
   branch = "master"
-  digest = "1:cb0f37e3cdf50a27abbf33a48797b30786239d4fd69dbfbbc63cfa19d400d3ce"
+  digest = "1:ebd714d33041c5b3b18a05aa83cf836e95e092d7d0b58d76124f151687cb9b58"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api",
@@ -237,21 +322,25 @@
     "googleapis/api/label",
     "googleapis/api/metric",
     "googleapis/api/monitoredres",
+    "googleapis/container/v1",
     "googleapis/devtools/cloudprofiler/v2",
     "googleapis/devtools/cloudtrace/v2",
     "googleapis/monitoring/v3",
     "googleapis/rpc/errdetails",
     "googleapis/rpc/status",
+    "googleapis/type/calendarperiod",
     "protobuf/field_mask",
   ]
   pruneopts = "UT"
-  revision = "3bdd9d9f5532d75d09efb230bd767d265245cfe5"
+  revision = "3f67cca344726c97b3e8e967f95b8041980129bd"
 
 [[projects]]
-  digest = "1:c68a5ee8060d988d82cd42bf0a53f5ec24d40ea20d341346b26dbf74b1d95a1c"
+  digest = "1:e1791243943c8fef26fc167192e5fe3a99655f3f8f047a79085c87eabcd1dd0c"
   name = "google.golang.org/grpc"
   packages = [
     ".",
+    "attributes",
+    "backoff",
     "balancer",
     "balancer/base",
     "balancer/grpclb",
@@ -279,10 +368,15 @@
     "internal/backoff",
     "internal/balancerload",
     "internal/binarylog",
+    "internal/buffer",
     "internal/channelz",
     "internal/envconfig",
+    "internal/grpclog",
     "internal/grpcrand",
     "internal/grpcsync",
+    "internal/grpcutil",
+    "internal/resolver/dns",
+    "internal/resolver/passthrough",
     "internal/syscall",
     "internal/transport",
     "keepalive",
@@ -292,16 +386,14 @@
     "reflection",
     "reflection/grpc_reflection_v1alpha",
     "resolver",
-    "resolver/dns",
-    "resolver/passthrough",
     "serviceconfig",
     "stats",
     "status",
     "tap",
   ]
   pruneopts = "UT"
-  revision = "1d89a3c832915b2314551c1d2a506874d62e53f7"
-  version = "v1.22.0"
+  revision = "142182889d38b76209f1d9f1d8e91d7608aff542"
+  version = "v1.28.0"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -309,17 +401,20 @@
   input-imports = [
     "cloud.google.com/go/profiler",
     "contrib.go.opencensus.io/exporter/stackdriver",
+    "contrib.go.opencensus.io/exporter/stackdriver/monitoredresource",
     "github.com/GoogleCloudPlatform/microservices-demo/src/shippingservice/genproto",
     "github.com/golang/protobuf/proto",
     "github.com/sirupsen/logrus",
-    "go.opencensus.io/exporter/jaeger",
+    "go.opencensus.io/examples/exporter",
     "go.opencensus.io/plugin/ocgrpc",
     "go.opencensus.io/stats/view",
     "go.opencensus.io/trace",
     "golang.org/x/net/context",
     "google.golang.org/grpc",
+    "google.golang.org/grpc/codes",
     "google.golang.org/grpc/health/grpc_health_v1",
     "google.golang.org/grpc/reflection",
+    "google.golang.org/grpc/status",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/src/shippingservice/Gopkg.toml
+++ b/src/shippingservice/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "contrib.go.opencensus.io/exporter/stackdriver"
-  version = "0.5.0"
+  version = "0.13.0"
 
 [[constraint]]
   name = "github.com/golang/protobuf"
@@ -43,7 +43,7 @@
 
 [[constraint]]
   name = "go.opencensus.io"
-  version = "0.16.0"
+  version = "0.22.3"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
Upgrade 3 services: frontend, productcatalog and shipping service to use the latest version of Stackdriver Exporter.

By doing this, Monitoring Exporter is able to gather trace exemplar along with stats and send it to Stackdriver.