### PR TITLE
fix: Correct minikube default CNI

### DIFF
--- a/kustomize/components/network-policies/README.md
+++ b/kustomize/components/network-policies/README.md
@@ -4,7 +4,7 @@ You can use [Network Policies](https://kubernetes.io/docs/concepts/services-netw
 
 To use `NetworkPolicies` in Google Kubernetes Engine (GKE), you will need a GKE cluster with network policy enforcement enabled, the recommended approach is to use [GKE Dataplane V2](https://cloud.google.com/kubernetes-engine/docs/how-to/dataplane-v2).
 
-To use `NetworkPolicies` on a local cluster such as [minikube](https://minikube.sigs.k8s.io/docs/start/), you will need to use an alternative CNI that supports `NetworkPolicies` like [Calico](https://projectcalico.docs.tigera.io/getting-started/kubernetes/minikube). To run a minikube cluster with Calico, run `minikube start --cni=calico`. By design, the minikube default CNI flannel does not support it.  
+To use `NetworkPolicies` on a local cluster such as [minikube](https://minikube.sigs.k8s.io/docs/start/), you will need to use an alternative CNI that supports `NetworkPolicies` like [Calico](https://projectcalico.docs.tigera.io/getting-started/kubernetes/minikube). To run a minikube cluster with Calico, run `minikube start --cni=calico`. By design, the minikube default CNI [Kindnet](https://github.com/aojea/kindnet) does not support it.  
 
 ## Deploy Online Boutique with `NetworkPolicies` via Kustomize
 


### PR DESCRIPTION
the default is kindnet not flannel. ref: https://minikube.sigs.k8s.io/docs/handbook/network_policy/#:~:text=minikube%20allows%20users%20to%20create,at%20the%20end%20of%20development.

### Background 
Docs were incorrect

### Fixes 
<!-- Link the issue(s) this PR fixes-->
### Change Summary
<!-- Short summary of the changes submitted -->

### Additional Notes
<!-- Any remaining concerns -->

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
