### PR TITLE
Add Cymbal branding to error page

### DIFF
--- a/src/frontend/handlers.go
+++ b/src/frontend/handlers.go
@@ -447,6 +447,7 @@ func renderHTTPError(log logrus.FieldLogger, r *http.Request, w http.ResponseWri
 		"error":             errMsg,
 		"status_code":       code,
 		"status":            http.StatusText(code),
+		"is_cymbal_brand":   isCymbalBrand,
 		"deploymentDetails": deploymentDetailsMap,
 	}); templateErr != nil {
 		log.Println(templateErr)


### PR DESCRIPTION
### Background 
* When enabling Cymbal branding (e.g., via https://github.com/GoogleCloudPlatform/microservices-demo/tree/release/v0.4.0/kustomize/components/cymbal-branding), the Cymbal logo was not being displayed in the app's "error" page.

### Fixes 
https://github.com/GoogleCloudPlatform/microservices-demo/issues/1166

### Change Summary
* Add the `is_cymbal_brand`/`isCymbalBrand` variable to the template that renders the error page.

### Testing Procedure
* If you would like to be thorough, you can 
    1. `skaffold dev` this branch (`nimjay/cymbal-error`)
    2. Set the `CYMBAL_BRANDING` to `"true"` inside `/kubernetes-manifests/frontend.yaml`.
    3. `kubectl delete deployment/cartservice` to bring up the error page.
* But I have done this testing myself and it worked! So feel free to skip testing during your review. :)

