### PR TITLE
Fix Deployment Details Bug

### DIFF
--- a/src/frontend/deployment_details.go
+++ b/src/frontend/deployment_details.go
@@ -15,6 +15,8 @@ var log *logrus.Logger
 
 func init() {
 	initializeLogger()
+	// Use a goroutine to ensure loadDeploymentDetails()'s GCP API
+	// calls don't block non-GCP deployments. See issue #685.
 	go loadDeploymentDetails()
 }
 

--- a/src/frontend/deployment_details.go
+++ b/src/frontend/deployment_details.go
@@ -9,8 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var areDeploymentDetailsLoaded = false
-var deploymentDetailsMap = make(map[string]string)
+var deploymentDetailsMap map[string]string
 var log *logrus.Logger
 
 func init() {
@@ -34,7 +33,8 @@ func initializeLogger() {
 	log.Out = os.Stdout
 }
 
-func loadDeploymentDetails() map[string]string {
+func loadDeploymentDetails() {
+	deploymentDetailsMap = make(map[string]string)
 	var metaServerClient = metadata.NewClient(&http.Client{})
 
 	podHostname, err := os.Hostname()
@@ -61,15 +61,8 @@ func loadDeploymentDetails() map[string]string {
 		"zone":     podZone,
 		"hostname": podHostname,
 	}).Debug("Loaded deployment details")
-
-	areDeploymentDetailsLoaded = true
-
-	return deploymentDetailsMap
 }
 
-func getDeploymentDetailsIfLoaded(httpRequest *http.Request) map[string]string {
-	if areDeploymentDetailsLoaded {
-		return deploymentDetailsMap
-	}
-	return nil
+func getDeploymentDetailsIfLoaded() map[string]string {
+	return deploymentDetailsMap
 }

--- a/src/frontend/deployment_details.go
+++ b/src/frontend/deployment_details.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"sync"
+
+	"cloud.google.com/go/compute/metadata"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	DetailsAreNotLoaded = 0
+	DetailsAreLoading   = 1
+	DetailsAreLoaded    = 2
+)
+
+var deploymentDetailsMap = make(map[string]string)
+var detailsLoadingStatus = DetailsAreNotLoaded
+var detailsLoadingStatusMutex sync.Mutex // Ensures only 1 HTTP request loads deployment details.
+
+func loadDeploymentDetails(httpRequest *http.Request) map[string]string {
+	var metaServerClient = metadata.NewClient(&http.Client{})
+
+	// The use of httpRequest here lets us to see HTTP request info in the logs.
+	var log = httpRequest.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
+
+	podHostname, err := os.Hostname()
+	if err != nil {
+		log.Error("Failed to fetch the hostname for the Pod", err)
+	}
+
+	podCluster, err := metaServerClient.InstanceAttributeValue("cluster-name")
+	if err != nil {
+		log.Error("Failed to fetch the name of the cluster in which the pod is running", err)
+	}
+
+	podZone, err := metaServerClient.Zone()
+	if err != nil {
+		log.Error("Failed to fetch the Zone of the node where the pod is scheduled", err)
+	}
+
+	deploymentDetailsMap["HOSTNAME"] = podHostname
+	deploymentDetailsMap["CLUSTERNAME"] = podCluster
+	deploymentDetailsMap["ZONE"] = podZone
+
+	log.WithFields(logrus.Fields{
+		"cluster":  podCluster,
+		"zone":     podZone,
+		"hostname": podHostname,
+	}).Debug("Loaded deployment details")
+
+	detailsLoadingStatus = DetailsAreLoaded
+
+	return deploymentDetailsMap
+}
+
+func getDeploymentDetailsIfLoaded(httpRequest *http.Request) map[string]string {
+	detailsLoadingStatusMutex.Lock()
+	defer detailsLoadingStatusMutex.Unlock()
+	if detailsLoadingStatus == DetailsAreNotLoaded {
+		detailsLoadingStatus = DetailsAreLoading
+		go loadDeploymentDetails(httpRequest)
+		return nil
+	}
+	return deploymentDetailsMap
+}

--- a/src/frontend/deployment_details.go
+++ b/src/frontend/deployment_details.go
@@ -62,7 +62,3 @@ func loadDeploymentDetails() {
 		"hostname": podHostname,
 	}).Debug("Loaded deployment details")
 }
-
-func getDeploymentDetailsIfLoaded() map[string]string {
-	return deploymentDetailsMap
-}

