### PR TITLE
review resources requests and limits based on vpa

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -43,11 +43,11 @@ spec:
         #  value: "jaeger-collector:14268"
         resources:
           requests:
-            cpu: 25m
-            memory: 244Mi
+            cpu: 20m
+            memory: 251Mi
           limits:
-            cpu: 50m
-            memory: 488Mi
+            cpu: 25m
+            memory: 286Mi
         readinessProbe:
           initialDelaySeconds: 20
           periodSeconds: 15

--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -44,10 +44,10 @@ spec:
         resources:
           requests:
             cpu: 25m
-            memory: 215Mi
+            memory: 244Mi
           limits:
             cpu: 50m
-            memory: 430Mi
+            memory: 488Mi
         readinessProbe:
           initialDelaySeconds: 20
           periodSeconds: 15

--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -44,10 +44,10 @@ spec:
         resources:
           requests:
             cpu: 20m
-            memory: 251Mi
+            memory: 321Mi
           limits:
             cpu: 25m
-            memory: 286Mi
+            memory: 346Mi
         readinessProbe:
           initialDelaySeconds: 20
           periodSeconds: 15

--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -43,11 +43,11 @@ spec:
         #  value: "jaeger-collector:14268"
         resources:
           requests:
-            cpu: 200m
-            memory: 180Mi
+            cpu: 25m
+            memory: 215Mi
           limits:
-            cpu: 300m
-            memory: 300Mi
+            cpu: 50m
+            memory: 430Mi
         readinessProbe:
           initialDelaySeconds: 20
           periodSeconds: 15

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -39,11 +39,11 @@ spec:
           value: "http://0.0.0.0:7070"
         resources:
           requests:
-            cpu: 35m
-            memory: 39Mi
+            cpu: 5m
+            memory: 35Mi
           limits:
-            cpu: 70m
-            memory: 78Mi
+            cpu: 20m
+            memory: 72Mi
         readinessProbe:
           initialDelaySeconds: 15
           exec:

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -40,7 +40,7 @@ spec:
         resources:
           requests:
             cpu: 5m
-            memory: 35Mi
+            memory: 36Mi
           limits:
             cpu: 20m
             memory: 72Mi

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -39,11 +39,11 @@ spec:
           value: "http://0.0.0.0:7070"
         resources:
           requests:
-            cpu: 200m
-            memory: 64Mi
+            cpu: 35m
+            memory: 39Mi
           limits:
-            cpu: 300m
-            memory: 128Mi
+            cpu: 70m
+            memory: 78Mi
         readinessProbe:
           initialDelaySeconds: 15
           exec:

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -62,10 +62,10 @@ spec:
           #   value: "jaeger-collector:14268"
           resources:
             requests:
-              cpu: 10m
-              memory: 16Mi
+              cpu: 15m
+              memory: 29Mi
             limits:
-              cpu: 35m
+              cpu: 40m
               memory: 152Mi
 ---
 apiVersion: v1

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -62,11 +62,11 @@ spec:
           #   value: "jaeger-collector:14268"
           resources:
             requests:
-              cpu: 25m
-              memory: 136Mi
+              cpu: 10m
+              memory: 16Mi
             limits:
-              cpu: 50m
-              memory: 272Mi
+              cpu: 35m
+              memory: 152Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -62,11 +62,11 @@ spec:
           #   value: "jaeger-collector:14268"
           resources:
             requests:
-              cpu: 100m
-              memory: 64Mi
+              cpu: 25m
+              memory: 136Mi
             limits:
-              cpu: 200m
-              memory: 128Mi
+              cpu: 50m
+              memory: 272Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -50,7 +50,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]
         resources:
           requests:
-            cpu: 15m
+            cpu: 20m
             memory: 83Mi
           limits:
             cpu: 50m

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -50,11 +50,11 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]
         resources:
           requests:
-            cpu: 20m
-            memory: 74Mi
+            cpu: 15m
+            memory: 83Mi
           limits:
-            cpu: 55m
-            memory: 85Mi
+            cpu: 50m
+            memory: 98Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -50,11 +50,11 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]
         resources:
           requests:
-            cpu: 100m
-            memory: 64Mi
+            cpu: 40m
+            memory: 74Mi
           limits:
-            cpu: 200m
-            memory: 128Mi
+            cpu: 80m
+            memory: 148Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -50,11 +50,11 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]
         resources:
           requests:
