### PR TITLE
Swap in a published test credit card number

### DIFF
--- a/src/frontend/templates/cart.html
+++ b/src/frontend/templates/cart.html
@@ -118,7 +118,7 @@
                                         <input type="text" class="form-control" id="credit_card_number"
                                             name="credit_card_number"
                                             placeholder="0000-0000-0000-0000"
-                                            value="4432-8015-6152-0454"
+                                            value="4242-4242-4242-4242"
                                             required pattern="\d{4}-\d{4}-\d{4}-\d{4}">
                                     </div>
                                     <div class="col-md-2 mb-3">

--- a/src/loadgenerator/locustfile.py
+++ b/src/loadgenerator/locustfile.py
@@ -58,7 +58,7 @@ def checkout(l):
         'city': 'Mountain View',
         'state': 'CA',
         'country': 'United States',
-        'credit_card_number': '4432-8015-6152-0454',
+        'credit_card_number': '4242-4242-4242-4242',
         'credit_card_expiration_month': '1',
         'credit_card_expiration_year': '2039',
         'credit_card_cvv': '672',


### PR DESCRIPTION
Is it possible to swap out the current `4432-8015-6152-0454` in exchange for a published test card number? `4242-4242-4242-4242` was obtained from https://stripe.com/docs/testing#cards