### PR TITLE
bug: update the dotnet version in the master branch ci workflow

### DIFF
--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.201'
+        dotnet-version: '6.0.100'
     - name: Go Unit Tests
       timeout-minutes: 10
       run: |


### PR DESCRIPTION
### Fixes .

### Issue
- PR #629 updated the .NET version on cart-service
- It also updated the [github actions workflow](https://github.com/GoogleCloudPlatform/microservices-demo/blob/master/.github/workflows/ci-pr.yaml#L30) to use the latest `dotnet-sdk`
- However, it missed to update the same in the [GH actions workflow for the master branch](https://github.com/GoogleCloudPlatform/microservices-demo/blob/master/.github/workflows/ci-master.yaml#L29)

### Change summary:
- Update the master branch GH actions workflow file to use the latest .NET SDK

### Related issues/PRs:
- #629 