### PR TITLE
`loadgenerator` - `securityContext` for `initContainer`

### DIFF
--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -47,6 +47,13 @@ spec:
               exit 1
           fi
         name: frontend-check
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - all
+          privileged: false
+          readOnlyRootFilesystem: true
         image: busybox:latest
         env:
         - name: FRONTEND_ADDR


### PR DESCRIPTION
`loadgenerator` - `securityContext` for `initContainer`

Was missing when did this https://github.com/GoogleCloudPlatform/microservices-demo/pull/887

Got raised when applying PoCo's `Constraints`:
```
psp-capabilities | init container <frontend-check> is not dropping all required capabilities. Container must drop all of ["NET_RAW"] or "ALL"
psp-allow-privilege-escalation-container | Privilege escalation container is not allowed: frontend-check
```