### PR TITLE
Enable pip-compile support in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "pip-compile": {
+    "enabled": true,
+    "fileMatch": ["(^|/)requirements\\.in$"]
+  }
 }


### PR DESCRIPTION
### Background 
* We just enabled `renovate-bot` via #700.

### Fixes 
* See sibling task from Bank of Anthos: https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/609.

### Change Summary
* We're making sure the `requirements.in` files are visible to `renovate-bot`.

### Testing Procedure
* We will have to check the `renovate-bot` pull-requests created after this is merged. We have to see if the `requirements.in` files are being targeted. 
