### PR TITLE
.NET 5 for cartservice

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -100,6 +100,8 @@ jobs:
         done
         EXTERNAL_IP=$(get_externalIP)
         echo "::set-env name=EXTERNAL_IP::$EXTERNAL_IP"
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - name: Smoke Test
       timeout-minutes: 5	
       run: |	

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -64,6 +64,7 @@ jobs:
         skaffold config set --global local-cluster false
         skaffold run --default-repo=gcr.io/$PROJECT_ID/$GITHUB_REF --tag=$GITHUB_SHA --namespace=$NAMESPACE
       env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PROJECT_ID: ${{ secrets.PROJECT_ID }}
         PR_CLUSTER: ${{ secrets.PR_CLUSTER }}
         ZONE: ${{ secrets.PR_CLUSTER_ZONE }}

--- a/src/cartservice/Dockerfile
+++ b/src/cartservice/Dockerfile
@@ -15,7 +15,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:5.0 as builder
 WORKDIR /app
 COPY . .
-RUN dotnet publish -r linux-musl-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=True -p:TrimMode=Link -c release -o /cartservice
+RUN dotnet publish -r linux-musl-x64 --self-contained true -c release -o /cartservice
 
 # cartservice
 FROM alpine:3.8

--- a/src/cartservice/Dockerfile
+++ b/src/cartservice/Dockerfile
@@ -15,7 +15,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:5.0 as builder
 WORKDIR /app
 COPY . .
-RUN dotnet publish -r linux-musl-x64 --self-contained true -c release -o /cartservice
+RUN dotnet publish -r linux-musl-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=True -p:TrimMode=Link -c release -o /cartservice
 
 # cartservice
 FROM alpine:3.8

--- a/src/cartservice/Dockerfile
+++ b/src/cartservice/Dockerfile
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as builder
+FROM mcr.microsoft.com/dotnet/sdk:5.0 as builder
 WORKDIR /app
 COPY . .
-RUN dotnet restore && \
-    dotnet build && \
-    dotnet publish -c release -r linux-musl-x64 -o /cartservice
+RUN dotnet publish -r linux-musl-x64 --self-contained true -c release -o /cartservice
 
 # cartservice
 FROM alpine:3.8

--- a/src/cartservice/Dockerfile
+++ b/src/cartservice/Dockerfile
@@ -18,9 +18,9 @@ COPY . .
 RUN dotnet publish -r linux-musl-x64 --self-contained true -c release -o /cartservice
 
 # cartservice
-FROM alpine:3.8
+FROM alpine:3.12
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.3.4 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
 
@@ -33,9 +33,10 @@ RUN apk add --no-cache \
     libuuid \
     libgcc \
     libstdc++ \
-    libssl1.0 \
+    libssl1.1 \
     libintl \
-    icu
+    icu \
+    gcompat
 WORKDIR /app
 COPY --from=builder /cartservice .
 ENTRYPOINT ["./cartservice", "start"]

--- a/src/cartservice/cartservice.csproj
+++ b/src/cartservice/cartservice.csproj
@@ -6,14 +6,14 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.13.0" />
-    <PackageReference Include="grpc" Version="1.22.1" />
-    <PackageReference Include="Grpc.HealthCheck" Version="1.22.1" />
-    <PackageReference Include="grpc.tools" Version="1.22.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
-    <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
+    <PackageReference Include="Google.Protobuf" Version="3.14.0" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.14.0" />
+    <PackageReference Include="Grpc" Version="2.33.1" />
+    <PackageReference Include="Grpc.HealthCheck" Version="2.33.1" />
+    <PackageReference Include="grpc.tools" Version="2.33.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/cartservice/cartservice.csproj
+++ b/src/cartservice/cartservice.csproj
@@ -1,8 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/cartservice/tests/cartservice.tests.csproj
+++ b/src/cartservice/tests/cartservice.tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/cartservice/tests/cartservice.tests.csproj
+++ b/src/cartservice/tests/cartservice.tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.13.0" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.13.0" />
-    <PackageReference Include="Grpc" Version="1.22.1" />
-    <PackageReference Include="Grpc.Tools" Version="1.22.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Google.Protobuf" Version="3.14.0" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.14.0" />
+    <PackageReference Include="Grpc" Version="2.33.1" />
+    <PackageReference Include="Grpc.Tools" Version="2.33.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/src/cartservice/tests/cartservice.tests.csproj.user
+++ b/src/cartservice/tests/cartservice.tests.csproj.user
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ShowAllFiles>true</ShowAllFiles>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
- https://docs.microsoft.com/en-us/aspnet/core/migration/31-to-50
- https://docs.microsoft.com/en-us/dotnet/core/compatibility/3.1-5.0
- `mcr.microsoft.com/dotnet/core/sdk:3.1` --> `mcr.microsoft.com/dotnet/sdk:5.0`

Not related, but in addition:
- `alpine:3.8` --> `alpine:3.12`
- `grpc-health-probe 0.3.2` --> `grpc-health-probe 0.3.4`