### PR TITLE
Use DeployStack in main `/README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you’re using this demo, please **★Star** this repository to show your int
 
 ## Quickstart (GKE)
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/microservices-demo&cloudshell_workspace=.&cloudshell_tutorial=docs/cloudshell-tutorial.md)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fmicroservices-demo&shellonly=true&cloudshell_image=gcr.io/ds-artifacts-cloudshell/deploystack_custom_image)
 
 1. **[Create a Google Cloud Platform project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project)** or use an existing project. Set the `PROJECT_ID` environment variable and ensure the Google Kubernetes Engine and Cloud Operations APIs are enabled.
 


### PR DESCRIPTION
### Background 
* In https://github.com/GoogleCloudPlatform/microservices-demo/pull/1142, we introduced a "Open in Cloud Shell" button that uses [DeployStack](https://cloud.google.com/shell/docs/cloud-shell-tutorials/deploystack) to deploy Online Boutique.
* But we only added the button to [/docs/deploystack.md](https://github.com/tpryan/microservices-demo/blob/471cb9e1fe83c405fef3c27c7e69e80d3595b238/docs/deploystack.md).
* After having used this button a few times (and successfully deploying Online Boutique), I am confident we can replace the button that we currently have in Online Boutique's main [/README.md](https://github.com/GoogleCloudPlatform/microservices-demo#quickstart-gke) file.
* The button we _**currently**_ have in Online Boutique's main [/README.md](https://github.com/GoogleCloudPlatform/microservices-demo#quickstart-gke) file does not deploy Online Boutique — it only opens Cloud Shell and `git clone`s this repo.

### Change Summary
* Replace the button that we current have in Online Boutique's main [/README.md](https://github.com/GoogleCloudPlatform/microservices-demo#quickstart-gke) file.

### Testing Procedure
* The full DeployStack user journey has already been tested in https://github.com/GoogleCloudPlatform/microservices-demo/pull/1142. So we just have to make sure that the "Open in Google Cloud Shell" button uses the correct link. We don't need to test the full journey.

![Screenshot 2022-11-14 at 5 35 25 PM](https://user-images.githubusercontent.com/10292865/201782421-6e377ca1-daba-4dcc-9dbc-1148504365b1.png)

As long as we see the above screenshot when clicking on the button, we're good. :)