### PR TITLE
Fix various breaking changes in docs/kustomize

### DIFF
--- a/docs/cloudshell-tutorial.md
+++ b/docs/cloudshell-tutorial.md
@@ -101,9 +101,7 @@ Congratulations! You've successfully deployed Online Boutique using Cloud Shell.
 ##### What's next?
 
 Try other deployment options for Online Boutique:
-- **Workload Identity**: <walkthrough-editor-open-file filePath="./docs/workload-identity.md">See these instructions</walkthrough-editor-open-file>.
 - **Istio**: <walkthrough-editor-open-file filePath="./docs/service-mesh.md">See these instructions</walkthrough-editor-open-file>.
-- **Anthos Service Mesh**: ASM requires Workload Identity to be enabled in your GKE cluster. <walkthrough-editor-open-file filePath="./docs/workload-identity.md">See these instructions</walkthrough-editor-open-file> to configure and deploy the app. Then, use the <walkthrough-editor-open-file filePath="./docs/service-mesh.md">service mesh guide</walkthrough-editor-open-file>.
-- **Memorystore**: <walkthrough-editor-open-file filePath="./docs/memorystore.md">See these instructions</walkthrough-editor-open-file> to replace the in-cluster `redis` database with hosted Google Cloud Memorystore (redis).
+- **Anthos Service Mesh**: <walkthrough-editor-open-file filePath="./docs/service-mesh.md">See these instructions</walkthrough-editor-open-file>.
 
 Learn more about the [Cloud Shell](https://cloud.google.com/shell) IDE environment and the [Cloud Code](https://cloud.google.com/code) extension.

--- a/docs/service-mesh.md
+++ b/docs/service-mesh.md
@@ -13,9 +13,12 @@ PROJECT_ID="<your-project-id>"
 ZONE="<your-GCP-zone>"
 
 gcloud container clusters create onlineboutique \
-    --project=${PROJECT_ID} --zone=${ZONE} \
-    --machine-type=e2-standard-4 --num-nodes=4
+    --project=${PROJECT_ID} \
+    --zone=${ZONE} \
+    --machine-type=e2-standard-4 \
+    --num-nodes=4
 ```
+_Note: Anthos Service Mesh (ASM) requires [Workload Identity to be enabled in your GKE cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#enable)._
 
 2. [Install Istio](https://istio.io/latest/docs/setup/getting-started/) on your cluster. 
 

--- a/kustomize/components/container-images-registry/kustomization.yaml
+++ b/kustomize/components/container-images-registry/kustomization.yaml
@@ -37,3 +37,5 @@ images:
   newName: CONTAINER_IMAGES_REGISTRY/recommendationservice
 - name: gcr.io/google-samples/microservices-demo/shippingservice
   newName: CONTAINER_IMAGES_REGISTRY/shippingservice
+- name: redis
+  newName: CONTAINER_IMAGES_REGISTRY/redis

--- a/kustomize/components/memorystore/README.md
+++ b/kustomize/components/memorystore/README.md
@@ -50,7 +50,7 @@ Update current Kustomize manifest to target this Memorystore (Redis) instance.
 ```bash
 REDIS_IP=$(gcloud redis instances describe redis-cart --region=${REGION} --format='get(host)')
 REDIS_PORT=$(gcloud redis instances describe redis-cart --region=${REGION} --format='get(port)')
-sed -i "s/\"REDIS_ADDR\"/${REDIS_IP}:${REDIS_PORT}/g" components/memorystore/kustomization.yaml
+sed -i "s/REDIS_CONNECTION_STRING/${REDIS_IP}:${REDIS_PORT}/g" components/memorystore/kustomization.yaml
 ```
 
 You can locally render these manifests by running `kubectl kustomize .` as well as deploying them by running `kubectl apply -k .`.

--- a/kustomize/components/memorystore/kustomization.yaml
+++ b/kustomize/components/memorystore/kustomization.yaml
@@ -28,7 +28,7 @@ patchesStrategicMerge:
           - name: server
             env:
             - name: REDIS_ADDR
-              value: "REDIS_ADDR"
+              value: "REDIS_CONNECTION_STRING"
 # redis - remove the redis-cart Deployment
 - |-
   apiVersion: apps/v1

--- a/kustomize/components/native-grpc-health-check/README.md
+++ b/kustomize/components/native-grpc-health-check/README.md
@@ -8,9 +8,8 @@ To automate the deployment of Online Boutique integrated with native gRPC probes
 
 From the `kustomize/` folder at the root level of this repository, execute this command:
 ```bash
-SUFFIX=-native-grpc-probes
-sed -i "s/CONTAINER_IMAGES_TAG_SUFFIX/$SUFFIX/g" components/container-images-tag-suffix/kustomization.yaml
-kustomize edit add component components/container-images-tag-suffix
+ONLINE_BOUTIQUE_VERSION=$(curl -s https://api.github.com/repos/GoogleCloudPlatform/microservices-demo/releases | jq -r '[.[]] | .[0].tag_name')
+sed -i "s/CONTAINER_IMAGES_TAG/$ONLINE_BOUTIQUE_VERSION-native-grpc-probes/g" components/native-grpc-health-check/kustomization.yaml
 kustomize edit add component components/native-grpc-health-check
 ```
 _Note: we are applying the `-native-grpc-probes` tag suffix to all the container images, it's a prebuilt image without the [grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe) binary since the version 0.4.0 of Online Boutique._
@@ -22,14 +21,10 @@ kind: Kustomization
 resources:
 - base
 components:
-- components/container-images-tag-suffix
 - components/native-grpc-health-check
 ```
 
-You can (optionally) locally render these manifests by running `kubectl kustomize . | sed "s/$SUFFIX$SUFFIX/$SUFFIX/g"`.
-You can deploy them by running `kubectl kustomize . | sed "s/$SUFFIX$SUFFIX/$SUFFIX/g" | kubectl apply -f`.
-
-_Note: for this variation, `kubectl apply -k .` alone won't work because there is a [known issue currently in Kustomize](https://github.com/kubernetes-sigs/kustomize/issues/4814) where the `tagSuffix` is duplicated. The `sed "s/$SUFFIX$SUFFIX/$SUFFIX/g"` commands above are a temporary workaround._
+You can locally render these manifests by running `kubectl kustomize .` as well as deploying them by running `kubectl apply -k .`.
 
 ## Resources
 

--- a/kustomize/components/native-grpc-health-check/kustomization.yaml
+++ b/kustomize/components/native-grpc-health-check/kustomization.yaml
@@ -14,6 +14,25 @@
 
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
+images:
+- name: gcr.io/google-samples/microservices-demo/adservice
+  newTag: CONTAINER_IMAGES_TAG
+- name: gcr.io/google-samples/microservices-demo/cartservice
+  newTag: CONTAINER_IMAGES_TAG
+- name: gcr.io/google-samples/microservices-demo/checkoutservice
+  newTag: CONTAINER_IMAGES_TAG
+- name: gcr.io/google-samples/microservices-demo/currencyservice
+  newTag: CONTAINER_IMAGES_TAG
+- name: gcr.io/google-samples/microservices-demo/emailservice
+  newTag: CONTAINER_IMAGES_TAG
+- name: gcr.io/google-samples/microservices-demo/paymentservice
+  newTag: CONTAINER_IMAGES_TAG
+- name: gcr.io/google-samples/microservices-demo/productcatalogservice
+  newTag: CONTAINER_IMAGES_TAG
+- name: gcr.io/google-samples/microservices-demo/recommendationservice
+  newTag: CONTAINER_IMAGES_TAG
+- name: gcr.io/google-samples/microservices-demo/shippingservice
+  newTag: CONTAINER_IMAGES_TAG
 patchesStrategicMerge:
 # adservice - remove the exec and add the grpc for liveness and readiness probes
 - |-

--- a/kustomize/components/service-accounts/README.md
+++ b/kustomize/components/service-accounts/README.md
@@ -1,6 +1,6 @@
 # Create Kubernetes Service Accounts for Online Boutique
 
-Creating a `ServiceAccount` per `Deployment` could be helpful if you need to define a fine granular identity for each `Deployment` in your Kubernetes clusters. This could help if for example you want to give specific Google Cloud IAM role binding by leveraging [Workload Identity with GKE](/docs/workload-identity.md). Another scenario could be if you want to define fine granular [`AuthorizationPolicies` with Istio/ASM](https://cloud.google.com/service-mesh/docs/by-example/authz).
+Creating a `ServiceAccount` per `Deployment` could be helpful if you need to define a fine granular identity for each `Deployment` in your Kubernetes clusters. This could help if for example you want to give specific Google Cloud IAM role binding by leveraging [Workload Identity with GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#enable). Another scenario could be if you want to define fine granular [`AuthorizationPolicies` with Istio/ASM](https://cloud.google.com/service-mesh/docs/by-example/authz).
 
 ## Deploy Online Boutique with `ServiceAccounts` via Kustomize
 

--- a/terraform/memorystore.tf
+++ b/terraform/memorystore.tf
@@ -34,7 +34,7 @@ resource "google_redis_instance" "redis-cart" {
 resource "null_resource" "kustomization-update" {
   provisioner "local-exec" {
     interpreter = ["bash", "-exc"]
-    command     = "sed -i \"s/\"REDIS_ADDR\"/${google_redis_instance.redis-cart[0].host}:${google_redis_instance.redis-cart[0].port}/g\" ../kustomize/components/memorystore/kustomization.yaml"
+    command     = "sed -i \"s/REDIS_CONNECTION_STRING/${google_redis_instance.redis-cart[0].host}:${google_redis_instance.redis-cart[0].port}/g\" ../kustomize/components/memorystore/kustomization.yaml"
   }
 
   # count specifies the number of instances to create;


### PR DESCRIPTION
- Fix `REDIS_ADDR` token, now `REDIS_CONNECTION_STRING`. Issue illustrated here: https://github.com/GoogleCloudPlatform/microservices-demo/pull/1102#discussion_r1002101340
- Following up on https://github.com/GoogleCloudPlatform/microservices-demo/pull/1201 by fixing other broken `docs/workload-identity` links
- Fix issue with loadgenerator and frontend for the native-grpc-health-check Kustomize component