### PR TITLE
[Python] add generic exception catch on tracing setup

### DIFF
--- a/src/emailservice/email_server.py
+++ b/src/emailservice/email_server.py
@@ -193,7 +193,7 @@ if __name__ == '__main__':
         project_id=os.environ.get('GCP_PROJECT_ID'),
         transport=AsyncTransport)
       tracer_interceptor = server_interceptor.OpenCensusServerInterceptor(sampler, exporter)
-  except (KeyError, DefaultCredentialsError):
+  except (KeyError, DefaultCredentialsError, OSError):
       logger.info("Tracing disabled.")
       tracer_interceptor = server_interceptor.OpenCensusServerInterceptor()
 

--- a/src/emailservice/email_server.py
+++ b/src/emailservice/email_server.py
@@ -20,6 +20,7 @@ import os
 import sys
 import time
 import grpc
+import traceback
 from jinja2 import Environment, FileSystemLoader, select_autoescape, TemplateError
 from google.api_core.exceptions import GoogleAPICallError
 from google.auth.exceptions import DefaultCredentialsError
@@ -193,8 +194,11 @@ if __name__ == '__main__':
         project_id=os.environ.get('GCP_PROJECT_ID'),
         transport=AsyncTransport)
       tracer_interceptor = server_interceptor.OpenCensusServerInterceptor(sampler, exporter)
-  except (KeyError, DefaultCredentialsError, OSError):
+  except (KeyError, DefaultCredentialsError):
       logger.info("Tracing disabled.")
       tracer_interceptor = server_interceptor.OpenCensusServerInterceptor()
-
+  except Exception as e:
+      logger.warn(f"Exception on Cloud Trace setup: {traceback.format_exc()}, tracing disabled.") 
+      tracer_interceptor = server_interceptor.OpenCensusServerInterceptor()
+  
   start(dummy_mode = True)

--- a/src/recommendationservice/recommendation_server.py
+++ b/src/recommendationservice/recommendation_server.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
           project_id=os.environ.get('GCP_PROJECT_ID'),
           transport=AsyncTransport)
         tracer_interceptor = server_interceptor.OpenCensusServerInterceptor(sampler, exporter)
-    except (KeyError, DefaultCredentialsError):
+    except (KeyError, DefaultCredentialsError, OSError):
         logger.info("Tracing disabled.")
         tracer_interceptor = server_interceptor.OpenCensusServerInterceptor()
 

--- a/src/recommendationservice/recommendation_server.py
+++ b/src/recommendationservice/recommendation_server.py
@@ -112,11 +112,13 @@ if __name__ == "__main__":
           project_id=os.environ.get('GCP_PROJECT_ID'),
           transport=AsyncTransport)
         tracer_interceptor = server_interceptor.OpenCensusServerInterceptor(sampler, exporter)
-    except (KeyError, DefaultCredentialsError, OSError):
+    except (KeyError, DefaultCredentialsError):
         logger.info("Tracing disabled.")
         tracer_interceptor = server_interceptor.OpenCensusServerInterceptor()
-
-
+    except Exception as e:
+        logger.warn(f"Exception on Cloud Trace setup: {traceback.format_exc()}, tracing disabled.") 
+        tracer_interceptor = server_interceptor.OpenCensusServerInterceptor()
+   
     try:
       if "DISABLE_DEBUGGER" in os.environ:
         raise KeyError()


### PR DESCRIPTION
Related #563.

Change summary:
- Catch `OSError` when GCP credentials aremissing

When GCP credentials are missing, the client library seems to raise an `OSError` now which isn't being caught.

```
 - deployment/emailservice: container server terminated with exit code 1
    - pod/emailservice-6df7776944-t2brd: container server terminated with exit code 1
      > [emailservice-6df7776944-t2brd server] {"timestamp": 1624328682.6577306, "severity": "INFO", "name": "emailservice-server", "message": "starting the email service in dummy mode."}
      > [emailservice-6df7776944-t2brd server] {"timestamp": 1624328682.6580193, "severity": "INFO", "name": "emailservice-server", "message": "Profiler disabled."}
      > [emailservice-6df7776944-t2brd server] {"timestamp": 1624328682.6581447, "severity": "INFO", "name": "emailservice-server", "message": "Tracing enabled."}
      > [emailservice-6df7776944-t2brd server] /usr/local/lib/python3.7/site-packages/google/auth/_default.py:69: UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK without a quota project. You might receive a "quota exceeded" or "API not enabled" error. We recommend you rerun `gcloud auth application-default login` and make sure a quota project is added. Or you can use service accounts instead. For more information about service accounts, see https://cloud.google.com/docs/authentication/
      > [emailservice-6df7776944-t2brd server]   warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)
      > [emailservice-6df7776944-t2brd server] Traceback (most recent call last):
      > [emailservice-6df7776944-t2brd server]   File "email_server.py", line 194, in <module>
      > [emailservice-6df7776944-t2brd server]     transport=AsyncTransport)
      > [emailservice-6df7776944-t2brd server]   File "/usr/local/lib/python3.7/site-packages/opencensus/ext/stackdriver/trace_exporter/__init__.py", line 186, in __init__
      > [emailservice-6df7776944-t2brd server]     client = Client(project=project_id)
      > [emailservice-6df7776944-t2brd server]   File "/usr/local/lib/python3.7/site-packages/google/cloud/trace/client.py", line 62, in __init__
      > [emailservice-6df7776944-t2brd server]     super(Client, self).__init__(project=project, credentials=credentials)
      > [emailservice-6df7776944-t2brd server]   File "/usr/local/lib/python3.7/site-packages/google/cloud/client.py", line 249, in __init__
      > [emailservice-6df7776944-t2brd server]     _ClientProjectMixin.__init__(self, project=project)
      > [emailservice-6df7776944-t2brd server]   File "/usr/local/lib/python3.7/site-packages/google/cloud/client.py", line 204, in __init__
      > [emailservice-6df7776944-t2brd server]     "Project was not passed and could not be "
      > [emailservice-6df7776944-t2brd server] OSError: Project was not passed and could not be determined from the environment.
 ```
 
 Probably worth noting that I don't see how a `KeyError` would be raised here, and in several other places we're just catching all `Exception`s instead, which might be the better route here to catch potential failures like this.