### PR TITLE
Feat: Implement Memorystore (Redis) Deployment Variation with Online Boutique

### DIFF
--- a/kustomize/components/memorystore/kustomization.yaml
+++ b/kustomize/components/memorystore/kustomization.yaml
@@ -44,4 +44,3 @@ patchesStrategicMerge:
       metadata:
         name: redis-cart
       $patch: delete
- 

--- a/kustomize/components/memorystore/kustomization.yaml
+++ b/kustomize/components/memorystore/kustomization.yaml
@@ -1,0 +1,47 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patchesStrategicMerge:
+  # cartservice - replace REDIS_ADDR to target new Memorystore (redis) instance
+    - |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: cartservice
+      spec:
+        template:
+          spec:
+            containers:
+              - name: server
+                env:
+                - name: REDIS_ADDR
+                  value: "REDIS_IP"
+  # redis - remove the redis-cart Deployment
+    - |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: redis-cart
+      $patch: delete
+  # redis - remove the redis-cart Service
+    - |-
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: redis-cart
+      $patch: delete
+ 

--- a/kustomize/kustomization.yaml
+++ b/kustomize/kustomization.yaml
@@ -21,4 +21,4 @@ resources:
 components:
   # - components/cymbal-branding
   # - components/google-cloud-operations
-  - components/memorystore
+  # - components/memorystore

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -79,7 +79,6 @@ resource "null_resource" "apply_deployment" {
   }
 
   depends_on = [
-    # google_container_cluster.my_cluster
     module.gcloud
   ]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,7 +37,7 @@ module "enable_google_apis" {
   project_id                  = var.gcp_project_id
   disable_services_on_destroy = false
 
-  # activate_apis is defined as base_apis and memorystore_apis if memorystore is enabled
+  # activate_apis is the set of base_apis and the APIs required by user-configured deployment options
   activate_apis = concat(local.base_apis, var.memorystore ? local.memorystore_apis : [])
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -14,14 +14,15 @@
 
 # Definition of local variables
 locals {
-  apis = [
+  base_apis = [
     "container.googleapis.com",
     "monitoring.googleapis.com",
     "cloudtrace.googleapis.com",
     "clouddebugger.googleapis.com",
     "cloudprofiler.googleapis.com"
   ]
-
+  memorystore_apis = ["redis.googleapis.com"]
+  
   # Variables cluster_list and cluster_name are used for an implicit dependency
   # between module "gcloud" and resource "google_container_cluster" 
   cluster_id_parts = split("/", google_container_cluster.my_cluster.id)
@@ -36,7 +37,8 @@ module "enable_google_apis" {
   project_id                  = var.gcp_project_id
   disable_services_on_destroy = false
 
-  activate_apis = local.apis
+  # activate_apis is defined as base_apis and memorystore_apis if memorystore is enabled
+  activate_apis = concat(local.base_apis, var.memorystore ? local.memorystore_apis : [])
 }
 
 # Create GKE cluster

--- a/terraform/memorystore.tf
+++ b/terraform/memorystore.tf
@@ -16,7 +16,7 @@
 resource "google_redis_instance" "redis-cart" {
   name           = "redis-cart"
   memory_size_gb = 1
-  region         = var.region_memorystore
+  region         = var.region
 
   # count specifies the number of instances to create;
   # if var.memorystore is true then the resource is enabled

--- a/terraform/memorystore.tf
+++ b/terraform/memorystore.tf
@@ -12,13 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
+# Create the Memorystore (redis) instance
+resource "google_redis_instance" "redis-cart" {
+  name           = "redis-cart"
+  memory_size_gb = 1
+  region         = var.region_memorystore
 
-resources:
-  - base
+  # count specifies the number of instances to create;
+  # if var.memorystore is true then the resource is enabled
+  count          = var.memorystore ? 1 : 0
 
-components:
-  # - components/cymbal-branding
-  # - components/google-cloud-operations
-  - components/memorystore
+  redis_version  = "REDIS_6_X"
+  project        = var.gcp_project_id
+
+  depends_on = [
+    module.enable_google_apis
+  ]
+}

--- a/terraform/memorystore.tf
+++ b/terraform/memorystore.tf
@@ -29,3 +29,15 @@ resource "google_redis_instance" "redis-cart" {
     module.enable_google_apis
   ]
 }
+
+# Edit contents of Memorystore kustomization.yaml file to target new Memorystore (redis) instance
+resource "null_resource" "kustomization-update" {
+  provisioner "local-exec" {
+    interpreter = ["bash", "-exc"]
+    command     = "sed -i \"s/REDIS_IP/${google_redis_instance.redis-cart[0].host}/g\" ../kustomize/components/memorystore/kustomization.yaml"
+  }
+
+  depends_on = [
+    resource.google_redis_instance.redis-cart
+  ]
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-gcp_project_id = "<PROJECT_ID_HERE>"
+gcp_project_id = "<project_id_here>"
 
 memorystore = false

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -12,4 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-gcp_project_id = "<project_id_here>"
+gcp_project_id = "jaspermai-main-project"
+
+memorystore = false

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-gcp_project_id = "jaspermai-main-project"
+gcp_project_id = "<project_id_here>"
 
-memorystore = true
+memorystore = false

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-gcp_project_id = "jaspermai-main-project"
+gcp_project_id = "<PROJECT_ID_HERE>"
 
 memorystore = false

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-gcp_project_id = "<project_id_here>"
+gcp_project_id = "jaspermai-main-project"
 
-memorystore = false
+memorystore = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,12 +29,6 @@ variable "region" {
   default     = "us-central1"
 }
 
-variable "region_memorystore" {
-  type        = string
-  description = "Region of Memorystore redis"
-  default     = "us-central1"
-}
-
 variable "namespace" {
   type        = string
   description = "Kubernetes Namespace in which the Online Boutique resources are to be deployed"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,6 +29,12 @@ variable "region" {
   default     = "us-central1"
 }
 
+variable "region_memorystore" {
+  type        = string
+  description = "Region of Memorystore redis"
+  default     = "us-central1"
+}
+
 variable "namespace" {
   type        = string
   description = "Kubernetes Namespace in which the Online Boutique resources are to be deployed"
@@ -39,4 +45,9 @@ variable "filepath_manifest" {
   type        = string
   description = "Path to the Kubernetes manifest that defines the Online Boutique resources"
   default     = "../release/kubernetes-manifests.yaml"
+}
+
+variable "memorystore" {
+  type        = bool
+  description = "Value associated with enabling the Memorystore (Redis) deployment variation of Online Boutique"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,5 +49,5 @@ variable "filepath_manifest" {
 
 variable "memorystore" {
   type        = bool
-  description = "Value associated with enabling the Memorystore (Redis) deployment variation of Online Boutique"
+  description = "If true, Online Boutique's in-cluster Redis cache will be replaced with a Google Cloud Memorystore Redis cache"
 }


### PR DESCRIPTION
This Pull Request introduces the Memorystore (Redis) Deployment variant of Online Boutique. The deployment uses Terraform to implement infrastructure changes and shell/Kustomize to implement configuration changes.

# Background 
[Online Boutique (microservices-demo)](https://github.com/GoogleCloudPlatform/microservices-demo) is a sample web application that simulates a web-based e-commerce application for users to browse items, add them to cart, and purchase them. The sample application demonstrates using an 11-tier microservices application deployed using Kubernetes/GKE.

In addition to the vanilla deployment of Online Boutique, the sample application supports various deployment options that allow users to introduce debugging, styling, and infrastructure changes to their version of the sample application. The complete list of deployment options can be found [here](https://github.com/GoogleCloudPlatform/microservices-demo) in the Other Deployment Options section of the README.

**This PR supports the automation of a third deployment option ([Memorystore](https://github.com/GoogleCloudPlatform/microservices-demo/blob/main/docs/memorystore.md)) and showcases how the existing Online Boutique repo should be used with Terraform & Kustomize.**

An explanation on the usage of components can be found in the **Why Components** section of [my previous pull request](https://github.com/GoogleCloudPlatform/microservices-demo/pull/937).

# Summary of Changes

## What does Memorystore do
The vanilla Online Boutique deployment uses the default in-cluster `redis` database for storing the contents of its shopping cart. The Memorystore deployment variation overrides the default database with its own Memorystore (redis) database. These changes directly affect `cartservice`.

## Repository Updates
The resources used for the Memorystore deployment build on top of the previously-implemented Terraform and Kustomize directories. These additions are as follows:

- **`terraform/variables.tf` & `terraform/terraform.tfvars`** - A `memorystore` boolean variable is introduced for users to specify enabling and disabling the Memorystore deployment variation. Additionally, a separate `region_memorystore` variable is defined to create a distinction between the google_redis_instance region with the gke_cluster region (by default they are both set to `us-central1`).
- **`terraform/main.tf`** - The `enable_google_apis` module is updated to conditionally enable the "redis.googleapis.com" api if the `memorystore` boolean value is set to `true`. Otherwise, `enable_google_apis` will only enable the `base_apis` list as per usual. 
- **`terraform/memorystore.tf`** - A new Terraform file that takes care of the extra resources needed for the Memorystore deployment. If the `memorystore` boolean value is set to `true`, then the `google_redis_instance` resource will create a memorystore instance.
- **`kustomize/components/memorystore/kustomization.yaml`** - A new Kustomize file that takes care of all the configuration changes to the existing Kubernetes manifest files. The file performs the following actions: (1) Replaces the `REDIS_ADDR` environment variable in the `cartservice` deployment. (2) Removes the `redis-cart` deployment. (3) Removes the `redis-cart` service.

## Manual to Automated Deployment (1:1 Mapping)
The infrastructure/configuration changes that Terraform and Kustomize implement are a direct application to the [manual Memorystore deployment steps](https://github.com/GoogleCloudPlatform/microservices-demo/blob/main/docs/memorystore.md). Here is a 1:1 mapping of the manual:automated process:
- `1. Create a GKE cluster with VPC-native/IP aliasing enabled.` - Autopilot GKE clusters by default have VPC-native/IP aliasing enabled
- `2. Enable the memorystore (redis) service on your project.` - Terraform (`enable_google_apis` module)
- `3. Create the Memorystore (redis) instance.` - Terraform (`google_redis_instance` resource)
- `4. Update current manifests to target this Memorystore (redis) instance.` - Kustomize deployment and `sed` command
- `5. Apply all the updated manifests.` - Kustomize deployment

# Deploy Memorystore (Redis)

This section will walk you through the steps required to deploy the Memorystore (Redis) variant of the Online Boutique sample application on a [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine) cluster.

## Prerequisites
Make sure you are working on Google Cloud Platform (GCP) on either a [new or existing project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#console). 

For this deployment, it is not required to have an already-running deployment of Online Boutique, but it will speed up the process. It is recommended to use the [built-in Terraform setup with Online Boutique](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/terraform).

## Run the deployment options
1. While in the `microservices-demo` directory, enter the `terraform/` directory.
    ```
    cd terraform
    ```

1. Open the `terraform.tfvars` file. Replace `<project_id_here>` with the [GCP Project ID](https://cloud.google.com/resource-manager/docs/creating-managing-projects?hl=en#identifying_projects) for the `gcp_project_id` variable. Change the value of `memorystore = false` to `memorystore = true`.

1. Initialize Terraform.
    ```
    terraform init
    ```

1. See what resources will be created.
    ```
    terraform plan
    ```

1. Create the resources and deploy the updated infrastructure.
    ```
    terraform apply
    ```
    1. If there is a confirmation prompt, type `yes` and hit Enter/Return.
    
    Note: Following completion, there may be an error saying that the cluster already exists-- this is okay.

1. While in the `terraform/` directory, enter the `kustomize/` directory.
    ```
    cd ../kustomize
    ```

1. Edit the base level `kustomization.yaml` so that it is using the Memorystore component.
    ```
    vim kustomization.yaml
    ```
    The code file should contain the following snippet of code.
    ```
    components:
      - components/memorystore
    ```

1. Check to see what changes will be made to the existing deployment config.
    ```
    kustomize build .
    ```

1. Apply the Kustomize deployment changes to the existing deployment.
    ```
    kubectl apply -k .
    ```
    Note: It may take 2-3 minutes before the changes are reflected on the deployment.

## Cleanup
After you have run the deployment variant on Online Boutique, you will want to reset the sample application back to its vanilla state.

1. While still in the `kustomize/` directory, re-apply the original Kubernetes config to the Online Boutique deployment.
    ```
    kubectl apply -f base
    ```

1. Enter the `terraform/` directory.
    ```
    cd ../terraform
    ```

1. Undo the additional Terraform infrastructure by targeting the Memorystore instance.
    ```
    terraform destroy -target=google_redis_instance.redis-cart
    ```
    1. If there is a confirmation prompt, type `yes` and hit Enter/Return.

## Testing
In its deployment, check to make sure that Online Boutique's shopping cart is working properly after it has started to use Memorystore (Redis).