### PR TITLE
Force `git pull` in the release process

### DIFF
--- a/hack/make-release.sh
+++ b/hack/make-release.sh
@@ -34,6 +34,10 @@ if [[ "$TAG" != v* ]]; then
     fail "\$TAG must start with 'v', e.g. v0.1.0 (got: $TAG)"
 fi
 
+# make sure local source is up to date
+git checkout main
+git pull
+
 # build and push images
 "${SCRIPTDIR}"/make-docker-images.sh
 

--- a/hack/make-release.sh
+++ b/hack/make-release.sh
@@ -34,6 +34,12 @@ if [[ "$TAG" != v* ]]; then
     fail "\$TAG must start with 'v', e.g. v0.1.0 (got: $TAG)"
 fi
 
+# ensure there are no uncommitted changes
+if [[ $(git status -s | wc -l) -gt 0 ]]; then
+    echo "error: can't have uncommitted changes"
+    exit 1
+fi
+
 # make sure local source is up to date
 git checkout main
 git pull


### PR DESCRIPTION
Proposing to force `git pull` in the release process.

It looks like `v0.4.1` was not generated from the latest and greatest from the `main` branch.

At least for the `frontend` app. I found out that `v0.4.1` for `frontend` still has 2 vulnerabilities with a known fix:
```
CVE-2022-40304 | Unspecified | 0 | Yes | libxml2 | OS
CVE-2022-40303 | Unspecified | 0 | Yes | libxml2 | OS
```
But if I do:
```
git checkout main
git pull
cd src/frontend
docker build...
docker push...
```
I don't see these 2 CVE vulnerabilities anymore. So guessing the issue came from this.

Once this PR is merged in the `main` branch, please let's generate `v0.4.2` release of Online Boutique with this (the GKE Security Posture feature will be happy with that :)). Thanks!


