### PR TITLE
Clarify product-requirements.md

### DIFF
--- a/docs/product-requirements.md
+++ b/docs/product-requirements.md
@@ -8,7 +8,7 @@ Every change must:
 
 These requirements are about the default deployment (default configuration) of Online Boutique.
 Changes that will violate any of these rules should not be built into the default configuration of Online Boutique.
-Such changes should be opt-in only — ideally, as a [Kustomize Component](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/kustomize).
+Such changes should be opt-in only — ideally, as a [Kustomize Component](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/kustomize) if they align with the [purpose of Online Boutique](/docs/purpose.md).
 
 ### 1. Preserve the golden user journey taken by Kubernetes beginners
 


### PR DESCRIPTION
### Background 
* The `product-requirements.md` needs to clarify that the requirements are about the _default_ deployment of Online Boutique.
* This was inspired by a conversation we had with @boredabdel.

### Change Summary
* Clarify that Online Boutique welcomes changes as long as they are added as an "opt-in" feature — and is not builts into the default configuration of Online Boutique.

### Testing Procedure
* Read `product-requirements.md` as though you are a non-Googler that would like to contribute.
