### PR TITLE
improvement: add cluster, pod and zonal details to the page footer

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -89,19 +89,19 @@ profiles:
       path: /build/artifacts/7/docker/dockerfile
       value: Dockerfile.debug
 
-# ---
+---
 
-# apiVersion: skaffold/v2beta18
-# kind: Config
-# metadata:
-#   name: loadgenerator
-# requires:
-#   - configs: [app]
-# build:
-#   artifacts:
-#   - image: loadgenerator
-#     context: src/loadgenerator
-# deploy:
-#   kubectl:
-#     manifests:
-#     - ./kubernetes-manifests/loadgenerator.yaml
+apiVersion: skaffold/v2beta18
+kind: Config
+metadata:
+  name: loadgenerator
+requires:
+  - configs: [app]
+build:
+  artifacts:
+  - image: loadgenerator
+    context: src/loadgenerator
+deploy:
+  kubectl:
+    manifests:
+    - ./kubernetes-manifests/loadgenerator.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -89,19 +89,19 @@ profiles:
       path: /build/artifacts/7/docker/dockerfile
       value: Dockerfile.debug
 
----
+# ---
 
-apiVersion: skaffold/v2beta18
-kind: Config
-metadata:
-  name: loadgenerator
-requires:
-  - configs: [app]
-build:
-  artifacts:
-  - image: loadgenerator
-    context: src/loadgenerator
-deploy:
-  kubectl:
-    manifests:
-    - ./kubernetes-manifests/loadgenerator.yaml
+# apiVersion: skaffold/v2beta18
+# kind: Config
+# metadata:
+#   name: loadgenerator
+# requires:
+#   - configs: [app]
+# build:
+#   artifacts:
+#   - image: loadgenerator
+#     context: src/loadgenerator
+# deploy:
+#   kubectl:
+#     manifests:
+#     - ./kubernetes-manifests/loadgenerator.yaml

