### PR TITLE
Complete PR#689 - Cloud Armor stup for onlineboutique.dev

### DIFF
--- a/.github/release-cluster/frontend-ingress.yaml
+++ b/.github/release-cluster/frontend-ingress.yaml
@@ -7,6 +7,11 @@ metadata:
     networking.gke.io/managed-certificates: online-boutique-certificate
     networking.gke.io/v1beta1.FrontendConfig: frontend-frontend-config
 spec:
+  defaultBackend:
+    service:
+      name: frontend
+      port:
+        number: 80
   rules:
   - http:
       paths:


### PR DESCRIPTION
- Fix the `defaultBackend` field of the Ingress to avoid any old pointer to the old `frontend-nodeport` service