### PR TITLE
Use Istio compatible port name for redis-cart service and deployment

### DIFF
--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -652,6 +652,8 @@ spec:
         image: redis:alpine
         ports:
         - containerPort: 6379
+          name: tcp-redis
+          protocol: TCP
         readinessProbe:
           periodSeconds: 5
           tcpSocket:
@@ -683,7 +685,8 @@ spec:
   selector:
     app: redis-cart
   ports:
-  - name: redis
+  - name: tcp-redis
+    protocol: TCP
     port: 6379
     targetPort: 6379
 ---


### PR DESCRIPTION
### Background 
<!-- What was happening before this PR, and the problem(s) it solves -->
Using [explicit Istio port protocol compatible port names](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/) allows it to correctly determine the protocol.  

This fix uses the explicit `tcp-*` format to ensure compatibility with Istio versions prior to recognizing the `redis` port-name.

### Fixes 
<!-- Link the issue(s) this PR fixes-->

Fixes: #776 

### Change Summary
<!-- Short summary of the changes submitted -->

### Additional Notes
<!-- Any remaining concerns -->

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->

Enable Istio with auto-sidecar injection in the namespace where you're installing the microservices-demo manifest.  Install the manifest and validate all pods come up with Istio sidecars.  Validate the cartservice connects to the `redis-cart` DB.

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
