### PR TITLE
Fix: Added conditional requirement for all resources in memorystore.tf

### DIFF
--- a/terraform/memorystore.tf
+++ b/terraform/memorystore.tf
@@ -37,6 +37,10 @@ resource "null_resource" "kustomization-update" {
     command     = "sed -i \"s/REDIS_IP/${google_redis_instance.redis-cart[0].host}/g\" ../kustomize/components/memorystore/kustomization.yaml"
   }
 
+  # count specifies the number of instances to create;
+  # if var.memorystore is true then the resource is enabled
+  count          = var.memorystore ? 1 : 0
+
   depends_on = [
     resource.google_redis_instance.redis-cart
   ]


### PR DESCRIPTION
### Fixes 
![image](https://user-images.githubusercontent.com/55037635/185489789-7e6bcc99-3867-43de-93ce-06bd50019850.png)

`terraform apply` was running the `kustomization-update` resource in `memorystore.tf` regardless if `memorystore = false` in `terraform.tfvars`

### Change Summary
Added a `count` attribute in the `kustomization-update` resource, that only creates an instance of the resource if `memorystore = true`.
