### PR TITLE
Changed ci workflows, md to reference main as default

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,7 +4,7 @@ This page describes the CI/CD workflows for the Online Boutique app, which run i
 
 ## Infrastructure
 
-The CI/CD pipelines for Online Boutique run in Github Actions, using a pool of two [self-hosted runners]((https://help.github.com/en/actions/automating-your-workflow-with-github-actions/about-self-hosted-runners)). These runners are GCE instances (virtual machines) that, for every open Pull Request in the repo, run the code test pipeline, deploy test pipeline, and (on master) deploy the latest version of the app to [onlineboutique.dev](https://onlineboutique.dev)
+The CI/CD pipelines for Online Boutique run in Github Actions, using a pool of two [self-hosted runners]((https://help.github.com/en/actions/automating-your-workflow-with-github-actions/about-self-hosted-runners)). These runners are GCE instances (virtual machines) that, for every open Pull Request in the repo, run the code test pipeline, deploy test pipeline, and (on main) deploy the latest version of the app to [onlineboutique.dev](https://onlineboutique.dev)
 
 We also host a test GKE cluster, which is where the deploy tests run. Every PR has its own namespace in the cluster.
 
@@ -14,12 +14,12 @@ We also host a test GKE cluster, which is where the deploy tests run. Every PR h
 
 ### Code Tests - [ci-pr.yaml](ci-pr.yaml)
 
-These tests run on every commit for every open PR, as well as any commit to master / any release branch. Currently, this workflow runs only Go unit tests.
+These tests run on every commit for every open PR, as well as any commit to main / any release branch. Currently, this workflow runs only Go unit tests.
 
 
 ### Deploy Tests- [ci-pr.yaml](ci-pr.yaml)
 
-These tests run on every commit for every open PR, as well as any commit to master / any release branch. This workflow:
+These tests run on every commit for every open PR, as well as any commit to main / any release branch. This workflow:
 
 1. Creates a dedicated GKE namespace for that PR, if it doesn't already exist, in the PR GKE cluster.
 2. Uses `skaffold run` to build and push the images specific to that PR commit. Then skaffold deploys those images, via `kubernetes-manifests`, to the PR namespace in the test cluster.
@@ -29,7 +29,7 @@ These tests run on every commit for every open PR, as well as any commit to mast
 
 ### Push and Deploy Latest - [push-deploy](push-deploy.yml)
 
-This is the Continuous Deployment workflow, and it runs on every commit to the master branch. This workflow:
+This is the Continuous Deployment workflow, and it runs on every commit to the main branch. This workflow:
 
 1. Builds the contaner images for every service, tagging as `latest`.
 2. Pushes those images to Google Container Registry.
@@ -38,7 +38,7 @@ Note that this workflow does not update the image tags used in `release/kubernet
 
 ### Cleanup - [cleanup.yaml](cleanup.yaml)
 
-This workflow runs when a PR closes, regardless of whether it was merged into master. This workflow deletes the PR-specific GKE namespace in the test cluster.
+This workflow runs when a PR closes, regardless of whether it was merged into main. This workflow deletes the PR-specific GKE namespace in the test cluster.
 
 ## Appendix - Creating a new Actions runner
 
@@ -51,7 +51,7 @@ Should one of the two self-hosted Github Actions runners (GCE instances) fail, o
 3. Install project-specific dependencies, including go, docker, skaffold, and kubectl:
 
 ```
-wget -O - https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/.github/workflows/install-dependencies.sh | bash
+wget -O - https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/main/.github/workflows/install-dependencies.sh | bash
 ```
 
 The instance will restart when the script completes in order to finish the Docker install.

--- a/.github/workflows/ci-master.yaml
+++ b/.github/workflows/ci-master.yaml
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Continuous Integration - Master/Release"
+name: "Continuous Integration - Main/Release"
 on:
   push:
-    # run on pushes to master or release/*
+    # run on pushes to main or release/*
     branches:
-      - master
+      - main
       - release/*
 jobs:
   code-tests:

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -16,7 +16,7 @@ name: "Continuous Integration - Pull Request"
 on:
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   code-tests:
     runs-on: [self-hosted, is-enabled]

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -15,9 +15,9 @@
 name: "Clean up deployment"
 on:
   pull_request:
-    # run on pull requests targeting master
+    # run on pull requests targeting main
     branches:
-      - master
+      - main
     types: closed
 jobs:
   cleanup-namespace:

--- a/.github/workflows/push-deploy.yaml
+++ b/.github/workflows/push-deploy.yaml
@@ -15,9 +15,9 @@
 name: "Push and Deploy"
 on:
   push:
-    # run on pushes to master
+    # run on pushes to main
     branches:
-      - master
+      - main
 jobs:
   push-deploy:
     runs-on: [self-hosted, is-enabled]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 
-![Continuous Integration](https://github.com/GoogleCloudPlatform/microservices-demo/workflows/Continuous%20Integration%20-%20Master/Release/badge.svg)
+![Continuous Integration](https://github.com/GoogleCloudPlatform/microservices-demo/workflows/Continuous%20Integration%20-%20Main/Release/badge.svg)
 
 > **⚠ ATTENTION: Apache Log4j 2 advisory.**  
 > Due to [vulnerabilities](https://cloud.google.com/log4j2-security-advisory) present in earlier versions

--- a/hack/README.md
+++ b/hack/README.md
@@ -5,7 +5,7 @@ This directory contains the scripts for creating a new `microservices-demo` rele
 ### Create a New Release
 
 #### 1. Decide on the next release version number using [semantic versioning](https://semver.org/).
-- Look at the [commits since the previous release](https://github.com/GoogleCloudPlatform/microservices-demo/commits/master).
+- Look at the [commits since the previous release](https://github.com/GoogleCloudPlatform/microservices-demo/commits/main).
 
 #### 2. Open a new terminal.
 
@@ -37,7 +37,7 @@ export REPO_PREFIX=gcr.io/google-samples/microservices-demo
 
 #### 8. [Draft a new release on GitHub](https://github.com/GoogleCloudPlatform/microservices-demo/releases).
 
-- Summarize the [commits since the previous release](https://github.com/GoogleCloudPlatform/microservices-demo/commits/master).
+- Summarize the [commits since the previous release](https://github.com/GoogleCloudPlatform/microservices-demo/commits/main).
 - See previous releases for inspiration on release notes.
 
 #### 7. Create a new pull-request.

--- a/hack/make-release.sh
+++ b/hack/make-release.sh
@@ -18,7 +18,7 @@
 # - 1. building/pushing images
 # - 2. injecting tags into YAML manifests
 # - 3. creating a new git tag
-# - 4. pushing the tag/commit to master.
+# - 4. pushing the tag/commit to main.
 
 set -euo pipefail
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
### Background 
To promote inclusive language, and to follow Github’s ongoing efforts to remove instances of the word “master,” Anthos/GKE DPE proposes to move the base branch in our Github sample repos from “master” to “main,” and by default use the branch “main” for all new repos going forward.

### Fixes 
n/a
### Change Summary
Rename master to main in our workflows we have in .github.
Renamed any references to master in our md files

### Additional Notes
After this PR is merged, then we will change the default branch to main (scheduled time for tomorrow to do this).
Since Github redirects from master to main with URLs, there will be no breaking changes in redirect links (but I will change them and cc you all!)

### Testing Procedure
Ensure that I made the correct and necessary changes!

### Related PRs or Issues 
n/a
