### PR TITLE
Adding env var to display configurable text indicating location.

### DIFF
--- a/src/frontend/handlers.go
+++ b/src/frontend/handlers.go
@@ -86,6 +86,8 @@ func (fe *frontendServer) homeHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Set ENV_PLATFORM (default to local if not set; use env var if set; otherwise detect GCP, which overrides env)_
 	var env = os.Getenv("ENV_PLATFORM")
+	// Set ENV_REGION (default to empty if not set; use env var if set)_
+	var envRegion = os.Getenv("ENV_REGION")
 	// Only override from env variable if set + valid env
 	if env == "" || stringinSlice(validEnvs, env) == false {
 		fmt.Println("env platform is either empty or invalid")
@@ -115,6 +117,7 @@ func (fe *frontendServer) homeHandler(w http.ResponseWriter, r *http.Request) {
 		"platform_css":    plat.css,
 		"platform_name":   plat.provider,
 		"is_cymbal_brand": isCymbalBrand,
+		"env_region":      envRegion,
 	}); err != nil {
 		log.Error(err)
 	}

--- a/src/frontend/static/styles/styles.css
+++ b/src/frontend/static/styles/styles.css
@@ -519,7 +519,7 @@ similar to that of the hot-products-row.
   top: 98px;
   left: 0;
   width: 190px;
-  height: 50px;
+  height: 100px;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/frontend/templates/home.html
+++ b/src/frontend/templates/home.html
@@ -20,6 +20,7 @@
 <div {{ with $.platform_css }} class="{{.}}" {{ end }}>
   <span class="platform-flag">
     {{$.platform_name}}
+    {{$.env_region}}
   </span>
 </div>
 <main role="main" class="home">


### PR DESCRIPTION
Fixes #628 .

Change summary: Added ENV_REGION environment variable for user to specify the location of the Frontend instance in the deployment specification. Added UI field and increased the size of the platform-flag banner to account for the additional field.

- 


Remaining issues / concerns:
