### PR TITLE
ACTIONS_ALLOW_UNSECURE_COMMANDS: true

### DIFF
--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -65,6 +65,7 @@ jobs:
         skaffold config set --global local-cluster false
         skaffold run --default-repo=gcr.io/$PROJECT_ID/$GITHUB_REF --tag=$GITHUB_SHA --namespace=$NAMESPACE
       env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PROJECT_ID: ${{ secrets.PROJECT_ID }}
         PR_CLUSTER: ${{ secrets.PR_CLUSTER }}
         ZONE: ${{ secrets.PR_CLUSTER_ZONE }}

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -64,6 +64,7 @@ jobs:
         skaffold config set --global local-cluster false
         skaffold run --default-repo=gcr.io/$PROJECT_ID/$GITHUB_REF --tag=$GITHUB_SHA --namespace=$NAMESPACE
       env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PROJECT_ID: ${{ secrets.PROJECT_ID }}
         PR_CLUSTER: ${{ secrets.PR_CLUSTER }}
         ZONE: ${{ secrets.PR_CLUSTER_ZONE }}
@@ -99,6 +100,8 @@ jobs:
         done
         EXTERNAL_IP=$(get_externalIP)
         echo "::set-env name=EXTERNAL_IP::$EXTERNAL_IP"
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     - name: Smoke Test
       timeout-minutes: 5	
       run: |	


### PR DESCRIPTION
Like discussed with @askmeegs, fixing current GH actions issue:

```
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```