### PR TITLE
Remove ci check

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -15,7 +15,6 @@
 name: "Continuous Integration - Pull Request"
 on:
   pull_request:
-    types: [ready_for_review]
     branches:
       - main
 


### PR DESCRIPTION
### Background 
<!-- What was happening before this PR, and the problem(s) it solves -->

### Fixes 
I added checks to the ci so that it didn't run on draft prs. Behavior was not expected, hence why we are removing it. Potentially in the future we can revisit this
### Change Summary
<!-- Short summary of the changes submitted -->

### Additional Notes
<!-- Any remaining concerns -->

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
