### PR TITLE
Update paymentservice `uuid` usage to v9

### DIFF
--- a/src/paymentservice/charge.js
+++ b/src/paymentservice/charge.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 const cardValidator = require('simple-card-validator');
-const uuid = require('uuid');
+const { v4: uuidv4 } = require('uuid');
 const pino = require('pino');
 
 const logger = pino({
@@ -79,5 +79,5 @@ module.exports = function charge (request) {
   logger.info(`Transaction processed: ${cardType} ending ${cardNumber.substr(-4)} \
     Amount: ${amount.currency_code}${amount.units}.${amount.nanos}`);
 
-  return { transaction_id: uuid() };
+  return { transaction_id: uuidv4() };
 };

--- a/src/paymentservice/package-lock.json
+++ b/src/paymentservice/package-lock.json
@@ -16,7 +16,7 @@
         "@grpc/proto-loader": "0.7.2",
         "pino": "8.5.0",
         "simple-card-validator": "^1.1.0",
-        "uuid": "^3.2.1"
+        "uuid": "^9.0.0"
       }
     },
     "node_modules/@babel/parser": {
@@ -3453,12 +3453,11 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/webidl-conversions": {
@@ -6349,9 +6348,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/src/paymentservice/package.json
+++ b/src/paymentservice/package.json
@@ -17,6 +17,6 @@
     "@grpc/proto-loader": "0.7.2",
     "pino": "8.5.0",
     "simple-card-validator": "^1.1.0",
-    "uuid": "^3.2.1"
+    "uuid": "^9.0.0"
   }
 }


### PR DESCRIPTION
### Background 
* When I merged the upgrade of `paymentservice`'s `uuid` dependency to `v9.0.0`, I didn't update `paymentservice` invocation of `uuid` in `charge.js`.
* This broke the `paymentservice` (see error logs from https://github.com/GoogleCloudPlatform/microservices-demo/pull/1070). 

### Change Summary
* This PR contains the update from https://github.com/GoogleCloudPlatform/microservices-demo/pull/1031 (which was reverted in https://github.com/GoogleCloudPlatform/microservices-demo/pull/1070).

### Additional Notes
* The CI checks in the pull-request did not catch this error because it doesn't observe the errors witnessed by the `loadgenerator`.
* The CI checks of the `main` branch caught this error because it counts the errors seen by the `loadgenerator`: https://github.com/GoogleCloudPlatform/microservices-demo/actions/runs/3083297795/jobs/4984166585#step:5:1.
  * Maybe we should do this in the PR checks too — or I should at least make sure to test the staging URL (with a full cart checkout) [as a PR reviewer/author].

### Testing Procedure
* We'll need to make sure we can actually check out our cart in the staging URL!

