### PR TITLE
Shipping fee to be a flat rate

### DIFF
--- a/src/shippingservice/quote.go
+++ b/src/shippingservice/quote.go
@@ -49,7 +49,5 @@ func quoteByCountFloat(count int) float64 {
 	if count == 0 {
 		return 0
 	}
-	count64 := float64(count)
-	var p = 1 + (count64 * 0.2)
-	return count64 + math.Pow(3, p)
+	return 8.99
 }

--- a/src/shippingservice/shippingservice_test.go
+++ b/src/shippingservice/shippingservice_test.go
@@ -50,7 +50,7 @@ func TestGetQuote(t *testing.T) {
 	if err != nil {
 		t.Errorf("TestGetQuote (%v) failed", err)
 	}
-	if res.CostUsd.GetUnits() != 11 || res.CostUsd.GetNanos() != 220000000 {
+	if res.CostUsd.GetUnits() != 8 || res.CostUsd.GetNanos() != 990000000 {
 		t.Errorf("TestGetQuote: Quote value '%d.%d' does not match expected '%s'", res.CostUsd.GetUnits(), res.CostUsd.GetNanos(), "11.220000000")
 	}
 }


### PR DESCRIPTION
### Background 
Related to https://github.com/GoogleCloudPlatform/microservices-demo/issues/691 , where it was found that the shipping cost was calculated using <img src="https://latex.codecogs.com/svg.image?price&space;=&space;n&plus;3^{1&plus;\frac{n}{5}}" title="price = n+3^{1+\frac{n}{5}}" /> As per the suggestion in the issue, I changed the shipping fee to be a 'flat rate'

### Fixes 
Related to this issue https://github.com/GoogleCloudPlatform/microservices-demo/issues/691
### Change Summary
Changed `quoteByCountFloat` in the shippingService to return `8.99` (an arbitrary number, but shipping usually costs around this much in my experience)

### Additional Notes
If we did want to calculate the shipping rate still, I'm ok with closing this PR!

### Testing Procedure
Tested it locally, and shows the shipping rate to be `8.99`

