### PR TITLE
Generate `/kustomize/base/` YAMLs inside release automation

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -1,4 +1,4 @@
-## `hack/` 
+## `hack/`
 
 This directory contains the scripts for creating a new `microservices-demo` release.
 
@@ -14,8 +14,8 @@ This directory contains the scripts for creating a new `microservices-demo` rele
 #### 4. Set the following environment variables:
 
 - `TAG` - This is the new version (e.g., `v0.3.5`).
-- `REPO_PREFIX` - This is the Docker repository. 
-##### Example: 
+- `REPO_PREFIX` - This is the Docker repository.
+##### Example:
 ```
 export TAG=v0.3.5
 export REPO_PREFIX=gcr.io/google-samples/microservices-demo
@@ -23,10 +23,10 @@ export REPO_PREFIX=gcr.io/google-samples/microservices-demo
 
 #### 5. Run `./hack/make-release.sh`.
 
-- Make sure you run `./hack/make-release.sh` from this project's root folder — **not** from inside the `hack/` folder. 
+- Make sure you run `./hack/make-release.sh` from this project's root folder — **not** from inside the `hack/` folder.
 - This script:
   1. uses `make-docker-images.sh` to build and push a Docker image for each microservice to the previously specified repository.
-  1. uses `make-release-artifacts.sh` to regenerates (and update the image $TAGS) YAML file at `./release/kubernetes-manifests.yaml`. 
+  1. uses `make-release-artifacts.sh` to regenerates (and update the image $TAGS) YAML file at `./release/kubernetes-manifests.yaml` and `./kustomize/base/`.
   1. runs `git tag` and pushes a new branch (e.g., `release/v0.3.5`) with the changes to `release/kubernetes-manifests.yaml`.
 
 #### 6. Make sure the new Docker images were created and pushed.

--- a/hack/make-release-artifacts.sh
+++ b/hack/make-release-artifacts.sh
@@ -97,6 +97,12 @@ mk_kustomize_base() {
     service_name="$(basename "${file_to_copy}" .yaml)"
     image="$REPO_PREFIX/$service_name:$TAG"
 
+    # Inside redis.yaml, we use the official `redis:alpine` Docker image.
+    # We don't use an image from `gcr.io/google-samples/microservices-demo`.
+    if [[ $service_name == "redis" ]]; then
+      continue
+    fi
+
     pattern="^(\s*)image:\s.*${service_name}(.*)(\s*)"
     replace="\1image: ${image}\3"
     gsed --in-place --regexp-extended "s|${pattern}|${replace}|g" ./kustomize/base/${service_name}.yaml

--- a/hack/make-release-artifacts.sh
+++ b/hack/make-release-artifacts.sh
@@ -52,7 +52,7 @@ read_manifests() {
 
     while IFS= read -d $'\0' -r file; do
         echo "---"
-        
+
         # strip license headers (pattern "^# ")
         awk '
         /^[^# ]/ { found = 1 }
@@ -89,6 +89,20 @@ mk_istio_manifests() {
     echo '# [END servicemesh_release_istio_manifests_microservices_demo]'
 }
 
+mk_kustomize_base() {
+  for file_to_copy in ./kubernetes-manifests/*.yaml
+  do
+    cp ${file_to_copy} ./kustomize/base/
+
+    service_name="$(basename "${file_to_copy}" .yaml)"
+    image="$REPO_PREFIX/$service_name:$TAG"
+
+    pattern="^(\s*)image:\s.*${service_name}(.*)(\s*)"
+    replace="\1image: ${image}\3"
+    gsed --in-place --regexp-extended "s|${pattern}|${replace}|g" ./kustomize/base/${service_name}.yaml
+  done
+}
+
 main() {
     mkdir -p "${OUT_DIR}"
     local k8s_manifests_file istio_manifests_file
@@ -102,6 +116,9 @@ main() {
     istio_manifests_file="${OUT_DIR}/istio-manifests.yaml"
     mk_istio_manifests > "${istio_manifests_file}"
     log "Written ${istio_manifests_file}"
+
+    mk_kustomize_base
+    log "Written Kustomize base"
 }
 
 main

--- a/hack/make-release.sh
+++ b/hack/make-release.sh
@@ -43,7 +43,7 @@ fi
 # create git release / push to new branch
 git checkout -b "release/${TAG}"
 git add "${SCRIPTDIR}/../release/"
-git add "${SCRIPTDIR}/../kustomize/"
+git add "${SCRIPTDIR}/../kustomize/base/"
 git commit --allow-empty -m "Release $TAG"
 log "Pushing k8s manifests to release/${TAG}..."
 git tag "$TAG"


### PR DESCRIPTION
### Background 
* We recently added `/kustomize/base` which needs to be automatically generated when an Online Boutique release takes place.
* Currently, the `/hack/make-release.sh` script generates a `/kustomize/base/kubernetes-manifests.yaml` file.
* In [issue 375](https://github.com/GoogleCloudPlatform/microservices-demo/issues/375), we wanted to move away from the use of a single, all-encompassing `kubernetes-manifests.yaml` file.
* See [relevant comment from pull-request 1097](https://github.com/GoogleCloudPlatform/microservices-demo/pull/1097#discussion_r981349212).

### Change Summary
* This pull-requests adjusts the automation inside `/hack` such that the YAML files in `/kustomize/base/` are automatically generated when a new release of Online Boutique is created.

### Additional Info
* When the next release is created, we need to: 
  * remove `/kustomize/base/kubernetes-manifests.yaml`
  * update `/kustomize/base/kustomization.yaml` (include each service's YAML file and remove `- kubernetes-manifests.yaml` as a resource)

### Testing Procedure
* I have tested the script myself (by commenting out the `/hack/` automation that pushes images to `gcr.io/google-samples` and creates the commit/remote branch for `vX.Y.Z`).
* You may do the same if you want to be rigorous.
* But I will be doing a release soon, so either way, we'll know if it works then. :)

