### PR TITLE
Fix commands to set up GitHub actions runner

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,7 +11,7 @@
   - to set up dependencies, run the following commands:
     ```
     # install kubectl
-    sudo apt-get install -yq kubectl git
+    sudo apt-get install -yqq kubectl git
 
     # install go
     curl -O https://storage.googleapis.com/golang/go1.12.9.linux-amd64.tar.gz
@@ -37,11 +37,11 @@
     sudo mv skaffold /usr/local/bin
 
     # install docker
-    sudo apt install -yq apt-transport-https ca-certificates curl gnupg2 software-properties-common && \
+    sudo apt install -yqq apt-transport-https ca-certificates curl gnupg2 software-properties-common && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add - && \
     sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
     sudo apt-get update && \
-    sudo apt-get install -yq docker-ce && \
+    sudo apt-get install -yqq docker-ce && \
     sudo usermod -aG docker ${USER}
 
     # logout and back on

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,7 +11,7 @@
   - to set up dependencies, run the following commands:
     ```
     # install kubectl
-    sudo apt-get install kubectl
+    sudo apt-get install -yq kubectl git
 
     # install go
     curl -O https://storage.googleapis.com/golang/go1.12.9.linux-amd64.tar.gz
@@ -37,11 +37,11 @@
     sudo mv skaffold /usr/local/bin
 
     # install docker
-    sudo apt install apt-transport-https ca-certificates curl gnupg2 software-properties-common && \
+    sudo apt install -yq apt-transport-https ca-certificates curl gnupg2 software-properties-common && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add - && \
     sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-    sudo apt update && \
-    sudo apt install docker-ce && \
+    sudo apt-get update && \
+    sudo apt-get install -yq docker-ce && \
     sudo usermod -aG docker ${USER}
 
     # logout and back on


### PR DESCRIPTION
Add `git` installation
Add `-yq` flags to apt-get commands
Always use `apt-get` instead of `apt`.