### PR TITLE
Add setup-go action to ci-master

### DIFF
--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -27,6 +27,9 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '6.0.100'
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.17.5'
     - name: Go Unit Tests
       timeout-minutes: 10
       run: |


### PR DESCRIPTION
This PR added the `setup-go` github action to ci-pr, but not ci-master.
https://github.com/GoogleCloudPlatform/microservices-demo/pull/660

This PR adds it, to allow ci-master to run Go unit tests, fixing the breaking master build. 