### PR TITLE
Simplify the grpc health probes kustomize overlay

### DIFF
--- a/kustomize/components/native-grpc-health-check/README.md
+++ b/kustomize/components/native-grpc-health-check/README.md
@@ -9,7 +9,7 @@ To automate the deployment of Online Boutique integrated with native gRPC probes
 From the `kustomize/` folder at the root level of this repository, execute this command:
 ```bash
 ONLINE_BOUTIQUE_VERSION=$(curl -s https://api.github.com/repos/GoogleCloudPlatform/microservices-demo/releases | jq -r '[.[]] | .[0].tag_name')
-sed -i "s/CONTAINER_IMAGES_TAG/$ONLINE_BOUTIQUE_VERSION-native-grpc-probes/g" components/native-grpc-health-check/kustomization.yaml
+sed -i "s/ONLINE_BOUTIQUE_VERSION/$ONLINE_BOUTIQUE_VERSION/g" components/native-grpc-health-check/kustomization.yaml
 kustomize edit add component components/native-grpc-health-check
 ```
 _Note: we are applying the `-native-grpc-probes` tag suffix to all the container images, it's a prebuilt image without the [grpc-health-probe](https://github.com/grpc-ecosystem/grpc-health-probe) binary since the version 0.4.0 of Online Boutique._

--- a/kustomize/components/native-grpc-health-check/kustomization.yaml
+++ b/kustomize/components/native-grpc-health-check/kustomization.yaml
@@ -16,23 +16,23 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 images:
 - name: gcr.io/google-samples/microservices-demo/adservice
-  newTag: CONTAINER_IMAGES_TAG
+  newTag: ONLINE_BOUTIQUE_VERSION-native-grpc-probes
 - name: gcr.io/google-samples/microservices-demo/cartservice
-  newTag: CONTAINER_IMAGES_TAG
+  newTag: ONLINE_BOUTIQUE_VERSION-native-grpc-probes
 - name: gcr.io/google-samples/microservices-demo/checkoutservice
-  newTag: CONTAINER_IMAGES_TAG
+  newTag: ONLINE_BOUTIQUE_VERSION-native-grpc-probes
 - name: gcr.io/google-samples/microservices-demo/currencyservice
-  newTag: CONTAINER_IMAGES_TAG
+  newTag: ONLINE_BOUTIQUE_VERSION-native-grpc-probes
 - name: gcr.io/google-samples/microservices-demo/emailservice
-  newTag: CONTAINER_IMAGES_TAG
+  newTag: ONLINE_BOUTIQUE_VERSION-native-grpc-probes
 - name: gcr.io/google-samples/microservices-demo/paymentservice
-  newTag: CONTAINER_IMAGES_TAG
+  newTag: ONLINE_BOUTIQUE_VERSION-native-grpc-probes
 - name: gcr.io/google-samples/microservices-demo/productcatalogservice
-  newTag: CONTAINER_IMAGES_TAG
+  newTag: ONLINE_BOUTIQUE_VERSION-native-grpc-probes
 - name: gcr.io/google-samples/microservices-demo/recommendationservice
-  newTag: CONTAINER_IMAGES_TAG
+  newTag: ONLINE_BOUTIQUE_VERSION-native-grpc-probes
 - name: gcr.io/google-samples/microservices-demo/shippingservice
-  newTag: CONTAINER_IMAGES_TAG
+  newTag: ONLINE_BOUTIQUE_VERSION-native-grpc-probes
 patchesStrategicMerge:
 # adservice - remove the exec and add the grpc for liveness and readiness probes
 - |-


### PR DESCRIPTION
Simplify the grpc health probes kustomize overlay, less actions by end users, because `tagSuffix` is not working upstream with Kustomize, we still need to update the Online Boutique version...