### PR TITLE
Renovate for container images in Kubernetes manifests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,5 +39,8 @@
   },
   "npm":{
     "addLabels": ["lang: nodejs"]
+  },
+  "kubernetes": {
+    "fileMatch”: [“(^|/)[^/]*\\.yaml$”] }
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,10 @@
     "addLabels": ["lang: nodejs"]
   },
   "kubernetes": {
-    "fileMatch": ["\\.yaml$"]
+    "fileMatch": ["\\.yaml$"],
+    "ignorePaths": [
+      "^release/**",
+      "^kustomize/base/**"
+    ]
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,6 @@
     "addLabels": ["lang: nodejs"]
   },
   "kubernetes": {
-    "fileMatch”: [“(^|/)[^/]*\\.yaml$”] }
+    "fileMatch": ["\\.yaml$"]
   }
 }


### PR DESCRIPTION
https://docs.renovatebot.com/modules/manager/kubernetes/

As soon as it's merged in `main`, the goal is to catch any update of any container images referenced in any Kubernetes manifests. Like for example https://github.com/GoogleCloudPlatform/microservices-demo/blob/main/kustomize/components/google-cloud-operations/otel-collector.yaml#L71