--- a/src/frontend/handlers.go
+++ b/src/frontend/handlers.go
@@ -41,13 +41,9 @@ type platformDetails struct {
 }
 
 var (
-	ZONE                 string = "ZONE"
-	HOSTNAME             string = "HOSTNAME"
-	CLUSTERNAME          string = "CLUSTERNAME"
-	METADATA_CLUSTERNAME string = "cluster-name"
-	isCymbalBrand               = "true" == strings.ToLower(os.Getenv("CYMBAL_BRANDING"))
-	templates                   = template.Must(template.New("").
-				Funcs(template.FuncMap{
+	isCymbalBrand = "true" == strings.ToLower(os.Getenv("CYMBAL_BRANDING"))
+	templates     = template.Must(template.New("").
+			Funcs(template.FuncMap{
 			"renderMoney":        renderMoney,
 			"renderCurrencyLogo": renderCurrencyLogo,
 		}).ParseGlob("templates/*.html"))
@@ -106,24 +102,21 @@ func (fe *frontendServer) homeHandler(w http.ResponseWriter, r *http.Request) {
 	log.Debugf("ENV_PLATFORM is: %s", env)
 	plat = platformDetails{}
 	plat.setPlatformDetails(strings.ToLower(env))
-	deploymentDetails := getDeploymentDetails(r)
 
 	if err := templates.ExecuteTemplate(w, "home", map[string]interface{}{
-		"session_id":      sessionID(r),
-		"request_id":      r.Context().Value(ctxKeyRequestID{}),
-		"user_currency":   currentCurrency(r),
-		"show_currency":   true,
-		"currencies":      currencies,
-		"products":        ps,
-		"cart_size":       cartSize(cart),
-		"banner_color":    os.Getenv("BANNER_COLOR"), // illustrates canary deployments
-		"ad":              fe.chooseAd(r.Context(), []string{}, log),
-		"platform_css":    plat.css,
-		"platform_name":   plat.provider,
-		"is_cymbal_brand": isCymbalBrand,
-		"cluster":         deploymentDetails[CLUSTERNAME],
-		"zone":            deploymentDetails[ZONE],
-		"pod":             deploymentDetails[HOSTNAME],
+		"session_id":        sessionID(r),
+		"request_id":        r.Context().Value(ctxKeyRequestID{}),
+		"user_currency":     currentCurrency(r),
+		"show_currency":     true,
+		"currencies":        currencies,
+		"products":          ps,
+		"cart_size":         cartSize(cart),
+		"banner_color":      os.Getenv("BANNER_COLOR"), // illustrates canary deployments
+		"ad":                fe.chooseAd(r.Context(), []string{}, log),
+		"platform_css":      plat.css,
+		"platform_name":     plat.provider,
+		"is_cymbal_brand":   isCymbalBrand,
+		"deploymentDetails": getDeploymentDetails(r),
 	}); err != nil {
 		log.Error(err)
 	}
@@ -194,24 +187,21 @@ func (fe *frontendServer) productHandler(w http.ResponseWriter, r *http.Request)
 		Item  *pb.Product
 		Price *pb.Money
 	}{p, price}
-	deploymentDetails := getDeploymentDetails(r)
 
 	if err := templates.ExecuteTemplate(w, "product", map[string]interface{}{
-		"session_id":      sessionID(r),
-		"request_id":      r.Context().Value(ctxKeyRequestID{}),
-		"ad":              fe.chooseAd(r.Context(), p.Categories, log),
-		"user_currency":   currentCurrency(r),
-		"show_currency":   true,
-		"currencies":      currencies,
-		"product":         product,
-		"recommendations": recommendations,
-		"cart_size":       cartSize(cart),
-		"platform_css":    plat.css,
-		"platform_name":   plat.provider,
-		"is_cymbal_brand": isCymbalBrand,
-		"cluster":         deploymentDetails[CLUSTERNAME],
-		"zone":            deploymentDetails[ZONE],
-		"pod":             deploymentDetails[HOSTNAME],
+		"session_id":        sessionID(r),
+		"request_id":        r.Context().Value(ctxKeyRequestID{}),
+		"ad":                fe.chooseAd(r.Context(), p.Categories, log),
+		"user_currency":     currentCurrency(r),
+		"show_currency":     true,
+		"currencies":        currencies,
+		"product":           product,
+		"recommendations":   recommendations,
+		"cart_size":         cartSize(cart),
+		"platform_css":      plat.css,
+		"platform_name":     plat.provider,
+		"is_cymbal_brand":   isCymbalBrand,
+		"deploymentDetails": getDeploymentDetails(r),
 	}); err != nil {
 		log.Println(err)
 	}
@@ -307,26 +297,23 @@ func (fe *frontendServer) viewCartHandler(w http.ResponseWriter, r *http.Request
 	}
 	totalPrice = money.Must(money.Sum(totalPrice, *shippingCost))
 	year := time.Now().Year()
-	deploymentDetails := getDeploymentDetails(r)
 
 	if err := templates.ExecuteTemplate(w, "cart", map[string]interface{}{
-		"session_id":       sessionID(r),
-		"request_id":       r.Context().Value(ctxKeyRequestID{}),
-		"user_currency":    currentCurrency(r),
-		"currencies":       currencies,
-		"recommendations":  recommendations,
-		"cart_size":        cartSize(cart),
-		"shipping_cost":    shippingCost,
-		"show_currency":    true,
-		"total_cost":       totalPrice,
-		"items":            items,
-		"expiration_years": []int{year, year + 1, year + 2, year + 3, year + 4},
-		"platform_css":     plat.css,
-		"platform_name":    plat.provider,
-		"is_cymbal_brand":  isCymbalBrand,
-		"cluster":          deploymentDetails[CLUSTERNAME],
-		"zone":             deploymentDetails[ZONE],
-		"pod":              deploymentDetails[HOSTNAME],
+		"session_id":        sessionID(r),
+		"request_id":        r.Context().Value(ctxKeyRequestID{}),
+		"user_currency":     currentCurrency(r),
+		"currencies":        currencies,
+		"recommendations":   recommendations,
+		"cart_size":         cartSize(cart),
+		"shipping_cost":     shippingCost,
+		"show_currency":     true,
+		"total_cost":        totalPrice,
+		"items":             items,
+		"expiration_years":  []int{year, year + 1, year + 2, year + 3, year + 4},
+		"platform_css":      plat.css,
+		"platform_name":     plat.provider,
+		"is_cymbal_brand":   isCymbalBrand,
+		"deploymentDetails": getDeploymentDetails(r),
 	}); err != nil {
 		log.Println(err)
 	}
@@ -386,23 +373,20 @@ func (fe *frontendServer) placeOrderHandler(w http.ResponseWriter, r *http.Reque
 		renderHTTPError(log, r, w, errors.Wrap(err, "could not retrieve currencies"), http.StatusInternalServerError)
 		return
 	}
-	deploymentDetails := getDeploymentDetails(r)
 
 	if err := templates.ExecuteTemplate(w, "order", map[string]interface{}{
-		"session_id":      sessionID(r),
-		"request_id":      r.Context().Value(ctxKeyRequestID{}),
-		"user_currency":   currentCurrency(r),
-		"show_currency":   false,
-		"currencies":      currencies,
-		"order":           order.GetOrder(),
-		"total_paid":      &totalPaid,
-		"recommendations": recommendations,
-		"platform_css":    plat.css,
-		"platform_name":   plat.provider,
-		"is_cymbal_brand": isCymbalBrand,
-		"cluster":         deploymentDetails[CLUSTERNAME],
-		"zone":            deploymentDetails[ZONE],
-		"pod":             deploymentDetails[HOSTNAME],
+		"session_id":        sessionID(r),
+		"request_id":        r.Context().Value(ctxKeyRequestID{}),
+		"user_currency":     currentCurrency(r),
+		"show_currency":     false,
+		"currencies":        currencies,
+		"order":             order.GetOrder(),
+		"total_paid":        &totalPaid,
+		"recommendations":   recommendations,
+		"platform_css":      plat.css,
+		"platform_name":     plat.provider,
+		"is_cymbal_brand":   isCymbalBrand,
+		"deploymentDetails": getDeploymentDetails(r),
 	}); err != nil {
 		log.Println(err)
 	}
@@ -457,17 +441,14 @@ func renderHTTPError(log logrus.FieldLogger, r *http.Request, w http.ResponseWri
 	errMsg := fmt.Sprintf("%+v", err)
 
 	w.WriteHeader(code)
-	deploymentDetails := getDeploymentDetails(r)
 
 	if templateErr := templates.ExecuteTemplate(w, "error", map[string]interface{}{
-		"session_id":  sessionID(r),
-		"request_id":  r.Context().Value(ctxKeyRequestID{}),
-		"error":       errMsg,
-		"status_code": code,
-		"status":      http.StatusText(code),
-		"cluster":     deploymentDetails[CLUSTERNAME],
-		"zone":        deploymentDetails[ZONE],
-		"pod":         deploymentDetails[HOSTNAME],
+		"session_id":        sessionID(r),
+		"request_id":        r.Context().Value(ctxKeyRequestID{}),
+		"error":             errMsg,
+		"status_code":       code,
+		"status":            http.StatusText(code),
+		"deploymentDetails": getDeploymentDetails(r),
 	}); templateErr != nil {
 		log.Println(templateErr)
 	}
@@ -547,7 +528,7 @@ func getDeploymentDetails(httpRequest *http.Request) map[string]string {
 		log.Error("Failed to fetch the hostname for the Pod", err)
 	}
 
-	podCluster, err := metaServerClient.InstanceAttributeValue(METADATA_CLUSTERNAME)
+	podCluster, err := metaServerClient.InstanceAttributeValue("cluster-name")
 	if err != nil {
 		log.Error("Failed to fetch the name of the cluster in which the pod is running", err)
 	}
@@ -557,9 +538,9 @@ func getDeploymentDetails(httpRequest *http.Request) map[string]string {
 		log.Error("Failed to fetch the Zone of the node where the pod is scheduled", err)
 	}
 
-	deploymentDetailsMap[HOSTNAME] = podHostname
-	deploymentDetailsMap[CLUSTERNAME] = podCluster
-	deploymentDetailsMap[ZONE] = podZone
+	deploymentDetailsMap["HOSTNAME"] = podHostname
+	deploymentDetailsMap["CLUSTERNAME"] = podCluster
+	deploymentDetailsMap["ZONE"] = podZone
 
 	log.WithFields(logrus.Fields{
 		"cluster":  podCluster,

--- a/src/frontend/templates/footer.html
+++ b/src/frontend/templates/footer.html
@@ -26,7 +26,7 @@
                     {{ if $.session_id }}session-id: {{ $.session_id }} — {{end}}
                     {{ if $.request_id }}request-id: {{ $.request_id }}{{end}}
                 </small>
-                </br>
+                <br/>
                 <small>
                     {{ if $.deploymentDetails }}
                     <b>Cluster: </b>{{index .deploymentDetails "CLUSTERNAME" }}<br/>

--- a/src/frontend/templates/footer.html
+++ b/src/frontend/templates/footer.html
@@ -28,9 +28,11 @@
                 </small>
                 </br>
                 <small>
-                    {{ if $.cluster }}<b>Cluster: </b>: {{ $.cluster }} {{end}}</br>
-                    {{ if $.zone }}<b>Zone: </b>: {{ $.zone }} {{end}}</br>
-                    {{ if $.pod }}<b>Pod: </b>: {{ $.pod }} {{end}}</br>
+                    {{ if $.deploymentDetails }}
+                    <b>Cluster: </b>{{index .deploymentDetails "CLUSTERNAME" }}</br>
+                    <b>Zone: </b>{{index .deploymentDetails "ZONE" }}</br>
+                    <b>Pod: </b>{{index .deploymentDetails "HOSTNAME" }}
+                    {{ end }}
                 </small>
             </p>
         </div>

--- a/src/frontend/templates/footer.html
+++ b/src/frontend/templates/footer.html
@@ -26,6 +26,12 @@
                     {{ if $.session_id }}session-id: {{ $.session_id }} — {{end}}
                     {{ if $.request_id }}request-id: {{ $.request_id }}{{end}}
                 </small>
+                </br>
+                <small>
+                    {{ if $.cluster }}<b>Cluster: </b>: {{ $.cluster }} {{end}}</br>
+                    {{ if $.zone }}<b>Zone: </b>: {{ $.zone }} {{end}}</br>
+                    {{ if $.pod }}<b>Pod: </b>: {{ $.pod }} {{end}}</br>
+                </small>
             </p>
         </div>
     </div>

--- a/src/frontend/templates/footer.html
+++ b/src/frontend/templates/footer.html
@@ -29,8 +29,8 @@
                 </br>
                 <small>
                     {{ if $.deploymentDetails }}
-                    <b>Cluster: </b>{{index .deploymentDetails "CLUSTERNAME" }}</br>
-                    <b>Zone: </b>{{index .deploymentDetails "ZONE" }}</br>
+                    <b>Cluster: </b>{{index .deploymentDetails "CLUSTERNAME" }}<br/>
+                    <b>Zone: </b>{{index .deploymentDetails "ZONE" }}<br/>
                     <b>Pod: </b>{{index .deploymentDetails "HOSTNAME" }}
                     {{ end }}
                 </small>


### PR DESCRIPTION
### Background 
- It was requested that we show the pod placement details like - **Cluster, Zone, Hostname of Pod** - in the pages of the Online Boutique just like how we have with [Bank of Anthos](bank-of-anthos.xyz). This is mainly for demos which include multi cluster setups - so we can see that different clusters and regional pods are responding to requests from different locations.

### Fixes #628 #631 

### Change Summary
- Add a new utility method in the handlers package to get the deployment details
- Use the `cloud.google.com/go/compute/metadata` package to retreive the `Zone` and `Clustername` information
- Use the `os.hostname()` function to get the Pod name
- Use the utility method in all the places where the template rendering is called
- Update the `footer` template to include the deployment details

### Additional Notes
- N/A

### Testing Procedure
- Navigate to all the pages of the staged website to see if you see the details
- Verify that those details match the ones on the Google Cloud Console
- Check if there are any errors in the staged (or your own deployment)
- **Stretch test** - Check if you can setup a [multi cluster setup like explained for Bank of Anthos](https://github.com/GoogleCloudPlatform/bank-of-anthos/tree/master/extras/cloudsql-multicluster), and accessing the website from two VMs located in different regions (or via a VPN) and if the deployment details are different.

### Related PRs or Issues #628 #631 

![image](https://user-images.githubusercontent.com/7249208/143497016-d2a17e7b-ca81-4135-b5fe-7170b9632f22.png)
