### PR TITLE
Set ENV_PLATFORM default to `local`, auto-detect `gcp`

### DIFF
--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -67,7 +67,7 @@ spec:
           - name: AD_SERVICE_ADDR
             value: "adservice:9555"
           - name: ENV_PLATFORM
-            value: "gcp"
+            value: "local"
           # - name: DISABLE_TRACING
           #   value: "1"
           # - name: DISABLE_PROFILER

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -66,8 +66,10 @@ spec:
             value: "checkoutservice:5050"
           - name: AD_SERVICE_ADDR
             value: "adservice:9555"
-          - name: ENV_PLATFORM
-            value: "local"
+          # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem
+          # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp 
+          - name: ENV_PLATFORM 
+            value: "aws"
           # - name: DISABLE_TRACING
           #   value: "1"
           # - name: DISABLE_PROFILER

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -68,8 +68,8 @@ spec:
             value: "adservice:9555"
           # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem
           # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp 
-          - name: ENV_PLATFORM 
-            value: "aws"
+          # - name: ENV_PLATFORM 
+          #   value: "aws"
           # - name: DISABLE_TRACING
           #   value: "1"
           # - name: DISABLE_PROFILER

--- a/src/frontend/handlers.go
+++ b/src/frontend/handlers.go
@@ -80,19 +80,17 @@ func (fe *frontendServer) homeHandler(w http.ResponseWriter, r *http.Request) {
 		ps[i] = productView{p, price}
 	}
 
-	// Set ENV_PLATFORM (checks for GCP. otherwise uses env value.)
-	var env = "local"
+	// Set ENV_PLATFORM (default to local if not set; use env var if set; otherwise detect GCP, which overrides env)_
+	var env = os.Getenv("ENV_PLATFORM")
+	if env == "" {
+		env = "local"
+	}
 	addrs, err := net.LookupHost("metadata.google.internal.")
 	if err == nil && len(addrs) >= 0 {
-		log.Debugf("Detected Google metadata servers: %v, setting ENV_PLATFORM to GCP.", addrs)
+		log.Debugf("Detected Google metadata server: %v, setting ENV_PLATFORM to GCP.", addrs)
 		env = "gcp"
-	} else {
-		var envFromConfig = os.Getenv("ENV_PLATFORM")
-		fmt.Printf("⭐️ Env from config is: %s", envFromConfig)
-		if envFromConfig != "" {
-			env = envFromConfig
-		}
 	}
+
 	log.Debugf("ENV_PLATFORM is: %s", env)
 	plat = platformDetails{}
 	plat.setPlatformDetails(strings.ToLower(env))

--- a/src/frontend/handlers.go
+++ b/src/frontend/handlers.go
@@ -88,6 +88,7 @@ func (fe *frontendServer) homeHandler(w http.ResponseWriter, r *http.Request) {
 		env = "gcp"
 	} else {
 		var envFromConfig = os.Getenv("ENV_PLATFORM")
+		fmt.Printf("⭐️ Env from config is: %s", envFromConfig)
 		if envFromConfig != "" {
 			env = envFromConfig
 		}

--- a/src/frontend/static/styles/styles.css
+++ b/src/frontend/static/styles/styles.css
@@ -547,6 +547,7 @@ main.home {
 
 /*platform banner*/
 
+.local,
 .aws-platform,
 .onprem-platform,
 .azure-platform,
@@ -581,6 +582,12 @@ main.home {
 .azure-platform .platform-flag {
   background-color: #f35426;
 }
+
+.local,
+.local .platform-flag {
+  background-color: #2c0678;
+}
+
 
 .platform-flag {
   position: absolute;


### PR DESCRIPTION
Fixes #334 

Tested on:
- GKE (ENV_PLATFORM set to local, sees metadata server, correctly sets flag to GCP) 
- Minikube with `local` flag set --> sets to local 
- Minikube with no flag set  --> sets to local 
- Minikube with manual flag override to AWS --> sets to aws  