### PR TITLE
Update base images

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ We offer the following installation methods:
 
     ```sh
     gcloud services enable container.googleapis.com
+    gcloud services enable cloudprofiler.googleapis.com
     ```
 
     ```sh

--- a/docs/workload-identity.md
+++ b/docs/workload-identity.md
@@ -21,6 +21,14 @@ gcloud projects add-iam-policy-binding ${PROJECT_ID} \
 gcloud projects add-iam-policy-binding ${PROJECT_ID} \
   --member "serviceAccount:${GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
   --role roles/monitoring.metricWriter
+  
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+  --member "serviceAccount:${GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role roles/cloudprofiler.agent
+  
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+  --member "serviceAccount:${GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role roles/clouddebugger.agent
 ```
 
 3. **Generate OnlineBoutique manifests** using your KSA as the Pod service account. In `kubernetes-manifests/`, replace `serviceAccountName: default` with the name of your KSA. (**Note** - sample below is Bash.)

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         app: recommendationservice
     spec:
+      serviceAccountName: default
       terminationGracePeriodSeconds: 5
       containers:
       - name: server

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         app: shippingservice
     spec:
+      serviceAccountName: default
       containers:
       - name: server
         image: shippingservice

--- a/src/cartservice/Dockerfile
+++ b/src/cartservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM microsoft/dotnet:2.1-sdk-alpine as builder
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as builder
 WORKDIR /app
 COPY . .
 RUN dotnet restore && \
@@ -22,7 +22,7 @@ RUN dotnet restore && \
 # cartservice
 FROM alpine:3.8
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.2.0 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
 

--- a/src/cartservice/cartservice.csproj
+++ b/src/cartservice/cartservice.csproj
@@ -2,19 +2,19 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.2.1" />
-    <PackageReference Include="Google.Protobuf" Version="3.6.1" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.5.1" />
-    <PackageReference Include="grpc" Version="1.12.0" />
-    <PackageReference Include="Grpc.HealthCheck" Version="1.12.0" />
-    <PackageReference Include="grpc.tools" Version="1.12.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.13.0" />
+    <PackageReference Include="grpc" Version="1.22.1" />
+    <PackageReference Include="Grpc.HealthCheck" Version="1.22.1" />
+    <PackageReference Include="grpc.tools" Version="1.22.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
+    <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/cartservice/tests/cartservice.tests.csproj
+++ b/src/cartservice/tests/cartservice.tests.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.6.0" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.6.0" />
-    <PackageReference Include="Grpc" Version="1.12.0" />
-    <PackageReference Include="Grpc.Tools" Version="1.12.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.13.0" />
+    <PackageReference Include="Grpc" Version="1.22.1" />
+    <PackageReference Include="Grpc.Tools" Version="1.22.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:8-alpine as base
+FROM node:12-alpine as base
 
 FROM base as builder
 

--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:8-alpine as base
+FROM node:12-alpine as base
 
 FROM base as builder
 

