### PR TITLE
Silently catch Exception in recommendationservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,15 @@ Looking for the old Hipster Shop frontend interface? Use the [manifests](https:/
 
 ## Quickstart (GKE)
 
-1. **[Create a Google Cloud Platform project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project)** or use an existing project. Set the `PROJECT_ID` environment variable and ensure the Google Kubernetes Engine API is enabled.
+1. **[Create a Google Cloud Platform project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project)** or use an existing project. Set the `PROJECT_ID` environment variable and ensure the Google Kubernetes Engine and Cloud Operations APIs are enabled.
 
 ```
 PROJECT_ID="<your-project-id>"
 gcloud services enable container --project ${PROJECT_ID}
+gcloud services enable monitoring.googleapis.com \
+    cloudtrace.googleapis.com \
+    clouddebugger.googleapis.com \
+    cloudprofiler.googleapis.com
 ```
 
 2. **Clone this repository.**

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ gcloud services enable container --project ${PROJECT_ID}
 gcloud services enable monitoring.googleapis.com \
     cloudtrace.googleapis.com \
     clouddebugger.googleapis.com \
-    cloudprofiler.googleapis.com
+    cloudprofiler.googleapis.com \
+    --project ${PROJECT_ID}
 ```
 
 2. **Clone this repository.**

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Looking for the old Hipster Shop frontend interface? Use the [manifests](https:/
 
 ```
 PROJECT_ID="<your-project-id>"
-gcloud services enable container --project ${PROJECT_ID}
+gcloud services enable container.googleapis.com --project ${PROJECT_ID}
 gcloud services enable monitoring.googleapis.com \
     cloudtrace.googleapis.com \
     clouddebugger.googleapis.com \

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -8,11 +8,12 @@ This doc explains how to build and run the OnlineBoutique source code locally us
 - kubectl (can be installed via `gcloud components install kubectl`)
 - [skaffold]( https://skaffold.dev/docs/install/), a tool that builds and deploys Docker images in bulk. 
 - A Google Cloud Project with Google Container Registry enabled. 
-- Enable GCP APIs for Cloud Monitoring, Tracing, Debugger:
+- Enable GCP APIs for Cloud Monitoring, Tracing, Debugger, Profiler:
 ```
 gcloud services enable monitoring.googleapis.com \
     cloudtrace.googleapis.com \
-    clouddebugger.googleapis.com
+    clouddebugger.googleapis.com \
+    cloudprofiler.googleapis.com
 ```
 - [Minikube](https://minikube.sigs.k8s.io/docs/start/) (optional - see Local Cluster)
 - [Kind](https://kind.sigs.k8s.io/) (optional - see Local Cluster)
@@ -28,7 +29,6 @@ gcloud services enable monitoring.googleapis.com \
 
     ```sh
     gcloud services enable container.googleapis.com
-    gcloud services enable cloudprofiler.googleapis.com
     ```
 
     ```sh

--- a/src/recommendationservice/recommendation_server.py
+++ b/src/recommendationservice/recommendation_server.py
@@ -132,7 +132,7 @@ if __name__ == "__main__":
             logger.error("Could not enable debugger")
             logger.error(traceback.print_exc())
             pass
-    except KeyError:
+    except (Exception, DefaultCredentialsError):
         logger.info("Debugger disabled.")
 
     port = os.environ.get('PORT', "8080")

--- a/src/recommendationservice/recommendation_server.py
+++ b/src/recommendationservice/recommendation_server.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
               module='recommendationserver',
               version='1.0.0'
           )
-        except (Exception, err):
+        except (Exception, DefaultCredentialsError):
             logger.error("Could not enable debugger")
             logger.error(traceback.print_exc())
             pass


### PR DESCRIPTION
When running locally or not in GKE `recommendationservice`, the container is not starting properly (`CrashLoopBackOff`) like reported https://github.com/GoogleCloudPlatform/microservices-demo/issues/455 and https://github.com/GoogleCloudPlatform/microservices-demo/issues/457.

An easy way to reproduce it is to run this `docker run --env GCP_PROJECT_ID="" --env PRODUCT_CATALOG_SERVICE_ADDR="productcatalogservice:3550" gcr.io/google-samples/microservices-demo/recommendationservice:v0.2.1`:
```
WARNING:google.auth._default:No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable
{"timestamp": 1607656101.82327, "severity": "ERROR", "name": "recommendationservice-server", "message": "Could not enable debugger"}
Traceback (most recent call last):
  File "/recommendationservice/recommendation_server.py", line 125, in <module>
    version='1.0.0'
  File "/usr/local/lib/python2.7/site-packages/googleclouddebugger/__init__.py", line 152, in enable
    _StartDebugger()
  File "/usr/local/lib/python2.7/site-packages/googleclouddebugger/__init__.py", line 72, in _StartDebugger
    _flags.get('service_account_json_file'))
  File "/usr/local/lib/python2.7/site-packages/googleclouddebugger/gcp_hub_client.py", line 212, in SetupAuth
    'Unable to determine the project id from the API credentials. '
NoProjectIdError: Unable to determine the project id from the API credentials. Please specify the project id using the --project_id flag.
{"timestamp": 1607656101.823903, "severity": "ERROR", "name": "recommendationservice-server", "message": "None"}

```

Issues fixed with updates in the `src/recommendationservice/recommendation_server.py` file. The 2 other files updated are just for documentation.