### PR TITLE
Fix image alt texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="src/frontend/static/icons/Hipster_HeroLogoCyan.svg" width="300"/>
+<img src="src/frontend/static/icons/Hipster_HeroLogoCyan.svg" width="300" alt="Online Boutique" />
 </p>
 
 

--- a/src/frontend/templates/cart.html
+++ b/src/frontend/templates/cart.html
@@ -49,8 +49,9 @@
                     <div class="product-item">
                         <div class="row pt-2 mb-2">
                             <div class="col text-right image">
-                                    <a href="/product/{{.Item.Id}}"><img class="img-fluid"
-                                        src="{{.Item.Picture}}" /></a>
+                                <a href="/product/{{.Item.Id}}">
+                                    <img class="img-fluid" alt="" src="{{.Item.Picture}}" />
+                                </a>
                             </div>
                             <div class="col text-left text">
                                 <h4>{{ .Item.Name }}</h4>

--- a/src/frontend/templates/header.html
+++ b/src/frontend/templates/header.html
@@ -42,7 +42,7 @@
                 {{ if $.show_currency }}
                 <div class="h-controls">
                     <div class="h-control">
-                        <img src="/static/icons/Hipster_CurrencyIcon.svg" alt="icon" class="icon" />
+                        <img src="/static/icons/Hipster_CurrencyIcon.svg" alt="" class="icon" />
                         <form method="POST" class="controls-form" action="/setCurrency" id="currency_form" >
                             <select name="currency_code" onchange="document.getElementById('currency_form').submit();">
                                     {{range $.currencies}}
@@ -50,7 +50,7 @@
                                 {{end}}
                             </select>
                         </form>
-                        <img src="/static/icons/Hipster_DownArrow.svg" alt="icon" class="icon arrow" />
+                        <img src="/static/icons/Hipster_DownArrow.svg" alt="" class="icon arrow" />
                     </div>
                 </div>
                 {{ end }}
@@ -60,11 +60,11 @@
         <div class="navbar sub-navbar">
             <div class="container d-flex justify-content-between">
                 <a href="/" class="navbar-brand d-flex align-items-center">
-                    <img src="/static/icons/Hipster_NavLogo.svg" alt="logo" class="logo" />
+                    <img src="/static/icons/Hipster_NavLogo.svg" alt="" class="logo" />
                 </a>
                 <div class="controls">
                     <a href="/cart">
-                        <img src="/static/icons/Hipster_CartIcon.svg" alt="cart-icon" class="logo" />
+                        <img src="/static/icons/Hipster_CartIcon.svg" alt="" class="logo" />
                         <span>Cart
                             {{ if $.cart_size }}
                             <span class="badge badge-blue">{{$.cart_size}}</span>

--- a/src/frontend/templates/home.html
+++ b/src/frontend/templates/home.html
@@ -25,14 +25,14 @@
 <main role="main" class="home">
   <section class="jumbotron text-center mb-0 h-jumbotron">
     <div class="container">
-      <img src="/static/icons/Hipster_HeroLogo.svg" alt="icon" class="icon search-icon" />
+      <img src="/static/icons/Hipster_HeroLogo.svg" alt="Online Boutique" class="icon search-icon" />
     </div>
   </section>
 
   <div class="h-grid py-5 bg-light">
     <div class="container">
       <div class="row h-row">
-        <img src="/static/icons/Hipster_HotProducts.svg" alt="icon" class="icon search-icon" />
+        <img src="/static/icons/Hipster_HotProducts.svg" alt="Hot products" class="icon search-icon" />
       </div>
       <div class="row">
         {{ range $.products }}

--- a/src/frontend/templates/order.html
+++ b/src/frontend/templates/order.html
@@ -26,7 +26,7 @@
             <div class="container py-3 px-lg-5">
                 <div class="row mt-5 py-2">
                     <div class="col text-center">
-                        <img class="order-logo" src="/static/icons/Hipster_HeroLogoCyan.svg" alt="icon" />
+                        <img class="order-logo" src="/static/icons/Hipster_HeroLogoCyan.svg" alt="Online Boutique" />
                         <h3>
                             Your order is complete!
                         </h3>

--- a/src/frontend/templates/product.html
+++ b/src/frontend/templates/product.html
@@ -26,7 +26,7 @@
   <div class="h-product">
     <div class="row">
       <div class="col">
-        <img src="{{$.product.Item.Picture}}" />
+        <img alt="" src="{{$.product.Item.Picture}}" />
       </div>
       <div class="product-info col">
         <div class="product-wrapper">

--- a/src/frontend/templates/recommendations.html
+++ b/src/frontend/templates/recommendations.html
@@ -18,7 +18,7 @@
 <section class="recommendations">
     <div class="container">
       <div class="image">
-        <img src="/static/icons/Hipster_OtherProducts.svg" alt="icon" />
+        <img src="/static/icons/Hipster_OtherProducts.svg" alt="Other products you might like" />
       </div>
       <div class="row prods">
           {{range . }}


### PR DESCRIPTION
I do appreciate that this project is mostly a demo for microservices and related technologies, however I do also think that fixing accessibility errors will give value, especially for visually impaired devs wanting to learn from the app.

Change summary:
- Give logo images a descriptive alt text
- Give decorative images an empty alt text. This hides the image from the accessibility tree. Images with no `alt` attribute will have their `src` attribute read out loud by screen readers, which is not a good user experience.

Remaining issues / concerns:
I have not tested the rest of the application for accessibility errors, as I've only targeted `<img>` related ones for now.