### PR TITLE
`adservice` - `openjdk:18` + `gradle-7.5.1`

### DIFF
--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:17-slim as builder
+FROM openjdk:18-slim as builder
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ COPY . .
 RUN chmod +x gradlew
 RUN ./gradlew installDist
 
-FROM openjdk:17-slim
+FROM openjdk:18-slim
 
 # Download Stackdriver Profiler Java agent
 RUN apt-get -y update && apt-get install -qqy \

--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8-slim as builder
+FROM openjdk:17-slim as builder
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ COPY . .
 RUN chmod +x gradlew
 RUN ./gradlew installDist
 
-FROM openjdk:8-slim
+FROM openjdk:17-slim
 
 # Download Stackdriver Profiler Java agent
 RUN apt-get -y update && apt-get install -qqy \

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -93,9 +93,9 @@ startScripts.enabled = false
 // This to cache dependencies during Docker image building. First build will take time.
 // Subsequent build will be incremental.
 task downloadRepos(type: Copy) {
-    from configurations.compile
+    from configurations.compileClasspath
     into offlineCompile
-    from configurations.runtime
+    from configurations.compileClasspath
     into offlineCompile
 }
 

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -20,8 +20,8 @@ def jacksonVersion = "2.13.3"
 def protocVersion = "3.21.5"
 
 tasks.withType(JavaCompile) {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 ext {

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -20,8 +20,8 @@ def jacksonVersion = "2.13.3"
 def protocVersion = "3.21.5"
 
 tasks.withType(JavaCompile) {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_18
+    targetCompatibility = JavaVersion.VERSION_18
 }
 
 ext {

--- a/src/adservice/gradle/wrapper/gradle-wrapper.properties
+++ b/src/adservice/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
For `adservice`:
- `openjdk:8` --> `openjdk:18`
- `gradle-6.9.2` --> `gradle-7.5.1`

Fixing https://github.com/GoogleCloudPlatform/microservices-demo/issues/879.

Also, taking into account: https://github.com/GoogleCloudPlatform/microservices-demo/pull/905.

