### PR TITLE
cleanup: google-api-core bump

### DIFF
--- a/src/emailservice/requirements.in
+++ b/src/emailservice/requirements.in
@@ -1,4 +1,4 @@
-google-api-core==1.24.1
+google-api-core==1.31.5
 grpcio-health-checking==1.33.2
 grpcio==1.33.2
 jinja2==2.11.3

--- a/src/emailservice/requirements.txt
+++ b/src/emailservice/requirements.txt
@@ -10,7 +10,7 @@ certifi==2020.12.5
     # via requests
 charset-normalizer==2.0.10
     # via requests
-google-api-core[grpc]==1.24.1
+google-api-core[grpc]==1.31.5
     # via
     #   -r requirements.in
     #   google-api-python-client
@@ -20,7 +20,7 @@ google-api-core[grpc]==1.24.1
     #   opencensus
 google-api-python-client==1.12.8
     # via google-cloud-profiler
-google-auth==1.24.0
+google-auth==1.35.0
     # via
     #   google-api-core
     #   google-api-python-client
@@ -71,6 +71,8 @@ opencensus-ext-grpc==0.7.1
     # via -r requirements.in
 opencensus-ext-stackdriver==0.7.3
     # via -r requirements.in
+packaging==21.3
+    # via google-api-core
 protobuf==3.15.0
     # via
     #   -r requirements.in
@@ -85,7 +87,9 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
     # via google-auth
 pyparsing==2.4.7
-    # via httplib2
+    # via
+    #   httplib2
+    #   packaging
 python-json-logger==0.1.11
     # via -r requirements.in
 pytz==2018.9

--- a/src/recommendationservice/requirements.in
+++ b/src/recommendationservice/requirements.in
@@ -1,4 +1,4 @@
-google-api-core==1.23.0
+google-api-core==1.31.5
 google-python-cloud-debugger==2.18
 google-cloud-profiler==3.0.7
 grpcio-health-checking==1.33.2

--- a/src/recommendationservice/requirements.txt
+++ b/src/recommendationservice/requirements.txt
@@ -10,7 +10,7 @@ certifi==2020.12.5
     # via requests
 charset-normalizer==2.0.10
     # via requests
-google-api-core[grpc]==1.23.0
+google-api-core[grpc]==1.31.5
     # via
     #   -r requirements.in
     #   google-api-python-client
@@ -23,7 +23,7 @@ google-api-python-client==1.12.8
     # via
     #   google-cloud-profiler
     #   google-python-cloud-debugger
-google-auth==1.24.0
+google-auth==1.35.0
     # via
     #   google-api-core
     #   google-api-python-client
@@ -72,6 +72,8 @@ opencensus-ext-grpc==0.7.1
     # via -r requirements.in
 opencensus-ext-stackdriver==0.7.3
     # via -r requirements.in
+packaging==21.3
+    # via google-api-core
 protobuf==3.15.0
     # via
     #   -r requirements.in
@@ -86,7 +88,9 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
     # via google-auth
 pyparsing==2.4.7
-    # via httplib2
+    # via
+    #   httplib2
+    #   packaging
 python-json-logger==0.1.11
     # via -r requirements.in
 pytz==2018.9


### PR DESCRIPTION
### Background & FIxes
Updating the `google-api-core`

### Change Summary
Bumping google-api-core in recommendation service and email service in requirements.in to `v1.31.5`, and ran pip-compile

### Additional Notes
n/a

### Testing Procedure
smoke test, and please checkout the staging link (when commented)

### Related PRs or Issues 
n/a!
