### PR TITLE
`redis-cart`'s port name update from `tls-redis` --> `tcp-redis`

### DIFF
--- a/kubernetes-manifests/redis.yaml
+++ b/kubernetes-manifests/redis.yaml
@@ -73,6 +73,6 @@ spec:
   selector:
     app: redis-cart
   ports:
-  - name: tls-redis
+  - name: tcp-redis
     port: 6379
     targetPort: 6379


### PR DESCRIPTION
When I did https://github.com/GoogleCloudPlatform/microservices-demo/pull/846, I actually did it wrong with a typo `tls-` instead of `tcp-`, fixing this now :)