### PR TITLE
Specify Python version in Node.js services

### DIFF
--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -19,7 +19,7 @@ FROM base as builder
 # Some packages (e.g. @google-cloud/profiler) require additional
 # deps for post-install scripts
 RUN apk add --update --no-cache \
-    python \
+    python2 \
     make \
     g++
 

--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -19,7 +19,7 @@ FROM base as builder
 # Some packages (e.g. @google-cloud/profiler) require additional
 # deps for post-install scripts
 RUN apk add --update --no-cache \
-    python2 \
+    python3 \
     make \
     g++
 

--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -19,7 +19,7 @@ FROM base as builder
 # Some packages (e.g. @google-cloud/profiler) require additional
 # deps for post-install scripts
 RUN apk add --update --no-cache \
-    python \
+    python2 \
     make \
     g++ 
 

--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -19,7 +19,7 @@ FROM base as builder
 # Some packages (e.g. @google-cloud/profiler) require additional
 # deps for post-install scripts
 RUN apk add --update --no-cache \
-    python2 \
+    python3 \
     make \
     g++ 
 


### PR DESCRIPTION
Fixes # .

Change summary:
- 
Was getting the following error when building locally:

    Step 2/13 : FROM base as builder
     ---> f534e2bb4a44
    Step 3/13 : RUN apk add --update --no-cache     python     make     g++
     ---> Running in 7f14a56197d5
    fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
    fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
    ERROR: unable to select packages:
      python (no such package):
        required by: world[python]
    Building [adservice]...
    Canceled build for adservice
    Building [paymentservice]...
    Canceled build for paymentservice
    Building [recommendationservice]...
    Canceled build for recommendationservice
    Building [shippingservice]...
    Canceled build for shippingservice
    Building [productcatalogservice]...
    Canceled build for productcatalogservice
    Building [checkoutservice]...
    Canceled build for checkoutservice
    Building [emailservice]...
    Canceled build for emailservice
    Building [frontend]...
    Canceled build for frontend
    unable to stream build output: The command '/bin/sh -c apk add --update --no-cache     python     make     g++' returned a non-zero code: 1. Please fix the Dockerfile and try again..

Found the solution here: https://github.com/nodejs/docker-node/issues/1605, then updated the Dockerfiles for Currencyservice and Paymentservice (the two NodeJS based services) accordingly. 

Remaining issues / concerns:
May want to update from Node:12 in the future. As a first time contributor I'm not going to try pushing that but it may be smart going forward.