### PR TITLE
Set up Major.Minor version only for unit tests to avoid too many main…

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -27,10 +27,10 @@ jobs:
         repository: ${{github.event.pull_request.head.repo.full_name}}
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0.100'
+        dotnet-version: '6.0'
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.18.0'
+        go-version: '1.18'
     - name: Go Unit Tests
       timeout-minutes: 10
       run: |


### PR DESCRIPTION
Set up Major.Minor version only for unit tests to avoid too many maintenance with release/patch.

Go and .NET unit tests only.