### PR TITLE
Vary Cymbal buttons' style based on state

### DIFF
--- a/src/frontend/static/styles/styles.css
+++ b/src/frontend/static/styles/styles.css
@@ -587,9 +587,32 @@ the rules below could be extracted.
   color: white;
 }
 
+.cymbal-button-primary:active,
+.cymbal-button-primary:focus,
+.cymbal-button-primary:hover {
+  border: solid 1px #7b031d;
+  background-color: #7b031d;
+  box-shadow: 0px 2px 2px 0px rgb(0 0 0 / 30%);
+}
+
+.cymbal-button-primary:active {
+  box-shadow: 0px 3px 6px 0px rgb(0 0 0 / 30%);
+}
+
 .cymbal-button-secondary {
   background: none;
   color: #CE0631;
+}
+
+.cymbal-button-secondary:active,
+.cymbal-button-secondary:focus,
+.cymbal-button-secondary:hover {
+  color: #7b031d;
+  border: solid 1px #7b031d;
+}
+
+.cymbal-button-secondary:active {
+  background-color: #f5ccd5;
 }
 
 .cymbal-form-field {


### PR DESCRIPTION
### Background 
* Please see https://github.com/GoogleCloudPlatform/microservices-demo/issues/614.

### Fixes 
This fixes https://github.com/GoogleCloudPlatform/microservices-demo/issues/614.

### Change Summary
* The appearance of the primary and secondary buttons now respond to cursor hovering and clicks.

### Testing Procedure
* Open the staging URL.
* Go to the checkout page.
* Play around with the two buttons:
    * Try hovering with your mouse.
    * Try clicking.
 
![d1b65e2d-07cb-4936-b000-1561ab316bb2](https://user-images.githubusercontent.com/10292865/204028889-608f5cc2-c32a-40ba-bf9d-5820707decdc.gif)