### PR TITLE
[WIP] Use upstream Kubernetes gRPC Health Check feature

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -49,15 +49,15 @@ spec:
             cpu: 300m
             memory: 300Mi
         readinessProbe:
+          grpc:
+            port: 9555
           initialDelaySeconds: 20
           periodSeconds: 15
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:9555"]
         livenessProbe:
+          grpc:
+            port: 9555
           initialDelaySeconds: 20
           periodSeconds: 15
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:9555"]
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -43,14 +43,14 @@ spec:
             cpu: 300m
             memory: 128Mi
         readinessProbe:
+          grpc:
+            port: 7070
           initialDelaySeconds: 15
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
         livenessProbe:
+          grpc:
+            port: 7070
           initialDelaySeconds: 15
           periodSeconds: 10
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -32,11 +32,11 @@ spec:
           ports:
           - containerPort: 5050
           readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:5050"]
+            grpc:
+              port: 5050
           livenessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:5050"]
+            grpc:
+              port: 5050
           env:
           - name: PORT
             value: "5050"

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -43,11 +43,11 @@ spec:
         - name: DISABLE_DEBUGGER
           value: "1"
         readinessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:7000"]
+          grpc:
+            port: 7000
         livenessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:7000"]
+          grpc:
+            port: 7000
         resources:
           requests:
             cpu: 100m

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -40,13 +40,13 @@ spec:
         - name: DISABLE_PROFILER
           value: "1"
         readinessProbe:
+          grpc:
+            port: 8080
           periodSeconds: 5
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:8080"]
         livenessProbe:
+          grpc:
+            port: 8080
           periodSeconds: 5
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:8080"]
         resources:
           requests:
             cpu: 100m

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -42,11 +42,11 @@ spec:
         - name: DISABLE_DEBUGGER
           value: "1"
         readinessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:50051"]
+          grpc:
+            port: 50051
         livenessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:50051"]
+          grpc:
+            port: 50051
         resources:
           requests:
             cpu: 100m

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -44,11 +44,11 @@ spec:
         # - name: JAEGER_SERVICE_ADDR
         #   value: "jaeger-collector:14268"
         readinessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:3550"]
+          grpc:
+            port: 3550
         livenessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:3550"]
+          grpc:
+            port: 3550
         resources:
           requests:
             cpu: 100m

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -33,13 +33,13 @@ spec:
         ports:
         - containerPort: 8080
         readinessProbe:
+          grpc:
+            port: 8080
           periodSeconds: 5
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:8080"]
         livenessProbe:
+          grpc:
+            port: 8080
           periodSeconds: 5
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:8080"]
         env:
         - name: PORT
           value: "8080"

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -43,12 +43,12 @@ spec:
         # - name: JAEGER_SERVICE_ADDR
         #   value: "jaeger-collector:14268"
         readinessProbe:
+          grpc:
+            port: 50051
           periodSeconds: 5
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:50051"]
         livenessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:50051"]
+          grpc:
+            port: 50051
         resources:
           requests:
             cpu: 100m

--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -36,10 +36,6 @@ RUN mkdir -p /opt/cprof && \
     | tar xzv -C /opt/cprof && \
     rm -rf profiler_java_agent.tar.gz
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.11 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
-
 WORKDIR /app
 COPY --from=builder /app .
 

--- a/src/cartservice/src/Dockerfile
+++ b/src/cartservice/src/Dockerfile
@@ -22,9 +22,6 @@ RUN dotnet publish cartservice.csproj -p:PublishSingleFile=true -r linux-musl-x6
 
 # https://mcr.microsoft.com/v2/dotnet/runtime-deps/tags/list
 FROM mcr.microsoft.com/dotnet/runtime-deps:6.0.5-alpine3.14-amd64
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.11 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
 WORKDIR /app
 COPY --from=builder /cartservice .
 ENV ASPNETCORE_URLS http://*:7070

--- a/src/checkoutservice/Dockerfile
+++ b/src/checkoutservice/Dockerfile
@@ -28,10 +28,6 @@ ARG SKAFFOLD_GO_GCFLAGS
 RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /checkoutservice .
 
 FROM alpine as release
-RUN apk add --no-cache ca-certificates
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.11 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
 WORKDIR /src
 COPY --from=builder /checkoutservice /src/checkoutservice
 

--- a/src/currencyservice/Dockerfile
+++ b/src/currencyservice/Dockerfile
@@ -31,10 +31,6 @@ RUN npm install --only=production
 
 FROM base
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.11 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
-
 WORKDIR /usr/src/app
 
 COPY --from=builder /usr/src/app/node_modules ./node_modules

