### PR TITLE
Rollback changes in generated release/kubernetes-manifests.yaml 

### DIFF
--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -427,8 +427,10 @@ spec:
         env:
         - name: REDIS_ADDR
           value: "redis-cart:6379"
-        - name: ASPNETCORE_URLS
-          value: "http://0.0.0.0:7070"
+        - name: PORT
+          value: "7070"
+        - name: LISTEN_ADDR
+          value: "0.0.0.0"
         resources:
           requests:
             cpu: 200m


### PR DESCRIPTION
Since the `release/kubernetes-manifests.yaml` file target the current release's prebuilt images, we should not update that generated file like mentioned in the doc, reverting the changes in that specific file made here https://github.com/GoogleCloudPlatform/microservices-demo/pull/454 (they will appear in that file when the new release version will happen).

Fixing this https://github.com/GoogleCloudPlatform/microservices-demo/issues/469