### PR TITLE
Temporarily Disable Renovate for Python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,7 @@
   "extends": [
     "config:base"
   ],
-  "pip-compile": {
-    "enabled": true,
-    "fileMatch": ["(^|/)requirements\\.in$"]
+  "python": {
+    "enabled": false
   }
 }


### PR DESCRIPTION
### Background 
* Renovate Bot created the following PRs:
  * #759
  * #758
  * #757
  * #756
  * #751
* They all update _transitive_ Python dependencies by modifying only the `requirements.txt` file, instead of updating the `requirements.txt` file first.
* [This article](https://www.augmentedmind.de/2021/07/25/renovate-bot-cheat-sheet/) contains an example of how to disable Renovate Bot for Go. I've copied that configuration.
* [This article](https://modelpredict.com/wht-requirements-txt-is-not-enough) explains the purpose of the `requirements.in` file.

### Fixes 

N/A

### Change Summary
* Let's temporarily disable Renovate for Python — until we get through most of the non-Python Renovate Bot pending updates listed in https://github.com/GoogleCloudPlatform/microservices-demo/issues/728.

### Additional Notes
* After this PR is merged, my plan is to close the aforementioned Renovate Bot pull-requests.
* I am totally open to exploring other options to this Python issue, so feel free to reject this PR. 😄 

### Testing Procedure
* We'll have to merge this pull-request and 

### Related PRs or Issues 
N/A