--- a/src/emailservice/Dockerfile
+++ b/src/emailservice/Dockerfile
@@ -31,15 +31,6 @@ ENV PYTHONUNBUFFERED=1
 # Enable Profiler
 ENV ENABLE_PROFILER=1
 
-RUN apt-get -qq update \
-    && apt-get install -y --no-install-recommends \
-        wget
-
-# Download the grpc health probe
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.11 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
-
 WORKDIR /email_server
 
 # Grab packages from builder

--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -31,10 +31,6 @@ RUN npm install --only=production
 
 FROM base
 
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.11 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
-
 WORKDIR /usr/src/app
 
 COPY --from=builder /usr/src/app/node_modules ./node_modules

--- a/src/productcatalogservice/Dockerfile
+++ b/src/productcatalogservice/Dockerfile
@@ -27,10 +27,6 @@ ARG SKAFFOLD_GO_GCFLAGS
 RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /productcatalogservice .
 
 FROM alpine AS release
-RUN apk add --no-cache ca-certificates
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.11 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
 WORKDIR /src
 COPY --from=builder /productcatalogservice ./server
 COPY products.json .

--- a/src/recommendationservice/Dockerfile
+++ b/src/recommendationservice/Dockerfile
@@ -14,15 +14,10 @@
 
 FROM python:3.7-slim
 RUN apt-get update -qqy && \
-	apt-get -qqy install wget g++ && \
+	apt-get -qqy install g++ && \
 	rm -rf /var/lib/apt/lists/*
 # show python logs as they occur
 ENV PYTHONUNBUFFERED=0
-
-# download the grpc health probe
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.11 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
 
 # get packages
 WORKDIR /recommendationservice

--- a/src/shippingservice/Dockerfile
+++ b/src/shippingservice/Dockerfile
@@ -27,10 +27,6 @@ ARG SKAFFOLD_GO_GCFLAGS
 RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /go/bin/shippingservice .
 
 FROM alpine as release
-RUN apk add --no-cache ca-certificates
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.11 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
 WORKDIR /src
 COPY --from=builder /go/bin/shippingservice /src/shippingservice
 ENV APP_PORT=50051


### PR DESCRIPTION
Experimental PR to test/implement https://github.com/GoogleCloudPlatform/microservices-demo/issues/662

This won't work with the current GKE cluster used in CI because it's GKE < 1.24.

In order to test this, you could provision a GKE cluster in 1.24:
```
gcloud container clusters create test-grpc \
    --release-channel=rapid \
    --cluster-version=1.24
```
_Note: Not an option with 1.23 because it's in alpha and forces users to enable alpha features flag on their Kubernetes clusters._

- [ ] Test on GKE 1.24
- [ ] Validate approach for a potential future merge into `main`
- [ ] Run image scanning to see differences in terms of CVEs (`docker run aquasec/trivy image`)
- [ ] Update CI's + OB Live's GKE clusters to 1.24 to make sure everything works

Once tested/approved, but before thinking about merging it, what are we going to do with this PR?

If we want to support Kubernetes < 1.24 we need to:
1. either have 2 containers (one with the old bin and the other without) + some Kustomize or Helm or manifests duplication - not ideal here...
2. or wait for the end of life of 1.23 as an example which is planned for 2023-02-28 ([source](https://kubernetes.io/releases/#release-history) and [source](https://endoflife.date/kubernetes)). Apparently for GKE it's 2023-06 ([source](https://cloud.google.com/kubernetes-engine/docs/release-schedule#schedule_for_release_channels))

I think 2. is a fair option if we could say that starting 2023-02-28 (or 2023-06) Online Boutique will only work on Kubernetes 1.24+ moving forward?

Complementary information:

## Image size locally
- `emailservice`: -24%
  - `gcr.io/google-samples/microservices-demo/emailservice:v0.3.8`: 220MB
  - `gcr.io/online-boutique-ci/refs/pull/849/emailservice:849`: 190MB
- `paymentservice`: -7%
  - `gcr.io/google-samples/microservices-demo/paymentservice:v0.3.8`: 162MB
  - `gcr.io/online-boutique-ci/refs/pull/849/paymentservice:849`: 151MB
- `cartservice`: -18%
  - `gcr.io/google-samples/microservices-demo/cartservice:v0.3.8`: 62.1MB
  - `gcr.io/online-boutique-ci/refs/pull/849/cartservice:849`: 51.2MB