### PR TITLE
Use pip prefix option

### DIFF
--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get -qq update \
 
 COPY requirements.txt .
 
-RUN pip install --install-option="--prefix=/install" -r requirements.txt
+RUN pip install --prefix='/install' -r requirements.txt
 
 FROM base
 COPY --from=builder /install /usr/local


### PR DESCRIPTION
Using pip --install-option leads to the following error when building the loadgenerator image:

```
ERROR: Location-changing options found in --install-option: ['--prefix'] from command line. This is unsupported, use pip-level options like --user, --prefix, --root, and --target instead.
```

The pip prefix option must be used instead.