### PR TITLE
cartservice - dotnet 5.0.3

### DIFF
--- a/src/cartservice/Dockerfile
+++ b/src/cartservice/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # https://mcr.microsoft.com/v2/dotnet/sdk/tags/list
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim as builder
+FROM mcr.microsoft.com/dotnet/sdk:5.0.103 as builder
 WORKDIR /app
 COPY cartservice.csproj .
 RUN dotnet restore cartservice.csproj -r linux-musl-x64
@@ -23,7 +23,7 @@ ENV COMPlus_EnableDiagnostics=0
 RUN dotnet publish cartservice.csproj -p:PublishSingleFile=true -r linux-musl-x64 --self-contained true -p:PublishTrimmed=True -p:TrimMode=Link -c release -o /cartservice --no-restore
 
 # https://mcr.microsoft.com/v2/dotnet/runtime-deps/tags/list
-FROM mcr.microsoft.com/dotnet/runtime-deps:5.0.2-alpine3.12-amd64
+FROM mcr.microsoft.com/dotnet/runtime-deps:5.0.3-alpine3.12-amd64
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.6 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe

--- a/src/cartservice/cartservice.csproj
+++ b/src/cartservice/cartservice.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.34.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.35.0" />
     <PackageReference Include="Grpc.HealthCheck" Version="2.35.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.4" />
   </ItemGroup>

--- a/src/cartservice/tests/cartservice.tests.csproj
+++ b/src/cartservice/tests/cartservice.tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.34.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.35.0" />
     <PackageReference Include="Grpc.Tools" Version="2.35.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
[.NET February 2021 Updates – 5.0.3](https://devblogs.microsoft.com/dotnet/net-february-2021/)
- `dotnet/sdk:5.0.103` and `dotnet/runtime-deps:5.0.3`
- `Grpc.AspNetCore` - `2.35.0`

Note: no need of this workaround anymore apparently (tested locally and via the CI on this PR): https://github.com/GoogleCloudPlatform/microservices-demo/pull/496