### PR TITLE
`adservice` - fix `jacksonVersion` conflict with `2.13.4.2`

### DIFF
--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -42,7 +42,7 @@ dependencies {
                 "io.grpc:grpc-census:${grpcVersion}",
                 "org.apache.logging.log4j:log4j-core:2.19.0"
 
-        runtimeOnly "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
+        runtimeOnly "com.fasterxml.jackson.core:jackson-core:${jacksonCoreVersion}",
                 "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}",
                 "io.netty:netty-tcnative-boringssl-static:2.0.54.Final"
     }

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -15,7 +15,8 @@ group = "adservice"
 version = "0.1.0-SNAPSHOT"
 
 def grpcVersion = "1.50.0"
-def jacksonVersion = "2.13.4"
+def jacksonCoreVersion = "2.13.4"
+def jacksonDatabindVersion = "2.13.4.2"
 def protocVersion = "3.21.8"
 
 tasks.withType(JavaCompile) {
@@ -42,7 +43,7 @@ dependencies {
                 "org.apache.logging.log4j:log4j-core:2.19.0"
 
         runtimeOnly "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
-                "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}",
+                "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}",
                 "io.netty:netty-tcnative-boringssl-static:2.0.54.Final"
     }
 }


### PR DESCRIPTION
`adservice` - fix `jacksonVersion` conflict with `2.13.4.2`

Fixing issue found in https://github.com/GoogleCloudPlatform/microservices-demo/pull/1157#issuecomment-1284166071

Fix a current known CVE: `CVE-2022-42003 | High | 7.5 | Yes | com.fasterxml.jackson.core:jackson-databind | Maven`