### PR TITLE
Fix Enabling Workload Identity Link

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -22,7 +22,7 @@ gcloud services enable monitoring.googleapis.com \
 
 > 💡 Recommended if you're using Google Cloud Platform and want to try it on
 > a realistic cluster. **Note**: If your cluster has Workload Identity enabled, 
-> [see these instructions](/docs/workload-identity.md)
+> [see these instructions](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#enable)
 
 1.  Create a Google Kubernetes Engine cluster and make sure `kubectl` is pointing
     to the cluster.


### PR DESCRIPTION
Fix Enable Workload Identity Link to point to https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#enable

### Background 
Getting 404 page when clicking on the link

### Fixes 
#1195
### Change Summary
<!-- Short summary of the changes submitted -->

### Additional Notes
<!-- Any remaining concerns -->

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
