### PR TITLE
Revert "fix(deps): update dependency uuid to v9"

### DIFF
--- a/src/paymentservice/package-lock.json
+++ b/src/paymentservice/package-lock.json
@@ -16,7 +16,7 @@
         "@grpc/proto-loader": "0.7.2",
         "pino": "8.5.0",
         "simple-card-validator": "^1.1.0",
-        "uuid": "^9.0.0"
+        "uuid": "^3.2.1"
       }
     },
     "node_modules/@babel/parser": {
@@ -3453,11 +3453,12 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/webidl-conversions": {
@@ -6348,9 +6349,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/src/paymentservice/package.json
+++ b/src/paymentservice/package.json
@@ -17,6 +17,6 @@
     "@grpc/proto-loader": "0.7.2",
     "pino": "8.5.0",
     "simple-card-validator": "^1.1.0",
-    "uuid": "^9.0.0"
+    "uuid": "^3.2.1"
   }
 }


### PR DESCRIPTION
* This PR reverts GoogleCloudPlatform/microservices-demo#1031.
* Reason for reverting: even though the CI GitHub checks were passing in GoogleCloudPlatform/microservices-demo#1031, the CI on the `main` branch is failing. See https://github.com/GoogleCloudPlatform/microservices-demo/actions/runs/3083297795.

## Relevant Logs

From the `mainpr` Namespace that runs the `main` branch's CI.
```
Info
2022-09-19 11:28:02.449 EDT Type Name # reqs # fails | Avg Min Max Med | req/s failures/s
Info
2022-09-19 11:28:02.449 EDT--------|----------------------------------------------------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
Info
2022-09-19 11:28:02.449 EDT GET / 210 0(0.00%) | 26 17 143 22 | 0.00 0.00
...
Info
2022-09-19 11:28:02.449 EDT POST /cart/checkout 203 203(100.00%) | 189 35 579 200 | 0.20 0.20
Info
2022-09-19 11:28:02.449 EDT GET /product/0PUK6V6EV0 334 0(0.00%) | 20 15 103 18 | 0.10 0.00
...
Info
2022-09-19 11:28:02.449 EDT POST /setCurrency 409 0(0.00%) | 27 20 119 25 | 0.00 0.00
Info
2022-09-19 11:28:02.449 EDT --------|----------------------------------------------------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
Info
2022-09-19 11:28:02.449 EDT Aggregated 4828 203(4.20%) | 33 14 579 20 | 2.70 0.20
```
In the above logs, you'll see that the endpoint `POST /cart/checkout` is failing. 203/203 (100%) of the HTTP requests are failing.


More specifically, it's the `paymentservice` that's err-ing. Logs from `paymentservice`:
```
2022-09-19 11:39:05.579 EDT TypeError: uuid is not a function at charge (/usr/src/app/charge.js:82:28) at HipsterShopServer.ChargeServiceHandler (/usr/src/app/server.js:50:24) at handleUnary (/usr/src/app/node_modules/@grpc/grpc-js/build/src/server.js:688:13) at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

