### PR TITLE
Removed checkout in cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -23,10 +23,6 @@ jobs:
   cleanup-namespace:
     runs-on: [self-hosted, is-enabled]
     steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Delete PR namespace in staging cluster
         if: ${{ always() }}
         timeout-minutes: 20


### PR DESCRIPTION
### Background 
Similar to this issue that we saw happening in Bank of Anthos (https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/619)

### Fixes 
If a branch was manually deleted, then the cleanup workflow would not work in successfully deleting the staged PR cluster
### Change Summary
Removed the git checkout step from the cleanup workflow

### Additional Notes
n/a

### Testing Procedure

### Related PRs or Issues 
n/a
