### PR TITLE
Use skaffold modules & update relevant docs

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -6,7 +6,7 @@ This doc explains how to build and run the OnlineBoutique source code locally us
 
 - [Docker for Desktop](https://www.docker.com/products/docker-desktop).
 - kubectl (can be installed via `gcloud components install kubectl`)
-- [skaffold]( https://skaffold.dev/docs/install/), a tool that builds and deploys Docker images in bulk. 
+- [skaffold **1.27+**](https://skaffold.dev/docs/install/) (latest version recommended), a tool that builds and deploys Docker images in bulk. 
 - A Google Cloud Project with Google Container Registry enabled. 
 - Enable GCP APIs for Cloud Monitoring, Tracing, Debugger, Profiler:
 ```

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v2beta1
+apiVersion: skaffold/v2beta18
 kind: Config
+metadata:
+  name: app
 build:
   artifacts:
   # image tags are relative; to specify an image repo (e.g. GCR), you
@@ -40,8 +42,6 @@ build:
       dockerfile: Dockerfile
   - image: frontend
     context: src/frontend
-  - image: loadgenerator
-    context: src/loadgenerator
   - image: adservice
     context: src/adservice
   tagPolicy:
@@ -51,7 +51,17 @@ build:
 deploy:
   kubectl:
     manifests:
-    - ./kubernetes-manifests/**.yaml
+    - ./kubernetes-manifests/adservice.yaml
+    - ./kubernetes-manifests/cartservice.yaml
+    - ./kubernetes-manifests/checkoutservice.yaml
+    - ./kubernetes-manifests/currencyservice.yaml
+    - ./kubernetes-manifests/emailservice.yaml
+    - ./kubernetes-manifests/frontend.yaml
+    - ./kubernetes-manifests/paymentservice.yaml
+    - ./kubernetes-manifests/productcatalogservice.yaml
+    - ./kubernetes-manifests/recommendationservice.yaml
+    - ./kubernetes-manifests/redis.yaml
+    - ./kubernetes-manifests/shippingservice.yaml
 profiles:
 # "gcb" profile allows building and pushing the images
 # on Google Container Builder without requiring docker
@@ -78,3 +88,20 @@ profiles:
     - op: replace
       path: /build/artifacts/7/docker/dockerfile
       value: Dockerfile.debug
+
+---
+
+apiVersion: skaffold/v2beta18
+kind: Config
+metadata:
+  name: loadgenerator
+requires:
+  - configs: [app]
+build:
+  artifacts:
+  - image: loadgenerator
+    context: src/loadgenerator
+deploy:
+  kubectl:
+    manifests:
+    - ./kubernetes-manifests/loadgenerator.yaml


### PR DESCRIPTION
Fixes #492.

**Change summary:**
This pull-request:
- splits the existing contents of `skaffold.yaml` into two modules: `app`; and `loadgenerator`.
  - We can now run something like `skaffold run ... --module=app` to run this sample app without the loadbalancer.
- updates docs accordingly (see [this comment from Bank of Anthos](https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/514#pullrequestreview-713779181) that confirms that we need skaffold 1.27+).

**Additional Notes**
- Running `skaffold run` or `skaffold dev` will still behave the same as it did before (i.e., run all microservices).
- Unlike [with Bank of Anthos](https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/514), we don't have modules for `backend`, `frontend`, `setup`, and `db`.
  - The reason: I don't imagine anyone wanting to run _just_ the front-end or _just_ the back-end (for this sample app). But I do imagine someone wanting to run this sample app without the `loadbalancer`.
  - Plus, I think we only really need 2 modules to showcase this skaffold feature.
  - I am very open to changing this, so please provide suggestions. :)
 
**Tested 👍**
I have tested the following commands and things work as expected:
* `skaffold run --default-repo=gcr.io/nimjay-microservices-demo`
* `skaffold run --default-repo=gcr.io/nimjay-microservices-demo --module=app`
* `skaffold run --default-repo=gcr.io/nimjay-microservices-demo --module=loadgenerator`

**Failing Check** ⚠️
A pull-request Check is currently failing because I have yet to upgrade the version of `skaffold` on our virtual machines (similar [to Bank of Anthos](https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/514#issuecomment-883461431)).