### PR TITLE
`loadgenerator` - fix conflict between `gevent` and `greenlet`

### DIFF
--- a/kustomize/components/native-grpc-health-check/README.md
+++ b/kustomize/components/native-grpc-health-check/README.md
@@ -28,5 +28,6 @@ You can locally render these manifests by running `kubectl kustomize .` as well 
 
 ## Resources
 
+- [gRPC health probes with Kubernetes 1.24+ with Online Boutique](https://medium.com/google-cloud/b5bd26253a4c)
 - [Kubernetes 1.24: gRPC container probes in beta](https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/)
 - [Define a gRPC liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe)

--- a/src/loadgenerator/requirements.txt
+++ b/src/loadgenerator/requirements.txt
@@ -25,13 +25,13 @@ flask-basicauth==0.2.0
     # via locust
 flask-cors==3.0.10
     # via locust
-gevent==22.10.1
+gevent==22.10.2
     # via
     #   geventhttpclient
     #   locust
 geventhttpclient==2.0.8
     # via locust
-greenlet==1.1.3.post0
+greenlet==2.0.0
     # via gevent
 idna==3.4
     # via requests


### PR DESCRIPTION
Fix conflict (chicken and egg problem) between `gevent` and `greenlet` that Renovate is not able to resolve itself:
- https://github.com/GoogleCloudPlatform/microservices-demo/pull/1220
- https://github.com/GoogleCloudPlatform/microservices-demo/pull/1219

Also, nothing related but also added the link to the blog for the gRPC health probes blog article.
