### PR TITLE
Renovate - `postUpdateOptions.gomodTidy`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,9 @@
      ],
      "stabilityDays":0
   },
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
   "labels": ["dependencies"],
   "python":{
     "addLabels": ["lang: python"]


### PR DESCRIPTION
Let's have `postUpdateOptions.gomodTidy` to help Renovate clean/update the Golang configs/packages, ref here: https://docs.renovatebot.com/configuration-options/#postupdateoptions