-            cpu: 45m
+            cpu: 20m
             memory: 74Mi
           limits:
-            cpu: 90m
-            memory: 148Mi
+            cpu: 55m
+            memory: 85Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -50,10 +50,10 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]
         resources:
           requests:
-            cpu: 40m
+            cpu: 45m
             memory: 74Mi
           limits:
-            cpu: 80m
+            cpu: 90m
             memory: 148Mi
 ---
 apiVersion: v1

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -49,11 +49,11 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:8080"]
         resources:
           requests:
-            cpu: 10m
-            memory: 46Mi
+            cpu: 5m
+            memory: 45Mi
           limits:
-            cpu: 20m
-            memory: 92Mi
+            cpu: 15m
+            memory: 48Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -49,7 +49,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:8080"]
         resources:
           requests:
-            cpu: 5m
+            cpu: 8m
             memory: 61Mi
           limits:
             cpu: 15m

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -50,10 +50,10 @@ spec:
         resources:
           requests:
             cpu: 5m
-            memory: 45Mi
+            memory: 61Mi
           limits:
             cpu: 15m
-            memory: 48Mi
+            memory: 63Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -49,11 +49,11 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:8080"]
         resources:
           requests:
-            cpu: 100m
-            memory: 64Mi
+            cpu: 10m
+            memory: 46Mi
           limits:
-            cpu: 200m
-            memory: 128Mi
+            cpu: 20m
+            memory: 92Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -76,10 +76,10 @@ spec:
           #   value: "jaeger-collector:14268"
           resources:
             requests:
-              cpu: 30m
+              cpu: 40m
               memory: 135Mi
             limits:
-              cpu: 60m
+              cpu: 80m
               memory: 270Mi
 ---
 apiVersion: v1

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -76,11 +76,11 @@ spec:
           #   value: "jaeger-collector:14268"
           resources:
             requests:
-              cpu: 40m
-              memory: 135Mi
+              cpu: 20m
+              memory: 21Mi
             limits:
-              cpu: 80m
-              memory: 270Mi
+              cpu: 55m
+              memory: 151Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -76,10 +76,10 @@ spec:
           #   value: "jaeger-collector:14268"
           resources:
             requests:
-              cpu: 20m
-              memory: 21Mi
+              cpu: 25m
+              memory: 27Mi
             limits:
-              cpu: 55m
+              cpu: 60m
               memory: 151Mi
 ---
 apiVersion: v1

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -76,10 +76,10 @@ spec:
           #   value: "jaeger-collector:14268"
           resources:
             requests:
-              cpu: 25m
+              cpu: 30m
               memory: 27Mi
             limits:
-              cpu: 60m
+              cpu: 70m
               memory: 151Mi
 ---
 apiVersion: v1

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -76,11 +76,11 @@ spec:
           #   value: "jaeger-collector:14268"
           resources:
             requests:
-              cpu: 100m
-              memory: 64Mi
+              cpu: 30m
+              memory: 135Mi
             limits:
-              cpu: 200m
-              memory: 128Mi
+              cpu: 60m
+              memory: 270Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -40,8 +40,8 @@ spec:
           value: "10"
         resources:
           requests:
-            cpu: 300m
-            memory: 256Mi
+            cpu: 20m
+            memory: 51Mi
           limits:
-            cpu: 500m
-            memory: 512Mi
+            cpu: 40m
+            memory: 102Mi

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -40,8 +40,8 @@ spec:
           value: "10"
         resources:
           requests:
-            cpu: 25m
-            memory: 59Mi
+            cpu: 15m
+            memory: 61Mi
           limits:
-            cpu: 50m
-            memory: 118Mi
+            cpu: 40m
+            memory: 114Mi

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -44,4 +44,4 @@ spec:
             memory: 118Mi
           limits:
             cpu: 55m
-            memory: 133Mi
+            memory: 243Mi

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -40,8 +40,8 @@ spec:
           value: "10"
         resources:
           requests:
-            cpu: 20m
-            memory: 51Mi
+            cpu: 25m
+            memory: 59Mi
           limits:
-            cpu: 40m
-            memory: 102Mi
+            cpu: 50m
+            memory: 118Mi

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -40,8 +40,8 @@ spec:
           value: "10"
         resources:
           requests:
-            cpu: 15m
-            memory: 61Mi
+            cpu: 50m
+            memory: 118Mi
           limits:
