### PR TITLE
Remove secrets, switch back to pull_request

### DIFF
--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: self-hosted
     steps:
     - uses: actions/checkout@v2
-    - name: Go Unit Tests 
+    - name: Go Unit Tests
       timeout-minutes: 10
       run: |
         for SERVICE in "shippingservice"; do
@@ -33,7 +33,7 @@ jobs:
           go test
           popd
         done
-    # - name: TODO - run C# Unit Tests 
+    # - name: TODO - run C# Unit Tests
     #   timeout-minutes: 10
     #   run: |
     #     dotnet test src/cartservice/tests/cartservice.tests.csproj
@@ -66,9 +66,9 @@ jobs:
         skaffold run --default-repo=gcr.io/$PROJECT_ID/$GITHUB_REF --tag=$GITHUB_SHA --namespace=$NAMESPACE
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-        PROJECT_ID: ${{ secrets.PROJECT_ID }}
-        PR_CLUSTER: ${{ secrets.PR_CLUSTER }}
-        ZONE: ${{ secrets.PR_CLUSTER_ZONE }}
+        PROJECT_ID: "onlineboutique-ci"
+        PR_CLUSTER: "onlineboutique-pr"
+        ZONE: "us-east1-b"
     - name: Wait For Pods
       timeout-minutes: 20
       run: |
@@ -87,19 +87,19 @@ jobs:
         kubectl wait --for=condition=available --timeout=1000s deployment/recommendationservice
         kubectl wait --for=condition=available --timeout=1000s deployment/shippingservice
     - name: Smoke Test
-      timeout-minutes: 5	
-      run: |	
-        set -x	
-        # start fresh loadgenerator pod	
-        kubectl delete pod -l app=loadgenerator	
-        # wait for requests to come in	
-        REQUEST_COUNT="0"	
-        while [[ "$REQUEST_COUNT"  -lt "50"  ]]; do	
-            sleep 5	
-            REQUEST_COUNT=$(kubectl logs -l app=loadgenerator | grep Aggregated | awk '{print $2}')	
-        done	
-        # ensure there are no errors hitting endpoints	
-        ERROR_COUNT=$(kubectl logs -l app=loadgenerator | grep Aggregated | awk '{print $3}' | sed "s/[(][^)]*[)]//g")	
-        if [[ "$ERROR_COUNT" -gt "0" ]]; then	
-          exit 1	
+      timeout-minutes: 5
+      run: |
+        set -x
+        # start fresh loadgenerator pod
+        kubectl delete pod -l app=loadgenerator
+        # wait for requests to come in
+        REQUEST_COUNT="0"
+        while [[ "$REQUEST_COUNT"  -lt "50"  ]]; do
+            sleep 5
+            REQUEST_COUNT=$(kubectl logs -l app=loadgenerator | grep Aggregated | awk '{print $2}')
+        done
+        # ensure there are no errors hitting endpoints
+        ERROR_COUNT=$(kubectl logs -l app=loadgenerator | grep Aggregated | awk '{print $3}' | sed "s/[(][^)]*[)]//g")
+        if [[ "$ERROR_COUNT" -gt "0" ]]; then
+          exit 1
         fi

--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -67,7 +67,7 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PROJECT_ID: "onlineboutique-ci"
-        PR_CLUSTER: "onlineboutique-pr"
+        PR_CLUSTER: "online-boutique-pr"
         ZONE: "us-east1-b"
     - name: Wait For Pods
       timeout-minutes: 20

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -70,7 +70,7 @@ jobs:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PR_NUMBER: ${{ github.event.pull_request.number }}
         PROJECT_ID: "onlineboutique-ci"
-        PR_CLUSTER: "onlineboutique-pr"
+        PR_CLUSTER: "online-boutique-pr"
         ZONE: "us-east1-b"
     - name: Wait For Pods
       timeout-minutes: 20

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -14,8 +14,7 @@
 
 name: "Continuous Integration - Pull Request"
 on:
-# pull request target should allow secret access to fork PRs (deploy tests)
-  pull_request_target:
+  pull_request:
     branches:
       - master
 jobs:
@@ -70,9 +69,9 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PR_NUMBER: ${{ github.event.pull_request.number }}
-        PROJECT_ID: ${{ secrets.PROJECT_ID }}
-        PR_CLUSTER: ${{ secrets.PR_CLUSTER }}
-        ZONE: ${{ secrets.PR_CLUSTER_ZONE }}
+        PROJECT_ID: "onlineboutique-ci"
+        PR_CLUSTER: "onlineboutique-pr"
+        ZONE: "us-east1-b"
     - name: Wait For Pods
       timeout-minutes: 20
       run: |

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -36,7 +36,7 @@ jobs:
           NAMESPACE="pr${PR_NUMBER}"
           kubectl delete namespace $NAMESPACE
         env:
-          PROJECT_ID: ${{ secrets.PROJECT_ID }}
-          PR_CLUSTER: ${{ secrets.PR_CLUSTER }}
-          ZONE: ${{ secrets.PR_CLUSTER_ZONE }}
+          PROJECT_ID: "onlineboutique-ci"
+          PR_CLUSTER: "onlineboutique-pr"
+          ZONE: "us-east1-b"
           PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -37,6 +37,6 @@ jobs:
           kubectl delete namespace $NAMESPACE
         env:
           PROJECT_ID: "onlineboutique-ci"
-          PR_CLUSTER: "onlineboutique-pr"
+          PR_CLUSTER: "online-boutique-pr"
           ZONE: "us-east1-b"
           PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
Revert the `pull_request_target` change in the GH Actions pull request workflow. Switch back to `pull_request`, and to continue to allow fork PRs, take the Project ID / staging cluster name out of the upstream Github secrets and hardcode into the workflow. 

Conferred with CI/CD DPEs on the best practices of doing this, and they agree that project ID can be put directly in the workflow, and there are existing GCP samples that do this: https://github.com/GoogleCloudPlatform/cloud-run-samples/blob/main/testing/runner.sh 