### PR TITLE
Upgrade log4j from 2.13.3 to 2.15.0

### DIFF
--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -45,7 +45,7 @@ dependencies {
                 "io.grpc:grpc-stub:${grpcVersion}",
                 "io.grpc:grpc-netty:${grpcVersion}",
                 "io.grpc:grpc-services:${grpcVersion}",
-                "org.apache.logging.log4j:log4j-core:2.13.3"
+                "org.apache.logging.log4j:log4j-core:2.15.0"
 
         runtimeOnly "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
                 "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}",


### PR DESCRIPTION
### Background 

* See https://github.com/GoogleCloudPlatform/microservices-demo/issues/655.
* According to [Apache docs](https://logging.apache.org/log4j/2.x/security.html), this is fixed in log4j `2.15.0`. 

### Fixes  #655

### Change Summary

We're just updating log4j from `2.13.3` to `2.15.0`.

### Additional Notes

N/A

### Testing Procedure

* As a reviewer, I think we just need to make sure logging still works in the `adservice` microservice.
* Creation of GKE clusters in our PR checks/CI is currently broken, so a staging URL will not be generated for this pull-request.

### Related PRs or Issues 

We've addressed this same issue in Bank of Anthos. See https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/544.
