### PR TITLE
cleanup: update pr cluster in actions workflow

### DIFF
--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -70,7 +70,7 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PROJECT_ID: "onlineboutique-ci"
-        PR_CLUSTER: "online-boutique-pr-v2"
+        PR_CLUSTER: "onlineboutique-pr-v2"
         ZONE: "us-east1-b"
     - name: Wait For Pods
       timeout-minutes: 20

--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -70,7 +70,7 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PROJECT_ID: "onlineboutique-ci"
-        PR_CLUSTER: "online-boutique-pr"
+        PR_CLUSTER: "online-boutique-pr-v2"
         ZONE: "us-east1-b"
     - name: Wait For Pods
       timeout-minutes: 20

--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -71,7 +71,7 @@ jobs:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PROJECT_ID: "onlineboutique-ci"
         PR_CLUSTER: "onlineboutique-pr-v2"
-        ZONE: "us-east1-b"
+        ZONE: "us-west1-a"
     - name: Wait For Pods
       timeout-minutes: 20
       run: |

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -73,7 +73,7 @@ jobs:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PR_NUMBER: ${{ github.event.pull_request.number }}
         PROJECT_ID: "onlineboutique-ci"
-        PR_CLUSTER: "online-boutique-pr"
+        PR_CLUSTER: "online-boutique-pr-v2"
         ZONE: "us-east1-b"
     - name: Wait For Pods
       timeout-minutes: 20

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -73,7 +73,7 @@ jobs:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PR_NUMBER: ${{ github.event.pull_request.number }}
         PROJECT_ID: "onlineboutique-ci"
-        PR_CLUSTER: "online-boutique-pr-v2"
+        PR_CLUSTER: "onlineboutique-pr-v2"
         ZONE: "us-east1-b"
     - name: Wait For Pods
       timeout-minutes: 20

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -74,7 +74,7 @@ jobs:
         PR_NUMBER: ${{ github.event.pull_request.number }}
         PROJECT_ID: "onlineboutique-ci"
         PR_CLUSTER: "onlineboutique-pr-v2"
-        ZONE: "us-east1-b"
+        ZONE: "us-west1-a"
     - name: Wait For Pods
       timeout-minutes: 20
       run: |

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -37,6 +37,6 @@ jobs:
           kubectl delete namespace $NAMESPACE
         env:
           PROJECT_ID: "onlineboutique-ci"
-          PR_CLUSTER: "online-boutique-pr"
-          ZONE: "us-east1-b"
+          PR_CLUSTER: "onlineboutique-pr-v2"
+          ZONE: "us-west1-a"
           PR_NUMBER: ${{ github.event.number }}

--- a/src/currencyservice/server.js
+++ b/src/currencyservice/server.js
@@ -22,7 +22,7 @@ else {
   require('@google-cloud/profiler').start({
     serviceContext: {
       service: 'currencyservice',
-      version: '1.0.0'
+      version: 'v0.3.1'
     }
   });
 }
@@ -44,7 +44,7 @@ else {
   require('@google-cloud/debug-agent').start({
     serviceContext: {
       service: 'currencyservice',
-      version: 'VERSION'
+      version: 'v0.3.1'
     }
   });
 }


### PR DESCRIPTION
### Fixes (Not) #538 

#### EDIT
- This does not eradicate the memory issue in #538. It addresses one problem identified whilst debugging for the memory issue which is that the applications missing auth scopes to access the Debugger API. See [comment here](https://github.com/GoogleCloudPlatform/microservices-demo/issues/538#issuecomment-981754337).

### Background 
- The memory issue was actual caused by the `google-cloud/debug` library. 
- The library was failing to authenticate to the GCP API due to insufficient permissions
- As a result the retry loop held up a lot of space which takes a while for the NodeJS Garbage Collector to free up
- Thus, giving the appropriate access scopes to connect to the Debug API prevents the auth errors and thus the retry loop which took up a lot of memory. 

### Change Summary
- Create a new cluster for the PRs `online-boutique-pr-v2` with the **auth-scopes** `https://www.googleapis.com/auth/cloud_debugger,gke-default` 
- Update the PR CI workflows to use the new cluster

### Additional Notes
- See comments and discussion in the issue #538 

### Testing Procedure
- The CI pipeline for this PR should pass
- Check the memory usage of `currencyservice` and `paymentsservice` to validate
  - There is no `ERROR` logs related to `insufficient access scopes`
  - There is no linear growth of memory consumption resulting in the services being killed 

### Related PRs or Issues 
- N/A

**_Noticeable slow down with memory growth:_**

![image](https://user-images.githubusercontent.com/7249208/143897694-4f2dbbf8-5f65-4434-8d36-35a82592eca1.png)

