### PR TITLE
Fix the NuGet error

### DIFF
--- a/src/cartservice/Dockerfile
+++ b/src/cartservice/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102 as builder
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal as builder
 WORKDIR /app
 COPY cartservice.csproj .
 RUN dotnet restore cartservice.csproj -r linux-musl-x64

--- a/src/cartservice/Dockerfile
+++ b/src/cartservice/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
-FROM mcr.microsoft.com/dotnet/sdk:5.0-focal as builder
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim as builder
 WORKDIR /app
 COPY cartservice.csproj .
 RUN dotnet restore cartservice.csproj -r linux-musl-x64


### PR DESCRIPTION
Fixes the following error which is coming due to changes in Microsoft's CA signing changes.
[https://github.com/NuGet/Announcements/issues/49](https://github.com/NuGet/Announcements/issues/49)

```
app/cartservice.csproj : error NU3028: Package 'Microsoft.Extensions.Logging.Abstractions 3.0.3' from source 'https://api.nuget.org/v3/index.json': The author primary signature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain
/app/cartservice.csproj : error NU3037: Package 'Microsoft.Extensions.Logging.Abstractions 3.0.3' from source 'https://api.nuget.org/v3/index.json': The author primary signature validity period has expired.
/app/cartservice.csproj : error NU3028: Package 'Microsoft.Extensions.Logging.Abstractions 3.0.3' from source 'https://api.nuget.org/v3/index.json': The repository countersignature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain
/app/cartservice.csproj : error NU3028: Package 'System.Threading.Channels 4.6.0' from source 'https://api.nuget.org/v3/index.json': The author primary signature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain
/app/cartservice.csproj : error NU3037: Package 'System.Threading.Channels 4.6.0' from source 'https://api.nuget.org/v3/index.json': The author primary signature validity period has expired.
/app/cartservice.csproj : error NU3028: Package 'System.Threading.Channels 4.6.0' from source 'https://api.nuget.org/v3/index.json': The repository countersignature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain
/app/cartservice.csproj : error NU3028: Package 'System.Diagnostics.PerformanceCounter 5.0.0' from source 'https://api.nuget.org/v3/index.json': The author primary signature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain
/app/cartservice.csproj : error NU3037: Package 'System.Diagnostics.PerformanceCounter 5.0.0' from source 'https://api.nuget.org/v3/index.json': The author primary signature validity period has expired.
/app/cartservice.csproj : error NU3028: Package 'System.Diagnostics.PerformanceCounter 5.0.0' from source 'https://api.nuget.org/v3/index.json': The repository countersignature's timestamp found a chain building issue: UntrustedRoot: self signed certificate in certificate chain
```

Change summary:
 From:
 `FROM mcr.microsoft.com/dotnet/sdk:5.0.102 as builder `
 To:
` FROM mcr.microsoft.com/dotnet/sdk:5.0-focal as builder`


Remaining issues / concerns:
This is just a workaround for now. Will require changes when the new version comes out.