### PR TITLE
Renovate bot config python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,10 @@
   ],
   "pip-compile": {
     "enabled": true,
-    "fileMatch": ["(^|/)requirements\\.in$"]
+    "fileMatch": ["(^|/)requirements\\.in$"],
+    "lockFileMaintenance": {
+      "enabled": true
+    }
   },
   "pip_requirements": {
     "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,9 @@
       "enabled": true
     }
   },
+  "constraints": {
+    "python": "3.7"
+  },
   "pip_requirements": {
     "enabled": false
   }

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     "enabled": true,
     "fileMatch": ["(^|/)requirements\\.in$"],
     "lockFileMaintenance": {
-      "enabled": true,
+      "enabled": true
     }
   },
   "pip_requirements": {

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     "enabled": true,
     "fileMatch": ["(^|/)requirements\\.in$"],
     "lockFileMaintenance": {
-      "schedule": null
+      "enabled": true,
     }
   },
   "pip_requirements": {

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     "enabled": true,
     "fileMatch": ["(^|/)requirements\\.in$"],
     "lockFileMaintenance": {
-      "enabled": true
+      "schedule": null
     }
   },
   "pip_requirements": {


### PR DESCRIPTION
### Background 
Was seeing that renovate-bot was using python10 for pip-compile

### Fixes 
Constrains renovate.json to use python 3.7 in our python microservices
(see the [docs](https://docs.renovatebot.com/modules/manager/pip-compile/))


### Change Summary
```
  "constraints": {
    "python": "3.7"
  }
```
added to renovate.json

### Additional Notes
n/a

### Testing Procedure
Ensure that renovate-bot isn't using the latest python when preparing PRs

### Related PRs or Issues 
https://github.com/GoogleCloudPlatform/microservices-demo/pull/767#issuecomment-1057073369