### PR TITLE
Migrate to new GitHub Action Runners & GKE PR Cluster

### DIFF
--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -69,9 +69,9 @@ jobs:
         skaffold run --default-repo=gcr.io/$PROJECT_ID/$GITHUB_REF --tag=$GITHUB_SHA --namespace=$NAMESPACE
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-        PROJECT_ID: "onlineboutique-ci"
-        PR_CLUSTER: "online-boutique-pr"
-        ZONE: "us-east1-b"
+        PROJECT_ID: "online-boutique-ci"
+        PR_CLUSTER: "online-boutique-prs"
+        ZONE: "us-central1-c"
     - name: Wait For Pods
       timeout-minutes: 20
       run: |

--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -21,7 +21,7 @@ on:
       - release/*
 jobs:
   code-tests:
-    runs-on: self-hosted
+    runs-on: [self-hosted, is-enabled]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
@@ -41,7 +41,7 @@ jobs:
       run: |
         dotnet test src/cartservice/
   deployment-tests:
-    runs-on: self-hosted
+    runs-on: [self-hosted, is-enabled]
     needs: code-tests
     strategy:
       matrix:

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -19,7 +19,7 @@ on:
       - master
 jobs:
   code-tests:
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, is-enabled]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -42,7 +42,7 @@ jobs:
       run: |
         dotnet test src/cartservice/
   deployment-tests:
-    runs-on: self-hosted
+    runs-on: [self-hosted, is-enabled]
     needs: code-tests
     strategy:
       matrix:

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -28,6 +28,9 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '6.0.100'
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.17.5'
     - name: Go Unit Tests
       timeout-minutes: 10
       run: |

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -72,9 +72,9 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PR_NUMBER: ${{ github.event.pull_request.number }}
-        PROJECT_ID: "onlineboutique-ci"
-        PR_CLUSTER: "online-boutique-pr"
-        ZONE: "us-east1-b"
+        PROJECT_ID: "online-boutique-ci"
+        PR_CLUSTER: "online-boutique-prs"
+        ZONE: "us-central1-c"
     - name: Wait For Pods
       timeout-minutes: 20
       run: |

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -21,7 +21,7 @@ on:
     types: closed
 jobs:
   cleanup-namespace:
-    runs-on: self-hosted
+    runs-on: [self-hosted, is-enabled]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -36,7 +36,7 @@ jobs:
           NAMESPACE="pr${PR_NUMBER}"
           kubectl delete namespace $NAMESPACE
         env:
-          PROJECT_ID: "onlineboutique-ci"
-          PR_CLUSTER: "online-boutique-pr"
-          ZONE: "us-east1-b"
+          PROJECT_ID: "online-boutique-ci"
+          PR_CLUSTER: "online-boutique-prs"
+          ZONE: "us-central1-c"
           PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/install-dependencies.sh
+++ b/.github/workflows/install-dependencies.sh
@@ -37,20 +37,8 @@ echo "✅ dotnet installed"
 sudo apt-get install -yqq kubectl git
 echo "✅ kubectl installed"
 
-# install go
-wget https://golang.org/dl/go1.15.3.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.15.3.linux-amd64.tar.gz
-echo 'export GOPATH=$HOME/go' >> ~/.profile
-echo 'export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin' >> ~/.profile
-source ~/.profile
-echo "✅ golang installed"
-
 # install build-essential (gcc, used for go test)
 sudo apt install -y build-essential
-
-# install addlicense
-go get -u github.com/google/addlicense
-sudo ln -s $HOME/go/bin/addlicense /bin
 
 # install skaffold
 curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64 && \

--- a/.github/workflows/push-deploy.yaml
+++ b/.github/workflows/push-deploy.yaml
@@ -20,7 +20,7 @@ on:
       - master
 jobs:
   push-deploy:
-    runs-on: self-hosted
+    runs-on: [self-hosted, is-enabled]
     steps:
     - uses: actions/checkout@v2
     - name: Push latest images to GCR


### PR DESCRIPTION
### Background 

* See [GitHub Action Runners of this repo](https://github.com/GoogleCloudPlatform/microservices-demo/settings/actions/runners). These are just Google Compute Engine virtual machines.
* We are migrating from a GCP project called `onlineboutique-ci` to `online-boutique-ci`.
* Part of this migration involved setting up new GitHub Action runners in the new `online-boutique-ci` project.
* I just added 2 new Action Runners (GCE virtual machines).
* While I was setting up the 2 new Action Runners, I added/changed/fixed a few things (to the GitHub automation).

### Change Summary

There's really just 3 changes introduced:

**1. Only use Action Runners with the `is-enabled` label.**
* All jobs should only run on Runners that have an `is-enabled` label.
* This will make it easier to target/test specific Action Runners.
* `runs-on` is [documented here](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idruns-on).
* So now we're using `runs-on: [self-hosted, is-enabled]`.

**2. Use new GKE cluster for pull-requests.**
* For each pull-request, the Action Runners create a deployment (and staging URL) of `microservices-demo`.
* A new GKE cluster is used which exists in the new `online-boutique-ci` project. 

**3. Set up `go` using [`actions/setup-go@v2`](https://github.com/actions/setup-go).**
* Instead of installing `go` (Golang) in the GitHub Action runners, I'm using [`actions/setup-go@v2`](https://github.com/actions/setup-go).
* I believe we only use Golang to run `go` unit tests.
* I also didn't install a `go` library called [addlicense](github.com/google/addlicense) — which I don't believe we're using anywhere.
