### PR TITLE
Fix for failed docker image build

### DIFF
--- a/hack/make-docker-images.sh
+++ b/hack/make-docker-images.sh
@@ -27,9 +27,15 @@ REPO_PREFIX="${REPO_PREFIX:?REPO_PREFIX env variable must be specified}"
 while IFS= read -d $'\0' -r dir; do
     # build image
     svcname="$(basename "${dir}")"
+    builddir="${dir}"
+    #PR 516 moved cartservice build artifacts one level down to src
+    if [ $svcname == "cartservice" ] 
+    then
+        builddir="${dir}/src"
+    fi
     image="${REPO_PREFIX}/$svcname:$TAG"
     (
-        cd "${dir}"
+        cd "${builddir}"
         log "Building: ${image}"
         docker build -t "${image}" .
 


### PR DESCRIPTION
Signed-off-by: Sitaram IYER <sitaramkm@gmail.com>

Fixes #534 .

Change summary:
- Fix building docker image for cartservice. PR 516 moved cartservice build artifacts to one level down to src directory breaking automated builds.
- Special handling cart service with a if condition and appending src to build dir. 


Remaining issues / concerns:
None afaik.