### PR TITLE
`adservice` - `eclipse-temurin:18.0.2.1_1-jre-alpine`

### DIFF
--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -25,7 +25,7 @@ COPY . .
 RUN chmod +x gradlew
 RUN ./gradlew installDist
 
-FROM eclipse-temurin:18-jre-alpine as without-grpc-health-probe-bin
+FROM eclipse-temurin:18.0.2.1_1-jre-alpine as without-grpc-health-probe-bin
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
Doesn't change anything yet with the current version because `eclipse-temurin:18-jre-alpine` and `eclipse-temurin:18.0.2.1_1-jre-alpine` are similar since 2 months. But it's following up on https://github.com/GoogleCloudPlatform/microservices-demo/pull/1168 in order to better track/catch CVEs vulns fix in the future.