--- a/src/frontend/handlers.go
+++ b/src/frontend/handlers.go
@@ -115,7 +115,7 @@ func (fe *frontendServer) homeHandler(w http.ResponseWriter, r *http.Request) {
 		"platform_css":      plat.css,
 		"platform_name":     plat.provider,
 		"is_cymbal_brand":   isCymbalBrand,
-		"deploymentDetails": getDeploymentDetailsIfLoaded(r),
+		"deploymentDetails": getDeploymentDetailsIfLoaded(),
 	}); err != nil {
 		log.Error(err)
 	}
@@ -200,7 +200,7 @@ func (fe *frontendServer) productHandler(w http.ResponseWriter, r *http.Request)
 		"platform_css":      plat.css,
 		"platform_name":     plat.provider,
 		"is_cymbal_brand":   isCymbalBrand,
-		"deploymentDetails": getDeploymentDetailsIfLoaded(r),
+		"deploymentDetails": getDeploymentDetailsIfLoaded(),
 	}); err != nil {
 		log.Println(err)
 	}
@@ -312,7 +312,7 @@ func (fe *frontendServer) viewCartHandler(w http.ResponseWriter, r *http.Request
 		"platform_css":      plat.css,
 		"platform_name":     plat.provider,
 		"is_cymbal_brand":   isCymbalBrand,
-		"deploymentDetails": getDeploymentDetailsIfLoaded(r),
+		"deploymentDetails": getDeploymentDetailsIfLoaded(),
 	}); err != nil {
 		log.Println(err)
 	}
@@ -385,7 +385,7 @@ func (fe *frontendServer) placeOrderHandler(w http.ResponseWriter, r *http.Reque
 		"platform_css":      plat.css,
 		"platform_name":     plat.provider,
 		"is_cymbal_brand":   isCymbalBrand,
-		"deploymentDetails": getDeploymentDetailsIfLoaded(r),
+		"deploymentDetails": getDeploymentDetailsIfLoaded(),
 	}); err != nil {
 		log.Println(err)
 	}
@@ -447,7 +447,7 @@ func renderHTTPError(log logrus.FieldLogger, r *http.Request, w http.ResponseWri
 		"error":             errMsg,
 		"status_code":       code,
 		"status":            http.StatusText(code),
-		"deploymentDetails": getDeploymentDetailsIfLoaded(r),
+		"deploymentDetails": getDeploymentDetailsIfLoaded(),
 	}); templateErr != nil {
 		log.Println(templateErr)
 	}

--- a/src/frontend/handlers.go
+++ b/src/frontend/handlers.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"cloud.google.com/go/compute/metadata"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -116,7 +115,7 @@ func (fe *frontendServer) homeHandler(w http.ResponseWriter, r *http.Request) {
 		"platform_css":      plat.css,
 		"platform_name":     plat.provider,
 		"is_cymbal_brand":   isCymbalBrand,
-		"deploymentDetails": getDeploymentDetails(r),
+		"deploymentDetails": getDeploymentDetailsIfLoaded(r),
 	}); err != nil {
 		log.Error(err)
 	}
@@ -201,7 +200,7 @@ func (fe *frontendServer) productHandler(w http.ResponseWriter, r *http.Request)
 		"platform_css":      plat.css,
 		"platform_name":     plat.provider,
 		"is_cymbal_brand":   isCymbalBrand,
-		"deploymentDetails": getDeploymentDetails(r),
+		"deploymentDetails": getDeploymentDetailsIfLoaded(r),
 	}); err != nil {
 		log.Println(err)
 	}
@@ -313,7 +312,7 @@ func (fe *frontendServer) viewCartHandler(w http.ResponseWriter, r *http.Request
 		"platform_css":      plat.css,
 		"platform_name":     plat.provider,
 		"is_cymbal_brand":   isCymbalBrand,
-		"deploymentDetails": getDeploymentDetails(r),
+		"deploymentDetails": getDeploymentDetailsIfLoaded(r),
 	}); err != nil {
 		log.Println(err)
 	}
@@ -386,7 +385,7 @@ func (fe *frontendServer) placeOrderHandler(w http.ResponseWriter, r *http.Reque
 		"platform_css":      plat.css,
 		"platform_name":     plat.provider,
 		"is_cymbal_brand":   isCymbalBrand,
-		"deploymentDetails": getDeploymentDetails(r),
+		"deploymentDetails": getDeploymentDetailsIfLoaded(r),
 	}); err != nil {
 		log.Println(err)
 	}
@@ -448,7 +447,7 @@ func renderHTTPError(log logrus.FieldLogger, r *http.Request, w http.ResponseWri
 		"error":             errMsg,
 		"status_code":       code,
 		"status":            http.StatusText(code),
-		"deploymentDetails": getDeploymentDetails(r),
+		"deploymentDetails": getDeploymentDetailsIfLoaded(r),
 	}); templateErr != nil {
 		log.Println(templateErr)
 	}