-            cpu: 40m
-            memory: 114Mi
+            cpu: 55m
+            memory: 133Mi

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -43,11 +43,11 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]
         resources:
           requests:
-            cpu: 100m
-            memory: 64Mi
+            cpu: 40m
+            memory: 58Mi
           limits:
-            cpu: 200m
-            memory: 128Mi
+            cpu: 80m
+            memory: 116Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -46,7 +46,7 @@ spec:
             cpu: 9m
             memory: 72Mi
           limits:
-            cpu: 45m
+            cpu: 50m
             memory: 75Mi
 ---
 apiVersion: v1

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -43,11 +43,11 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]
         resources:
           requests:
-            cpu: 40m
-            memory: 58Mi
+            cpu: 9m
+            memory: 56Mi
           limits:
-            cpu: 80m
-            memory: 116Mi
+            cpu: 45m
+            memory: 59Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -44,10 +44,10 @@ spec:
         resources:
           requests:
             cpu: 9m
-            memory: 56Mi
+            memory: 72Mi
           limits:
             cpu: 45m
-            memory: 59Mi
+            memory: 75Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -55,7 +55,7 @@ spec:
             memory: 151Mi
           limits:
             cpu: 40m
-            memory: 158Mi
+            memory: 170Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -51,11 +51,11 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:3550"]
         resources:
           requests:
-            cpu: 100m
-            memory: 64Mi
+            cpu: 25m
+            memory: 17Mi
           limits:
-            cpu: 200m
-            memory: 128Mi
+            cpu: 50m
+            memory: 34Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -51,11 +51,11 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:3550"]
         resources:
           requests:
-            cpu: 25m
-            memory: 140Mi
+            cpu: 15m
+            memory: 25Mi
           limits:
-            cpu: 50m
-            memory: 280Mi
+            cpu: 30m
+            memory: 147Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -52,10 +52,10 @@ spec:
         resources:
           requests:
             cpu: 15m
-            memory: 25Mi
+            memory: 151Mi
           limits:
-            cpu: 30m
-            memory: 147Mi
+            cpu: 40m
+            memory: 158Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -52,10 +52,10 @@ spec:
         resources:
           requests:
             cpu: 25m
-            memory: 17Mi
+            memory: 140Mi
           limits:
             cpu: 50m
-            memory: 34Mi
+            memory: 280Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -53,11 +53,11 @@ spec:
         #   value: "1"
         resources:
           requests:
-            cpu: 100m
-            memory: 220Mi
+            cpu: 20m
+            memory: 142Mi
           limits:
-            cpu: 200m
-            memory: 450Mi
+            cpu: 40m
+            memory: 284Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -53,11 +53,11 @@ spec:
         #   value: "1"
         resources:
           requests:
-            cpu: 15m
+            cpu: 20m
             memory: 284Mi
           limits:
             cpu: 35m
-            memory: 446Mi
+            memory: 526Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -54,10 +54,10 @@ spec:
         resources:
           requests:
             cpu: 15m
-            memory: 247Mi
+            memory: 284Mi
           limits:
-            cpu: 25m
-            memory: 271Mi
+            cpu: 35m
+            memory: 446Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -53,11 +53,11 @@ spec:
         #   value: "1"
         resources:
           requests:
-            cpu: 25m
-            memory: 213Mi
+            cpu: 15m
+            memory: 247Mi
           limits:
-            cpu: 50m
-            memory: 426Mi
+            cpu: 25m
+            memory: 271Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -53,11 +53,11 @@ spec:
         #   value: "1"
         resources:
           requests:
-            cpu: 20m
-            memory: 142Mi
+            cpu: 25m
+            memory: 213Mi
           limits:
-            cpu: 40m
-            memory: 284Mi
+            cpu: 50m
+            memory: 426Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/redis.yaml
+++ b/kubernetes-manifests/redis.yaml
@@ -44,11 +44,10 @@ spec:
         resources:
           requests:
             cpu: 3m
-            memory: 3Mi
+            memory: 6Mi
           limits:
             cpu: 6m
-            memory: 4Mi
-
+            memory: 7Mi
       volumes:
       - name: redis-data
         emptyDir: {}

--- a/kubernetes-manifests/redis.yaml
+++ b/kubernetes-manifests/redis.yaml
@@ -42,12 +42,13 @@ spec:
         - mountPath: /data
           name: redis-data
         resources:
-          limits:
-            memory: 256Mi
-            cpu: 125m
           requests:
