### PR TITLE
Remove redundant COLLECTOR_SERVICE_ADDR

### DIFF
--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -45,8 +45,6 @@ spec:
         ports:
         - containerPort: 3550
         env:
-        - name: COLLECTOR_SERVICE_ADDR
-          value: "opentelemetrycollector:4317"
         - name: PORT
           value: "3550"
         - name: DISABLE_PROFILER


### PR DESCRIPTION
## Background
* This `COLLECTOR_SERVICE_ADDR` environment variable is only used when a user uses the `google-cloud-operations` Kustomize Component.
* The `google-cloud-operations` Kustomize Component takes care of running the OpenTelemetry Collector service, which the `productcatalogservice` will send its OpenTelemetry traces to.
* This `COLLECTOR_SERVICE_ADDR` environment variable is also set (for the `productcatalogservice`) by the `google-cloud-operations` Kustomize Component. See [`/kustomize/components/google-cloud-operations/kustomization.yaml`](https://github.com/GoogleCloudPlatform/microservices-demo/blob/release/v0.4.2/kustomize/components/google-cloud-operations/kustomization.yaml#L132).

## The Fix
* Remove `COLLECTOR_SERVICE_ADDR` from the default YAML of Online Boutique.

## Additional Info
* Relevant pull-request: https://github.com/GoogleCloudPlatform/microservices-demo/pull/1180/files.