### PR TITLE
Bump `Grpc.AspNetCore` and `Grpc.Net.Client` from 2.41.0-pre1 to 2.41.0

### DIFF
--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.41.0-pre1" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.41.0" />
     <PackageReference Include="Grpc.HealthCheck" Version="2.42.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.2.88" />
   </ItemGroup>


### PR DESCRIPTION
Fix https://github.com/GoogleCloudPlatform/microservices-demo/issues/632