### PR TITLE
Use DM Sans font

### DIFF
--- a/src/emailservice/templates/confirmation.html
+++ b/src/emailservice/templates/confirmation.html
@@ -18,11 +18,11 @@
 <html>
   <head>
     <title>Your Order Confirmation</title>
-    <link href="https://fonts.googleapis.com/css?family=Roboto:100,400,500" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
   </head>
   <style>
     body{
-      font-family: 'Roboto', sans-serif;
+      font-family: 'DM Sans', sans-serif;
     }
   </style>
   <body>

--- a/src/frontend/static/styles/styles.css
+++ b/src/frontend/static/styles/styles.css
@@ -22,7 +22,7 @@ html, body {
 
 body {
   color: #111111;
-  font-family: 'Roboto', sans-serif;
+  font-family: 'DM Sans', sans-serif;
   display: flex;
   flex-direction: column;
 }

--- a/src/frontend/templates/header.html
+++ b/src/frontend/templates/header.html
@@ -25,7 +25,9 @@
     <title>Online Boutique</title>
     <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB"
         crossorigin="anonymous">
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="/static/styles/styles.css">
     <link rel="stylesheet" type="text/css" href="/static/styles/cart.css">
     <link rel="stylesheet" type="text/css" href="/static/styles/order.css">


### PR DESCRIPTION
This is part of #574.

Change summary:
* Update the font from 'Roboto' to 'DM Sans' (the font used for Cymbal designs).
* This updates both the `emailservice` and the`frontend`.
* We use [`<link rel="preconnect" ... >`](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preconnect) as it was suggested by [Google Font](https://fonts.google.com/specimen/DM+Sans?query=Dm#standard-styles).
* We only import font weights 400 (default) and 700 (bold) from [Google Fonts](https://fonts.google.com/specimen/DM+Sans?query=Dm#standard-styles) because we don't use 500.

Remaining issues / concerns: 
* This is the first step of #574. We still have to make a whole bunch of UI changes.
