### PR TITLE
`adservice` - `eclipse-temurin:18-jre-alpine`

### DIFF
--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:18-slim as builder
+FROM eclipse-temurin:18 as builder
 
 WORKDIR /app
 
@@ -25,7 +25,7 @@ COPY . .
 RUN chmod +x gradlew
 RUN ./gradlew installDist
 
-FROM openjdk:18-alpine
+FROM eclipse-temurin:18-jre-alpine
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
`adservice` - `eclipse-temurin:18-jre-alpine`

- `openjdk:18-alpine`: 222.1 MB (virtual) / 395 MB (on disk) --> 4 vulnerabilities
- `eclipse-temurin:18-alpine`: 237 MB (virtual) / 425 MB (on disk) --> 1 vulnerability
- `eclipse-temurin:18-jre-alpine`: 97.2 MB (virtual) / 235 MB (on disk) --> 1 vulnerability