### PR TITLE
Specify python version in Node.js Dockerfiles

### DIFF
--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -19,7 +19,7 @@ FROM base as builder
 # Some packages (e.g. @google-cloud/profiler) require additional
 # deps for post-install scripts
 RUN apk add --update --no-cache \
-    python \
+    python3 \
     make \
     g++
 

--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -19,7 +19,7 @@ FROM base as builder
 # Some packages (e.g. @google-cloud/profiler) require additional
 # deps for post-install scripts
 RUN apk add --update --no-cache \
-    python \
+    python3 \
     make \
     g++ 
 


### PR DESCRIPTION
Fixes #619.

## Background
* `docker build`-ing of the Node.js microservices is currently broken:
```
#7 0.678 ERROR: unable to select packages:
#7 0.720   python (no such package):
#7 0.720     required by: world[python]
```
* Affected microservices: `paymentservice`; and `currencyservice`.
* Both services use base image `FROM node:12-alpine` and install `python` using `apk add ...`.
* But according to this [StackOverflow](https://stackoverflow.com/a/69860236), `python` is just an alias, and we need to now specify the exact version when using `apk add ...`.

## Change Summary
* We specify the version of `python` being installed, `python3`.

## Additional Concerns
* I have manually tested and everything worked fine. 👍 
  * I played around with a deployment (e.g., checked out a cart full of products) on my own GKE cluster.
  * I was able to `docker build`.
* It looks like Node.js Cloud Profiling is broken anyway, so we will need to address that later.
  * See #620.
* The reason for downloading `python` in the Dockerfiles is unclear:
  * https://github.com/GoogleCloudPlatform/microservices-demo/blob/884439c7437cab8d66da4657d8043278e01c33dc/src/currencyservice/Dockerfile#L19 
  * Is it for `@google-cloud/profiler`? Is it still required?