### PR TITLE
Use `/kustomize/` in `/terraform/`

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,7 +75,7 @@ module "gcloud" {
 resource "null_resource" "apply_deployment" {
   provisioner "local-exec" {
     interpreter = ["bash", "-exc"]
-    command     = "kubectl apply -f ${var.filepath_manifest}"
+    command     = "kubectl apply -k ${var.filepath_manifest}"
   }
 
   depends_on = [

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -37,8 +37,8 @@ variable "namespace" {
 
 variable "filepath_manifest" {
   type        = string
-  description = "Path to the Kubernetes manifest that defines the Online Boutique resources"
-  default     = "../release/kubernetes-manifests.yaml"
+  description = "Path to Online Boutique's Kubernetes resources, written using Kustomize"
+  default     = "../kustomize/"
 }
 
 variable "memorystore" {


### PR DESCRIPTION
### Background 
* We hope to eventually delete the all-encompassing `/release/kubernetes-manifests.yaml` file.
* See the [`/kustomize/kustomization.yaml`](https://github.com/GoogleCloudPlatform/microservices-demo/blob/main/kustomize/kustomization.yaml) file. We want to use this for all Online Boutique deployments going forward.

### Change Summary
* Online Boutique's Terraform (`./terraform`) now uses the Kubernetes resources from `/kustomize/base/` (via the `/kustomize/kustomization.yaml` file).

### Additional Notes
* I will need to merge this before merging https://github.com/GoogleCloudPlatform/microservices-demo/pull/1142#pullrequestreview-1134619610.

### Testing Procedure
* We need to test the instructions inside https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/kustomize#deploy-online-boutique-variations-with-kustomize.
* Note: I have **not** tested this myself (yet). ⚠️ 

### Related PRs or Issues 
* https://github.com/GoogleCloudPlatform/microservices-demo/issues/375
* https://github.com/GoogleCloudPlatform/microservices-demo/issues/536
