### PR TITLE
Use kustomize for skaffold local development

### DIFF
--- a/kubernetes-manifests/kustomization.yaml
+++ b/kubernetes-manifests/kustomization.yaml
@@ -1,0 +1,40 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+ - adservice.yaml
+ - cartservice.yaml
+ - checkoutservice.yaml
+ - currencyservice.yaml
+ - emailservice.yaml
+ - frontend.yaml
+ - loadgenerator.yaml
+ - paymentservice.yaml
+ - productcatalogservice.yaml
+ - recommendationservice.yaml
+ - redis.yaml
+ - shippingservice.yaml
+components:
+# - ../kustomize/components/cymbal-branding
+# - ../kustomize/components/google-cloud-operations
+# - ../kustomize/components/memorystore
+# - ../kustomize/components/network-policies
+# - ../kustomize/components/service-accounts
+# - ../kustomize/components/spanner
+# - ../kustomize/components/container-images-tag
+# - ../kustomize/components/container-images-tag-suffix
+# - ../kustomize/components/container-images-registry
+# - ../kustomize/components/native-grpc-health-check

--- a/kubernetes-manifests/kustomization.yaml
+++ b/kubernetes-manifests/kustomization.yaml
@@ -21,7 +21,7 @@ resources:
  - currencyservice.yaml
  - emailservice.yaml
  - frontend.yaml
- - loadgenerator.yaml
+# - loadgenerator.yaml # During development, the loadgenerator module inside skaffold.yaml will be used.
  - paymentservice.yaml
  - productcatalogservice.yaml
  - recommendationservice.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -49,18 +49,9 @@ build:
   local:
     useBuildkit: false
 manifests:
-  rawYaml:
-  - ./kubernetes-manifests/adservice.yaml
-  - ./kubernetes-manifests/cartservice.yaml
-  - ./kubernetes-manifests/checkoutservice.yaml
-  - ./kubernetes-manifests/currencyservice.yaml
-  - ./kubernetes-manifests/emailservice.yaml
-  - ./kubernetes-manifests/frontend.yaml
-  - ./kubernetes-manifests/paymentservice.yaml
-  - ./kubernetes-manifests/productcatalogservice.yaml
-  - ./kubernetes-manifests/recommendationservice.yaml
-  - ./kubernetes-manifests/redis.yaml
-  - ./kubernetes-manifests/shippingservice.yaml
+  kustomize:
+    paths:
+    - kubernetes-manifests
 deploy:
   kubectl: {}
 # "gcb" profile allows building and pushing the images


### PR DESCRIPTION
Adds kustomization.yaml to kubernetes-manifests folder Changes render target in skaffold.yaml to kustomize

### Background 
This change allows use of skaffold for local development with a different kustomize target than the default one in kustomize/

This allows us to keep separate "dev" manifests in kubernetes-manifests/ with clean "release" versions occasionally generated and stored in kustomize/base.  That way, when you deploy from kustomize/ you will not get any unrelease development noise/features.

### Additional Notes
This might not be an ideal solution, but I believe it is a step in the right direction.  Note that kustomize components are all in kustomize/components; there are no separate development and release versions.  Perhaps the modules could be moved to a dev folder and copied to kustomize/ on release, or perhaps that is less of a concern than ensuring that release manifests always point to pre-built known images.  I'm not sure.

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
#1228 is definitely related.  Using skaffold profiles might provide a better solution, but I'm not sure that it addresses the release/dev manifest separation discussed in **Background**.