@@ -516,37 +515,4 @@ func stringinSlice(slice []string, val string) bool {
 		}
 	}
 	return false
-}
-
-func getDeploymentDetails(httpRequest *http.Request) map[string]string {
-	var deploymentDetailsMap = make(map[string]string)
-	var metaServerClient = metadata.NewClient(&http.Client{})
-	var log = httpRequest.Context().Value(ctxKeyLog{}).(logrus.FieldLogger)
-
-	podHostname, err := os.Hostname()
-	if err != nil {
-		log.Error("Failed to fetch the hostname for the Pod", err)
-	}
-
-	podCluster, err := metaServerClient.InstanceAttributeValue("cluster-name")
-	if err != nil {
-		log.Error("Failed to fetch the name of the cluster in which the pod is running", err)
-	}
-
-	podZone, err := metaServerClient.Zone()
-	if err != nil {
-		log.Error("Failed to fetch the Zone of the node where the pod is scheduled", err)
-	}
-
-	deploymentDetailsMap["HOSTNAME"] = podHostname
-	deploymentDetailsMap["CLUSTERNAME"] = podCluster
-	deploymentDetailsMap["ZONE"] = podZone
-
-	log.WithFields(logrus.Fields{
-		"cluster":  podCluster,
-		"zone":     podZone,
-		"hostname": podHostname,
-	}).Debug("Fetched pod details")
-
-	return deploymentDetailsMap
 }

--- a/src/frontend/handlers.go
+++ b/src/frontend/handlers.go
@@ -115,7 +115,7 @@ func (fe *frontendServer) homeHandler(w http.ResponseWriter, r *http.Request) {
 		"platform_css":      plat.css,
 		"platform_name":     plat.provider,
 		"is_cymbal_brand":   isCymbalBrand,
-		"deploymentDetails": getDeploymentDetailsIfLoaded(),
+		"deploymentDetails": deploymentDetailsMap,
 	}); err != nil {
 		log.Error(err)
 	}
@@ -200,7 +200,7 @@ func (fe *frontendServer) productHandler(w http.ResponseWriter, r *http.Request)
 		"platform_css":      plat.css,
 		"platform_name":     plat.provider,
 		"is_cymbal_brand":   isCymbalBrand,
-		"deploymentDetails": getDeploymentDetailsIfLoaded(),
+		"deploymentDetails": deploymentDetailsMap,
 	}); err != nil {
 		log.Println(err)
 	}
@@ -312,7 +312,7 @@ func (fe *frontendServer) viewCartHandler(w http.ResponseWriter, r *http.Request
 		"platform_css":      plat.css,
 		"platform_name":     plat.provider,
 		"is_cymbal_brand":   isCymbalBrand,
-		"deploymentDetails": getDeploymentDetailsIfLoaded(),
+		"deploymentDetails": deploymentDetailsMap,
 	}); err != nil {
 		log.Println(err)
 	}
@@ -385,7 +385,7 @@ func (fe *frontendServer) placeOrderHandler(w http.ResponseWriter, r *http.Reque
 		"platform_css":      plat.css,
 		"platform_name":     plat.provider,
 		"is_cymbal_brand":   isCymbalBrand,
-		"deploymentDetails": getDeploymentDetailsIfLoaded(),
+		"deploymentDetails": deploymentDetailsMap,
 	}); err != nil {
 		log.Println(err)
 	}
@@ -447,7 +447,7 @@ func renderHTTPError(log logrus.FieldLogger, r *http.Request, w http.ResponseWri
 		"error":             errMsg,
 		"status_code":       code,
 		"status":            http.StatusText(code),
-		"deploymentDetails": getDeploymentDetailsIfLoaded(),
+		"deploymentDetails": deploymentDetailsMap,
 	}); templateErr != nil {
 		log.Println(templateErr)
 	}

--- a/src/frontend/templates/footer.html
+++ b/src/frontend/templates/footer.html
@@ -32,6 +32,9 @@
                     <b>Cluster: </b>{{index .deploymentDetails "CLUSTERNAME" }}<br/>
                     <b>Zone: </b>{{index .deploymentDetails "ZONE" }}<br/>
                     <b>Pod: </b>{{index .deploymentDetails "HOSTNAME" }}
+                    {{ else }}
+                    Deployment details are either still loading or failed to load.
+                    Try refreshing this page.
                     {{ end }}
                 </small>
             </p>

