### PR TITLE
chore: delete the redundant shebang in genproto.sh

### DIFF
--- a/src/adservice/genproto.sh
+++ b/src/adservice/genproto.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash -e
-
 # protos are needed in adservice folder for compiling during Docker build.
 
 mkdir -p proto && \

--- a/src/emailservice/genproto.sh
+++ b/src/emailservice/genproto.sh
@@ -14,6 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash -e
-
 python -m grpc_tools.protoc -I../../pb --python_out=. --grpc_python_out=. ../../pb/demo.proto

--- a/src/frontend/genproto.sh
+++ b/src/frontend/genproto.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash -e
-
 PATH=$PATH:$GOPATH/bin
 protodir=../../pb
 

--- a/src/productcatalogservice/genproto.sh
+++ b/src/productcatalogservice/genproto.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash -e
-
 PATH=$PATH:$GOPATH/bin
 protodir=../../pb
 

--- a/src/recommendationservice/genproto.sh
+++ b/src/recommendationservice/genproto.sh
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
-set -e
-
 # script to compile python protos
 #
 # requires gRPC tools:

--- a/src/shippingservice/genproto.sh
+++ b/src/shippingservice/genproto.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash -e
-
 PATH=$PATH:$GOPATH/bin
 protodir=../../pb
 


### PR DESCRIPTION
Delete the redundant shebang in genproto.sh