### PR TITLE
Constaint python and added config for renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,9 +10,14 @@
     }
   },
   "constraints": {
-    "python": "3.7"
+    "python": "~=3.7.0"
   },
-  "pip_requirements": {
-    "enabled": false
+  "prConcurrentLimit":5,
+  "stabilityDays":7,
+  "vulnerabilityAlerts":{
+     "labels":[
+       "type:security" 
+     ],
+     "stabilityDays":0
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -19,5 +19,15 @@
        "type:security" 
      ],
      "stabilityDays":0
+  },
+  "labels": ["dependencies"],
+  "python":{
+    "addLabels": ["lang: python"]
+  },
+  "java":{
+    "addLabels": ["lang: java"]
+  },
+  "golang":{
+    "addLabels": ["lang: go"]
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,6 @@
     "addLabels": ["lang: go"]
   },
   "nuget":{
-    "addLabels": ["lang: C#"]
+    "addLabels": ["lang: dotnet"]
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -29,5 +29,8 @@
   },
   "golang":{
     "addLabels": ["lang: go"]
+  },
+  "nuget":{
+    "addLabels": ["lang: C#"]
   }
 }


### PR DESCRIPTION
### Background 
Further fine tunes our renovate bot config setup

### Fixes 
Applying some of the results of the survey. This is an example PR, but it adds stability days, concurrent PR limits, and adds config to bypass that if there is a security vulnerability.
### Change Summary
* Sets prConcurrentLimit to 5, stabilityDays to 7
* Sets both prConcurrentLimit and stabilityDays to 0 if it is a CVE is reported
* Also constrains python to 3.7 (before, even though it said `"python":"3.7"`, it wasn't working. Followed up with the maintainer on why that was happening, but the solution was to use `"python":"~=3.7.0"` instead
* Have Renovate Bot add labels (e.g., `lang: java` and `dependencies`).
### Additional Notes
Note: we also have dependabot (which is built into Github) to notify us of security vulnerabilities. 

### Testing Procedure
The renovate bot PRs will decrease

### Related PRs or Issues 
n/a
