### PR TITLE
Releasing v0.3.4 to include log4j 2.16.0

### DIFF
--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.3
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.3.4
         ports:
         - containerPort: 8080
         env:
@@ -88,7 +88,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.3.3
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.3.4
           ports:
           - containerPort: 5050
           readinessProbe:
@@ -158,7 +158,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.3.3
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.3.4
         ports:
         - containerPort: 8080
         readinessProbe:
@@ -219,7 +219,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.3.3
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.3.4
           ports:
           - containerPort: 8080
           readinessProbe:
@@ -318,7 +318,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.3
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.3.4
         ports:
         - containerPort: 50051
         env:
@@ -368,7 +368,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.3.3
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.3.4
         ports:
         - containerPort: 3550
         env:
@@ -426,7 +426,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.3.3
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.3.4
         ports:
         - containerPort: 7070
         env:
@@ -499,7 +499,7 @@ spec:
           value: "frontend:80"
       containers:
       - name: main
-        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.3.3
+        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.3.4
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"
@@ -530,7 +530,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.3.3
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.3.4
         ports:
         - name: grpc
           containerPort: 7000
@@ -586,7 +586,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.3.3
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.3.4
         ports:
         - containerPort: 50051
         env:
@@ -698,7 +698,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/adservice:v0.3.3
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.3.4
         ports:
         - containerPort: 9555
         env:


### PR DESCRIPTION
### Background 
New Log4j exploits were found in version 2.15.0.  We updated our code to use 2.16.0.  Now we need to create a release.

