### PR TITLE
Replace --install-option with pip-level option

### DIFF
--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -18,11 +18,11 @@ FROM base as builder
 
 RUN apt-get -qq update \
     && apt-get install -y --no-install-recommends \
-        g++
+    g++
 
 COPY requirements.txt .
 
-RUN pip install --install-option="--prefix=/install" -r requirements.txt
+RUN pip install --prefix="/install" -r requirements.txt
 
 FROM base
 COPY --from=builder /install /usr/local
@@ -31,5 +31,5 @@ COPY . .
 RUN chmod +x ./loadgen.sh
 RUN apt-get -qq update \
     && apt-get install -y --no-install-recommends \
-        curl
+    curl
 ENTRYPOINT ./loadgen.sh

--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -18,7 +18,7 @@ FROM base as builder
 
 RUN apt-get -qq update \
     && apt-get install -y --no-install-recommends \
-    g++
+        g++
 
 COPY requirements.txt .
 
@@ -31,5 +31,5 @@ COPY . .
 RUN chmod +x ./loadgen.sh
 RUN apt-get -qq update \
     && apt-get install -y --no-install-recommends \
-    curl
+        curl
 ENTRYPOINT ./loadgen.sh


### PR DESCRIPTION
docker build for `loadgenerator` service fails due to this change in pip 20.2: https://github.com/pypa/pip/issues/7309

This change only makes that build complete successfully.