--- a/src/recommendationservice/Dockerfile
+++ b/src/recommendationservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:2.7-slim
+FROM python:3.7-slim
 RUN apt-get update -qqy && \
 	apt-get -qqy install wget g++ && \
 	rm -rf /var/lib/apt/lists/*

--- a/src/recommendationservice/recommendation_server.py
+++ b/src/recommendationservice/recommendation_server.py
@@ -46,7 +46,7 @@ def initStackdriverProfiling():
     # Environment variable not set
     pass
 
-  for retry in xrange(1,4):
+  for retry in range(1,4):
     try:
       if project_id:
         googlecloudprofiler.start(service='recommendation_server', service_version='1.0.0', verbose=0, project_id=project_id)
@@ -86,6 +86,10 @@ class RecommendationService(demo_pb2_grpc.RecommendationServiceServicer):
         return health_pb2.HealthCheckResponse(
             status=health_pb2.HealthCheckResponse.SERVING)
 
+    def Watch(self, request, context):
+        return health_pb2.HealthCheckResponse(
+            status=health_pb2.HealthCheckResponse.UNIMPLEMENTED)
+
 
 if __name__ == "__main__":
     logger.info("initializing recommendationservice")
@@ -124,7 +128,7 @@ if __name__ == "__main__":
               module='recommendationserver',
               version='1.0.0'
           )
-        except Exception, err:
+        except (Exception, err):
             logger.error("Could not enable debugger")
             logger.error(traceback.print_exc())
             pass

--- a/src/recommendationservice/requirements.in
+++ b/src/recommendationservice/requirements.in
@@ -1,7 +1,8 @@
-google-api-core==1.6.0
-google-python-cloud-debugger==2.9
-grpcio-health-checking==1.13.0
-grpcio==1.16.1
+google-api-core==1.22.0
+google-python-cloud-debugger==2.15
+grpcio-health-checking==1.30.0
+grpcio==1.30.0
 opencensus[stackdriver]==0.1.10
 python-json-logger==0.1.9
 google-cloud-profiler==1.0.8
+requests==2.24.0

--- a/src/recommendationservice/requirements.txt
+++ b/src/recommendationservice/requirements.txt
@@ -4,33 +4,31 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-cachetools==3.1.0         # via google-auth
+cachetools==3.1.1         # via google-auth
 certifi==2018.11.29       # via requests
 chardet==3.0.4            # via requests
-enum34==1.1.10            # via grpcio
-futures==3.3.0            # via google-api-core, grpcio
-google-api-core[grpc]==1.6.0  # via -r requirements.in, google-cloud-core, google-cloud-trace, opencensus
-google-api-python-client==1.7.8  # via google-cloud-profiler, google-python-cloud-debugger
-google-auth-httplib2==0.0.3  # via google-api-python-client, google-cloud-profiler, google-python-cloud-debugger
-google-auth==1.6.2        # via google-api-core, google-api-python-client, google-auth-httplib2, google-cloud-profiler, google-python-cloud-debugger
+google-api-core[grpc]==1.22.0  # via -r requirements.in, google-api-python-client, google-cloud-core, google-cloud-trace, opencensus
+google-api-python-client==1.10.0  # via google-cloud-profiler, google-python-cloud-debugger
+google-auth-httplib2==0.0.4  # via google-api-python-client, google-cloud-profiler, google-python-cloud-debugger
+google-auth==1.19.2        # via google-api-core, google-api-python-client, google-auth-httplib2, google-cloud-profiler, google-python-cloud-debugger
 google-cloud-core==0.29.1  # via google-cloud-trace
 google-cloud-profiler==1.0.8  # via -r requirements.in
 google-cloud-trace==0.20.2  # via opencensus
 google-python-cloud-debugger==2.9  # via -r requirements.in
-googleapis-common-protos==1.5.6  # via google-api-core
-grpcio-health-checking==1.13.0  # via -r requirements.in
-grpcio==1.16.1            # via -r requirements.in, google-api-core, grpcio-health-checking
-httplib2==0.18.0          # via google-api-python-client, google-auth-httplib2
-idna==2.8                 # via requests
+googleapis-common-protos==1.52.0  # via google-api-core
+grpcio-health-checking==1.30.0  # via -r requirements.in
+grpcio==1.30.0            # via -r requirements.in, google-api-core, grpcio-health-checking
+httplib2==0.18.1          # via google-api-python-client, google-auth-httplib2
+idna==2.10                 # via requests
 opencensus[stackdriver]==0.1.10  # via -r requirements.in
-protobuf==3.6.1           # via google-api-core, google-cloud-profiler, googleapis-common-protos, grpcio-health-checking
+protobuf==3.12.2          # via google-api-core, google-cloud-profiler, googleapis-common-protos, grpcio-health-checking
 pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5             # via pyasn1-modules, rsa
 python-json-logger==0.1.9  # via -r requirements.in
 pytz==2018.9              # via google-api-core
 pyyaml==5.1               # via google-python-cloud-debugger
-requests==2.21.0          # via google-api-core, google-cloud-profiler
+requests==2.24.0          # via -r requirements.in, google-api-core
 rsa==4.0                  # via google-auth
-six==1.12.0               # via google-api-core, google-api-python-client, google-auth, google-python-cloud-debugger, grpcio, protobuf
+six==1.12.0               # via google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-python-cloud-debugger, grpcio, protobuf
 uritemplate==3.0.0        # via google-api-python-client
 urllib3==1.24.2           # via requests


### PR DESCRIPTION
- `cartservice`: `microsoft/dotnet:2.1-sdk-alpine` --> `mcr.microsoft.com/dotnet/core/sdk:3.1-alpine`
  - FYI: back-porting from this https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/pull/182
- `currencyservice`: `node:8-alpine` --> `node:12-alpine`
  - FYI: back-porting from this https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/pull/360
- `paymentservice`: `node:8-alpine` --> `node:12-alpine`
  -  FYI: back-porting from this https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/pull/360
- `recommendationservice`: `python:2.7-slim` --> `python:3.7-slim`
  - FYI: back-porting from this https://github.com/GoogleCloudPlatform/cloud-ops-sandbox/pull/177

Misc updates/fixes while testing with Workload Identity:
- Fix missing `serviceAccountName: default` for `recommendationservice` and `shippingservice`
- Fix `@google-cloud/profiler Failed to create profile, waiting 48.1s to try again: Error: Stackdriver Profiler API has not been used in project xxx before or it is disabled.` silent issue in logs with `currencyservice`, `paymentservice` and `recommendationservice` by adding `gcloud services enable cloudprofiler.googleapis.com` command.
- Fix `@google-cloud/profiler Failed to create profile` silent issue in logs with `currencyservice`, `paymentservice` and `recommendationservice` by adding `roles/cloudprofiler.agent` IAM role with Workload Identity
- Fix `@google-cloud/debug-agent Failed to re-register debuggee` silent issue in logs with `currencyservice`, `paymentservice` and `recommendationservice` by adding `roles/clouddebugger.agent` IAM role with Workload Identity 