### PR TITLE
Move YAML document separator to top of release manifests

### DIFF
--- a/hack/make-release-artifacts.sh
+++ b/hack/make-release-artifacts.sh
@@ -51,12 +51,12 @@ read_manifests() {
     dir="$1"
 
     while IFS= read -d $'\0' -r file; do
+        echo "---"
+        
         # strip license headers (pattern "^# ")
         awk '
         /^[^# ]/ { found = 1 }
         found { print }' "${file}"
-
-        echo "---"
     done < <(find "${dir}" -name '*.yaml' -type f -print0)
 }
 


### PR DESCRIPTION
### Background 
I propose moving the YAML document separator inserted as part of `make-release-artifacts.sh` to the top of each manifest rather than the bottom.

Having the separator at the end of the manifest results in the generated release YAML files containing an empty document at the end. Whilst this is valid YAML, it is untidy, and certain YAML tools (`yq`) have been seen to handle empty document elements badly.

### Fixes 
<!-- Link the issue(s) this PR fixes-->
### Change Summary
Moved the YAML separator `---` to before each service manifest rather than after

### Additional Notes
<!-- Any remaining concerns -->

### Testing Procedure
Tested and deployed generated manifests succesfully

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
