### PR TITLE
Fixing golang Dockerfiles to work with `skaffold debug`

### DIFF
--- a/src/checkoutservice/Dockerfile
+++ b/src/checkoutservice/Dockerfile
@@ -14,6 +14,7 @@
 
 FROM golang:1.15-alpine as builder
 RUN apk add --no-cache ca-certificates git
+RUN apk add build-base
 WORKDIR /src
 
 # restore dependencies
@@ -21,13 +22,23 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN go build -gcflags='-N -l' -o /checkoutservice .
+
+# Skaffold passes in debug-oriented compiler flags
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /checkoutservice .
 
 FROM alpine as release
 RUN apk add --no-cache ca-certificates
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.6 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
-COPY --from=builder /checkoutservice /checkoutservice
+WORKDIR /src
+COPY --from=builder /checkoutservice /src/checkoutservice
+
+# Definition of this variable is used by 'skaffold debug' to identify a golang binary.
+# Default behavior - a failure prints a stack trace for the current goroutine.
+# See https://golang.org/pkg/runtime/
+ENV GOTRACEBACK=single
+
 EXPOSE 5050
-ENTRYPOINT ["/checkoutservice"]
+ENTRYPOINT ["/src/checkoutservice"]

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -14,20 +14,30 @@
 
 FROM golang:1.15-alpine as builder
 RUN apk add --no-cache ca-certificates git
+RUN apk add build-base
 WORKDIR /src
 
 # restore dependencies
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go build -o /go/bin/frontend .
+
+# Skaffold passes in debug-oriented compiler flags
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /go/bin/frontend .
 
 FROM alpine as release
 RUN apk add --no-cache ca-certificates \
     busybox-extras net-tools bind-tools
-WORKDIR /frontend
-COPY --from=builder /go/bin/frontend /frontend/server
+WORKDIR /src
+COPY --from=builder /go/bin/frontend /src/server
 COPY ./templates ./templates
 COPY ./static ./static
+
+# Definition of this variable is used by 'skaffold debug' to identify a golang binary.
+# Default behavior - a failure prints a stack trace for the current goroutine.
+# See https://golang.org/pkg/runtime/
+ENV GOTRACEBACK=single
+
 EXPOSE 8080
-ENTRYPOINT ["/frontend/server"]
+ENTRYPOINT ["/src/server"]

--- a/src/productcatalogservice/Dockerfile
+++ b/src/productcatalogservice/Dockerfile
@@ -14,22 +14,32 @@
 
 FROM golang:1.15-alpine AS builder
 RUN apk add --no-cache ca-certificates git
+RUN apk add build-base
 
 WORKDIR /src
 # restore dependencies
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go build -o /productcatalogservice .
+
+# Skaffold passes in debug-oriented compiler flags
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /productcatalogservice .
 
 FROM alpine AS release
 RUN apk add --no-cache ca-certificates
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.6 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
-WORKDIR /productcatalogservice
+WORKDIR /src
 COPY --from=builder /productcatalogservice ./server
 COPY products.json .
+
+# Definition of this variable is used by 'skaffold debug' to identify a golang binary.
+# Default behavior - a failure prints a stack trace for the current goroutine.
+# See https://golang.org/pkg/runtime/
+ENV GOTRACEBACK=single
+
 EXPOSE 3550
-ENTRYPOINT ["/productcatalogservice/server"]
+ENTRYPOINT ["/src/server"]
 

--- a/src/shippingservice/Dockerfile
+++ b/src/shippingservice/Dockerfile
@@ -14,20 +14,31 @@
 
 FROM golang:1.15-alpine as builder
 RUN apk add --no-cache ca-certificates git
+RUN apk add build-base
 WORKDIR /src
 
 # restore dependencies
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go build -o /go/bin/shippingservice
+
+# Skaffold passes in debug-oriented compiler flags
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /go/bin/shippingservice .
 
 FROM alpine as release
 RUN apk add --no-cache ca-certificates
 RUN GRPC_HEALTH_PROBE_VERSION=v0.3.5 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe
-COPY --from=builder /go/bin/shippingservice /shippingservice
+WORKDIR /src
+COPY --from=builder /go/bin/shippingservice /src/shippingservice
 ENV APP_PORT=50051
+
+# Definition of this variable is used by 'skaffold debug' to identify a golang binary.
+# Default behavior - a failure prints a stack trace for the current goroutine.
+# See https://golang.org/pkg/runtime/
+ENV GOTRACEBACK=single
+
 EXPOSE 50051
-ENTRYPOINT ["/shippingservice"]
+ENTRYPOINT ["/src/shippingservice"]


### PR DESCRIPTION
Fixes #556.

Change summary:
- Allow skaffold to pass in `go build` flags
- Set environment variable skaffold looks for to detect go debug environment
- cleanup of the workdir for consistency in pathmapping.


Remaining issues / concerns:
