### PR TITLE
Remove review requested

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -15,7 +15,7 @@
 name: "Continuous Integration - Pull Request"
 on:
   pull_request:
-    types: [review_requested, ready_for_review]
+    types: [ready_for_review]
     branches:
       - main
 


### PR DESCRIPTION
### Background 
I originally opened a PR to prevent CI from running when a draft was created (to save on resources). Noticed that the activity type `review_requested` had to be re-triggered. Not ideal behavior to re add a reviewer to update the ci.
### Fixes 
<!-- Link the issue(s) this PR fixes-->
n/a
### Change Summary
Remove the `review_requested` type

### Additional Notes
n/a

### Testing Procedure
See if the CI runs without need to add a reviewer manually

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
n/a