### PR TITLE
Fix skaffold `network-policies` Profile

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -84,10 +84,10 @@ profiles:
 # You can use it in isolation or in combination with other profiles:
 #     skaffold run -p network-policies, debug
 - name: network-policies
-  manifests:
-    kustomize:
-      paths:
-        - kustomize/components/network-policies
+  patches:
+  - op: add
+    path: /manifests/kustomize/paths/1
+    value: kustomize/components/network-policies
 ---
 apiVersion: skaffold/v3
 kind: Config


### PR DESCRIPTION
### Background 
* The [skaffold Profile](https://skaffold.dev/docs/environment/profiles/) called ["network-policies"](https://github.com/GoogleCloudPlatform/microservices-demo/pull/1228/files) currently **replaces** the skaffold.yaml's:
```
  manifests:
    kustomize:
      paths:
        - kubernetes-manifests
```
with
```
  manifests:
    kustomize:
      paths:
        - kustomize/components/network-policies
```
* But we do **not** want it to replace — we want it to **add**.

### Fixes 
https://github.com/GoogleCloudPlatform/microservices-demo/issues/1246

### Change Summary
* The [skaffold Profile](https://skaffold.dev/docs/environment/profiles/) called "network-policies" now deploys the base Online Boutique manifests (from `kubernetes-manifests`) — not just the [`NetworkPolicies` Kustomize Component](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/kustomize/components/network-policies).

### Additional Notes
* Relevant docs: 
  * [official skaffold docs on YAML](https://skaffold.dev/docs/references/yaml/#profiles-manifests)
  * [official skaffold sample using kustomize](https://github.com/GoogleContainerTools/skaffold/blob/main/examples/getting-started-kustomize/skaffold.yaml)
  * [official skaffold sample that uses Profiles and patching](https://github.com/GoogleContainerTools/skaffold/blob/main/examples/profile-patches/skaffold.yaml)


### Testing Procedure
* Make sure the staging URL is working. The staging URL uses `skaffold run ... -p network-policies` — so it tests changes from this pull-requests. See [relevant CI command here](https://github.com/GoogleCloudPlatform/microservices-demo/blob/main/.github/workflows/ci-pr.yaml#L82).
