### PR TITLE
enable lockFileMaintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,10 @@
   ],
   "pip-compile": {
     "enabled": true,
-    "fileMatch": ["(^|/)requirements\\.in$"]
+    "fileMatch": ["(^|/)requirements\\.in$"],
+    "lockFileMaintenance": {
+      "enabled": true
+    }
   },
   "pip_requirements": {
     "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     "enabled": true,
     "fileMatch": ["(^|/)requirements\\.in$"],
     "lockFileMaintenance": {
-      "enabled": true,
+      "enabled": true
     }
   },
   "pip_requirements": {

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     "enabled": true,
     "fileMatch": ["(^|/)requirements\\.in$"],
     "lockFileMaintenance": {
-      "schedule": null
+      "enabled": true,
     }
   },
   "pip_requirements": {

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     "enabled": true,
     "fileMatch": ["(^|/)requirements\\.in$"],
     "lockFileMaintenance": {
-      "enabled": true
+      "schedule": null
     }
   },
   "pip_requirements": {


### PR DESCRIPTION
### Background 
#764 

### Fixes 
Configuring renovate-bot in #764 caused requirements.in being updated, but not requirements.txt
### Change Summary
Enable lockFileMaintenance

### Additional Notes
https://github.com/renovatebot/renovate/discussions/10407#discussioncomment-861394

### Testing Procedure
We'll observe open pip-compile PRs, and see if renovate-bot will adjust the PRs accordingly. I'll go through the logs as well!

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