--- a/src/frontend/templates/footer.html
+++ b/src/frontend/templates/footer.html
@@ -29,11 +29,17 @@
                 <br/>
                 <small>
                     {{ if $.deploymentDetails }}
-                    <b>Cluster: </b>{{index .deploymentDetails "CLUSTERNAME" }}<br/>
-                    <b>Zone: </b>{{index .deploymentDetails "ZONE" }}<br/>
-                    <b>Pod: </b>{{index .deploymentDetails "HOSTNAME" }}
+                        {{ if index .deploymentDetails "CLUSTERNAME" }}
+                        <b>Cluster: </b>{{ index .deploymentDetails "CLUSTERNAME" }}<br/>
+                        {{ end }}
+                        {{ if index .deploymentDetails "ZONE" }}
+                        <b>Zone: </b>{{ index .deploymentDetails "ZONE" }}<br/>
+                        {{ end }}
+                        {{ if index .deploymentDetails "HOSTNAME" }}
+                        <b>Pod: </b>{{ index .deploymentDetails "HOSTNAME" }}
+                        {{ end }}
                     {{ else }}
-                    Deployment details are either still loading or failed to load.
+                    Deployment details are still loading.
                     Try refreshing this page.
                     {{ end }}
                 </small>


### PR DESCRIPTION
* This fixes: #697 and #685.

## Background

* Look at the footer of [onlineboutique.dev](https://onlineboutique.dev/).
* You'll see details about the "Zone", "Pod", and "Cluster".
* This info is loaded by the `getDeploymentDetails` (upon every HTTP request) in the `frontend` service. 
* `getDeploymentDetails` is using a Google Cloud API (cloud.google.com/go/compute/metadata) to load the cluster name and zone.
* This was causing issues on non-GCP deployments (e.g., [Kind](https://kind.sigs.k8s.io/) and EKS). 
* I've fixed the issue by doing 2 things: 
  * perform `getDeploymentDetails` asynchronously (so that the HTTP request handler isn't blocked)
  * have `getDeploymentDetails` load necessary info _once_.
* This certainly isn't a perfect solution — but fixing this issue is **high** priority. 

## Summary of Changes

**1. New File: deployment_details.go**

* I've moved the logic related to loading deployment details into a new file called `deployment_details.go`.
* Reason 1: Single responsibility principle. 
* Reason 2: The `handlers.go` file is too long in my opinion.

**2. Don't Wait on Deployment Details**
* Previously, we loaded deployment details synchronously.
* But now, we're using a `go` routine to load deployment details asynchronously.

**3. Only Load Deployment Details Once**
* Previously, every HTTP request that needed to display deployment details reloaded the deployment details (e.g., each request made a call to Google Cloud to figure out the zone and cluster name).
* Now we're only loading it once!

**4. Mutex**
* I have introduced the use of a mutex to ensure that two HTTP requests don't race to load the deployment details twice.
* Basically, I want to avoid this scenario:
  * Request 1: Are the details loaded? Nope, gotta load it.
  * Request 2: Are the details loaded? Nope, gotta load it.
  * Request 1: Let everyone know I'm taking care of loading it.
  * Request 2: Let everyone know I'm taking care of loading it.

**5. Front-end Message**
* The following message is now displayed in the footer appropriately:
> Deployment details are either still loading or failed to load.
> Try refreshing this page.

## Testing
* I have tested these changes on both a GKE cluster (e.g., see staging URL) and a local Kind cluster (i.e., see comment below). This works. 👍 
* If you would like to test these changes yourself on a Kind cluster:
1. Install Kind: `brew install kind`
1. Create a Kind cluster: `kind create cluster`
1. Make sure you're using the Kind cluster: `kubectx`. You should see `kind-kind` highlighted. 
1. Pull the changes from this pull-request: `git pull nimjay/non-gcp-bug`.
1. Build the modified frontend service: `docker push `
1. Push the modified frontend service: `docker push gcr.io/my-project/new-front-end`
1. Change the `kubernetes-manifests.yaml` file: use `docker push gcr.io/my-project/new-front-end` instead of `gcr.io/google-samples/microservices-demo/frontend:v0.3.5`.
1. `kubectl apply -f kubernetes-manifests.yaml`
1. To access the deployment on your web browser as `localhost:8080`, run: `kubectl port-forward <name-of-frontend-pod> 8080:8080`. (Use `kubectl get pods` to get the name of your front-end pod.)

## Additional Notes
* I am very new to Golang — so I'm open to significantly refactoring my code. I'm guessing there's a TON of room for improvement. 😅 

