### PR TITLE
dotnet 5.0.2

### DIFF
--- a/src/cartservice/Dockerfile
+++ b/src/cartservice/Dockerfile
@@ -13,15 +13,17 @@
 # limitations under the License.
 
 # https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
-FROM mcr.microsoft.com/dotnet/sdk:5.0.101 as builder
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102 as builder
 WORKDIR /app
 COPY cartservice.csproj .
 RUN dotnet restore cartservice.csproj -r linux-musl-x64
 COPY . .
+# Fix the issue on Debian 10: https://github.com/dotnet/dotnet-docker/issues/2470
+ENV COMPlus_EnableDiagnostics=0
 RUN dotnet publish cartservice.csproj -p:PublishSingleFile=true -r linux-musl-x64 --self-contained true -p:PublishTrimmed=True -p:TrimMode=Link -c release -o /cartservice --no-restore
 
 # https://mcr.microsoft.com/v2/dotnet/runtime-deps/tags/list
-FROM mcr.microsoft.com/dotnet/runtime-deps:5.0.1-alpine3.12-amd64
+FROM mcr.microsoft.com/dotnet/runtime-deps:5.0.2-alpine3.12-amd64
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.6 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe

--- a/src/cartservice/cartservice.csproj
+++ b/src/cartservice/cartservice.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.34.0" />
-    <PackageReference Include="Grpc.HealthCheck" Version="2.34.1" />
+    <PackageReference Include="Grpc.HealthCheck" Version="2.35.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
   </ItemGroup>
 

--- a/src/cartservice/cartservice.csproj
+++ b/src/cartservice/cartservice.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.34.0" />
-    <PackageReference Include="Grpc.HealthCheck" Version="2.34.0" />
+    <PackageReference Include="Grpc.HealthCheck" Version="2.34.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
   </ItemGroup>
 

--- a/src/cartservice/tests/cartservice.tests.csproj
+++ b/src/cartservice/tests/cartservice.tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.34.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.34.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.35.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />


### PR DESCRIPTION
- `dotnet 5.0.2`: https://devblogs.microsoft.com/dotnet/net-january-2021/
- `Grpc.HealthCheck 2.35.0`
- `Grpc.Tools 2.35.0`
- Fix local `docker run` on `Debian 10` with `Docker 20.10.2`