### PR TITLE
Prevent gh actions running on draft PRs

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -15,8 +15,10 @@
 name: "Continuous Integration - Pull Request"
 on:
   pull_request:
+    types: [review_requested, ready_for_review]
     branches:
       - main
+
 jobs:
   code-tests:
     runs-on: [self-hosted, is-enabled]


### PR DESCRIPTION
### Background 
On draft PRs, the gh ci runs. Depending on how long a draft is open for, it could use up resources for us.

### Fixes 
n/a

### Change Summary
Add a type on `ready to review`, and `requested review` in the `ci-pr.yaml`

### Additional Notes
n/a

### Testing Procedure
Putting this PR in draft, and seeing if gh actions runs

### Related PRs or Issues 
n/a
