### PR TITLE
Update DeployStack to use `main` branch

### DIFF
--- a/docs/deploystack.md
+++ b/docs/deploystack.md
@@ -3,7 +3,7 @@
 The "Open in Google Cloud Shell" button below will use [DeployStack](https://cloud.google.com/shell/docs/cloud-shell-tutorials/deploystack/overview) to deploy Online Boutique to a new Google Kubernetes Engine (GKE) cluster.
 
 <!-- TODO: remove reference to the deploystack-enable branch when it pushes to main -->
-<a href="https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Ftpryan%2Fmicroservices-demo&shellonly=true&cloudshell_image=gcr.io/ds-artifacts-cloudshell/deploystack_custom_image&cloudshell_git_branch=deploystack-enable" target="_new">
+<a href="https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fmicroservices-demo&shellonly=true&cloudshell_image=gcr.io/ds-artifacts-cloudshell/deploystack_custom_image&cloudshell_git_branch=main" target="_new">
     <img alt="Open in Cloud Shell" src="https://gstatic.com/cloudssh/images/open-btn.svg">
 </a>
 


### PR DESCRIPTION
### Background 
* Currently, DeployStack is using a different repo.
* See comment: https://github.com/GoogleCloudPlatform/microservices-demo/pull/1142#discussion_r990150313.

### Change Summary
* Make DeployStack use this repo and the `main` branch.

### Testing Procedure
* We will need to test the "Open in Google Cloud Shell" button

### Related PRs or Issues 
* https://github.com/GoogleCloudPlatform/microservices-demo/pull/1142
