### PR TITLE
Use --pull flag when building images for releases

### DIFF
--- a/hack/make-docker-images.sh
+++ b/hack/make-docker-images.sh
@@ -37,7 +37,7 @@ while IFS= read -d $'\0' -r dir; do
     (
         cd "${builddir}"
         log "Building: ${image}"
-        docker build -t "${image}" .
+        docker build --pull -t "${image}" .
 
         log "Pushing: ${image}"
         docker push "${image}"
@@ -45,7 +45,7 @@ while IFS= read -d $'\0' -r dir; do
         if [ $svcname != "frontend" ] && [ $svcname != "loadgenerator" ]
         then
             log "Building: ${image}-native-grpc-probes"
-            docker build -t "${image}-native-grpc-probes" . --target without-grpc-health-probe-bin
+            docker build --pull -t "${image}-native-grpc-probes" . --target without-grpc-health-probe-bin
             log "Pushing: ${image}-native-grpc-probes"
             docker push "${image}-native-grpc-probes"
         fi


### PR DESCRIPTION
### Background 
* When I first created the v0.4.2 release, [`emailservice:v0.4.2`](https://pantheon.corp.google.com/gcr/images/google-samples/global/microservices-demo/emailservice?tab=vulnz&project=google-samples&mods=prod_coliseum) still contained the same # of CVEs as `emailservice:v0.4.1`.
* But we expected CVE-2022-43680 to be fixed in `emailservice:v0.4.2`.
* The reason it wasn't being fixed was because CVE-2022-43680 was being sourced from the `emailservice`'s base Docker images — which my local machine was caching when I initially built `emailservice:v0.4.2`.
* The `--pull` flag is [explained here](https://stackoverflow.com/questions/58488535/whats-the-purpose-of-docker-build-pull). It makes sure the base Docker image is pulled (not from local cache but from the registry) when we `docker build`.

### Change Summary
* Use the `--pull` flag to ensure that the base Docker images is pulled from the registry (not my local cache) when container images are built.

### Testing Procedure
* I have already tested this when I created the images for `v0.4.2`.
* If you look at the [`emailservice` on our Google Container Registry](https://pantheon.corp.google.com/gcr/images/google-samples/global/microservices-demo/emailservice?tab=vulnz&project=google-samples&mods=prod_coliseum), you'll see that `v0.4.2` has one less vulnerability than `v0.4.1`, which means the base images was pulled (not from cache) when I build `emailservice` on my local machine.