-            cpu: 70m
-            memory: 200Mi
+            cpu: 6m
+            memory: 4Mi
+          limits:
+            cpu: 12m
+            memory: 8Mi
+
       volumes:
       - name: redis-data
         emptyDir: {}

--- a/kubernetes-manifests/redis.yaml
+++ b/kubernetes-manifests/redis.yaml
@@ -43,11 +43,11 @@ spec:
           name: redis-data
         resources:
           requests:
+            cpu: 3m
+            memory: 3Mi
+          limits:
             cpu: 6m
             memory: 4Mi
-          limits:
-            cpu: 12m
-            memory: 8Mi
 
       volumes:
       - name: redis-data

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -52,10 +52,10 @@ spec:
         resources:
           requests:
             cpu: 25m
-            memory: 16Mi
+            memory: 142Mi
           limits:
             cpu: 50m
-            memory: 32Mi
+            memory: 284Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -52,7 +52,7 @@ spec:
         resources:
           requests:
             cpu: 7m
-            memory: 35Mi
+            memory: 129Mi
           limits:
             cpu: 30m
             memory: 160Mi

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -51,11 +51,11 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]
         resources:
           requests:
-            cpu: 100m
-            memory: 64Mi
+            cpu: 25m
+            memory: 16Mi
           limits:
-            cpu: 200m
-            memory: 128Mi
+            cpu: 50m
+            memory: 32Mi
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -52,7 +52,7 @@ spec:
         resources:
           requests:
             cpu: 9m
-            memory: 16Mi
+            memory: 25Mi
           limits:
             cpu: 30m
             memory: 160Mi

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -51,8 +51,8 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]
         resources:
           requests:
-            cpu: 9m
-            memory: 25Mi
+            cpu: 7m
+            memory: 35Mi
           limits:
             cpu: 30m
             memory: 160Mi

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -51,11 +51,11 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]
         resources:
           requests:
-            cpu: 25m
-            memory: 142Mi
+            cpu: 9m
+            memory: 16Mi
           limits:
-            cpu: 50m
-            memory: 284Mi
+            cpu: 30m
+            memory: 160Mi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This PR allows to review the resources `requests` and `limits` (way too much conservative currently?) to avoid getting such following error while deploying this repo on a Kubernetes cluster already having other workloads on it: `Warning  FailedScheduling  74s (x2 over 74s)  default-scheduler  0/3 nodes are available: 3 Insufficient cpu.`

I got those new numbers for `cpu` or `memory` by leveraging `VPA` on my cluster: https://cloud.google.com/kubernetes-engine/docs/how-to/vertical-pod-autoscaling and have been having the `loadgenerator` doing its job. I took the ` Lower Bound` numbers provided and set the `requests` part with them. For `limits`, I set them with: `Upper Bound`. For example here is an example with `productcatalogservice`, `kubectl describe vpa productcatalogservice`:
```
...
Recommendation:
    Container Recommendations:
      Container Name:  server
      Lower Bound:
        Cpu:     15m
        Memory:  15728640
      Target:
        Cpu:     25m
        Memory:  146800640
      Uncapped Target:
        Cpu:     25m
        Memory:  146800640
      Upper Bound:
        Cpu:     30m
        Memory:  154140672
```

In addition, to verify those numbers, `kubectl top pods` gives:
```
NAME                                     CPU(cores)   MEMORY(bytes)   
adservice-cf9457796-wfg4c                16m          220Mi           
cartservice-6bbc74c9bb-5k77k             8m           29Mi            
checkoutservice-578ff48bb7-vb2xr         9m           12Mi            
currencyservice-6b5664c494-7t9z2         51m          45Mi            
emailservice-5b559f5955-f5qng            8m           37Mi            
frontend-5ddcc5c484-px82l                17m          16Mi            
loadgenerator-58794c8998-g2tch           12m          59Mi            
paymentservice-7fb5f8c97b-bdb5d          30m          43Mi            
productcatalogservice-86d7dd6cb4-b4hls   15m          21Mi            
recommendationservice-bdfc5bdc9-426zb    18m          230Mi           
redis-cart-6f866f9779-vn5dt              2m           2Mi             
shippingservice-9cf66f4f7-qw6w8          9m           19Mi 
```

Feel free to provide feedback, concerns, etc. first time I'm using this `VPA` feature (by the way, really awesome!) to estimate such numbers.