### PR TITLE
Clarify port-forwarding step for local dev

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -106,21 +106,10 @@ gcloud services enable monitoring.googleapis.com \
 
 4. Run `kubectl get pods` to verify the Pods are ready and running.
 
-5. Access the web frontend through your browser
-    - **Minikube** requires you to run a command to access the frontend service:
+5. Run `kubectl port-forward deployment/frontend 8080:8080` to forward a port to the frontend service.
 
-    ```shell
-    minikube service frontend-external
-    ```
+6. Navigate to `localhost:8080` to access the web frontend.
 
-    - **Docker For Desktop** should automatically provide the frontend at http://localhost:80
-
-    - **Kind** does not provision an IP address for the service.
-      You must run a port-forwarding process to access the frontend at http://localhost:8080:
-
-    ```shell
-    kubectl port-forward deployment/frontend 8080:8080
-    ```
 
 ## Cleanup
 


### PR DESCRIPTION
This PR clarifies and simplifies the port forwarding step in local dev environment to a simple `kubectl port-forward` which works on any local environment.

Fixes #895 