### PR TITLE
Disable the PROFILER and DEBUGGER by default

### DIFF
--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -47,10 +47,10 @@ spec:
           value: "productcatalogservice:3550"
         # - name: DISABLE_TRACING
         #   value: "1"
-        # - name: DISABLE_PROFILER
-        #   value: "1"
-        # - name: DISABLE_DEBUGGER
-        #   value: "1"
+        - name: DISABLE_PROFILER
+          value: "1"
+        - name: DISABLE_DEBUGGER
+          value: "1"
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
DIsable the Profiler and Debugger to avoid CrashLoop while run the demo outside of GCP.
Otherwise, the recommendationservice will fail health check before 8080 port ready.

Fixes # .

Change summary:
- 


Remaining issues / concerns:
