### PR TITLE
Use buildkit by default

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -17,7 +17,7 @@ kind: Config
 build:
   artifacts:
   # image tags are relative; to specify an image repo (e.g. GCR), you
-  # must provide a "default repo" using one of the methods described 
+  # must provide a "default repo" using one of the methods described
   # here:
   # https://skaffold.dev/docs/concepts/#image-repository-handling
   - image: emailservice
@@ -44,6 +44,8 @@ build:
     context: src/adservice
   tagPolicy:
     gitCommit: {}
+  local:
+    useBuildkit: true
 deploy:
   kubectl:
     manifests:


### PR DESCRIPTION
This repo's base images use multi stage build and I think it should be better to make the build faster by BuildKit.