### PR TITLE
cartservice: add libssl to allow connecting to external redis instances

### DIFF
--- a/src/cartservice/Dockerfile
+++ b/src/cartservice/Dockerfile
@@ -35,6 +35,7 @@ RUN apk add --no-cache \
     libuuid \
     libgcc \
     libstdc++ \
+    libssl1.0 \
     libintl \
     icu
 WORKDIR /app


### PR DESCRIPTION
This allows setting REDIS_ADDR to say a Google memorystore instance

Fixes #363