### PR TITLE
Made Loadgenerator capable of sending calls through https and outside the cluster

### DIFF
--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -35,7 +35,7 @@ spec:
         image: loadgenerator
         env:
         - name: FRONTEND_ADDR
-          value: "frontend:80"
+          value: "http://frontend:80"
         - name: USERS
           value: "10"
         resources:

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -482,7 +482,7 @@ spec:
         image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.2.2
         env:
         - name: FRONTEND_ADDR
-          value: "frontend:80"
+          value: "http://frontend:80"
         - name: USERS
           value: "10"
         resources:

--- a/src/loadgenerator/loadgen.sh
+++ b/src/loadgenerator/loadgen.sh
@@ -25,11 +25,11 @@ fi
 set -x
 
 # if one request to the frontend fails, then exit
-STATUSCODE=$(curl --silent --output /dev/stderr --write-out "%{http_code}" http://${FRONTEND_ADDR})
+STATUSCODE=$(curl --silent --output /dev/stderr --write-out "%{http_code}" ${FRONTEND_ADDR})
 if test $STATUSCODE -ne 200; then
     echo "Error: Could not reach frontend - Status code: ${STATUSCODE}"
     exit 1
 fi
 
 # else, run loadgen
-locust --host="http://${FRONTEND_ADDR}" --headless -u "${USERS:-10}" 2>&1
+locust --host="${FRONTEND_ADDR}" --headless -u "${USERS:-10}" 2>&1


### PR DESCRIPTION
Fixes # .

Change summary:
Adjusted loadgen shell script to include the entire http call so that the envvar can be adjusted for https calls. This allows for using the loadgenerator to call an external https lb.
- 


Remaining issues / concerns:
