### PR TITLE
Python 3.10

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     }
   },
   "constraints": {
-    "python": "~=3.9.0"
+    "python": "~=3.10.0"
   },
   "prConcurrentLimit":8,
   "stabilityDays":7,

--- a/src/emailservice/Dockerfile
+++ b/src/emailservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.9.15-slim as base
+FROM python:3.10.8-slim as base
 
 FROM base as builder
 
@@ -39,7 +39,7 @@ ENV ENABLE_PROFILER=1
 WORKDIR /email_server
 
 # Grab packages from builder
-COPY --from=builder /usr/local/lib/python3.9/ /usr/local/lib/python3.9/
+COPY --from=builder /usr/local/lib/python3.10/ /usr/local/lib/python3.10/
 
 # Add the application
 COPY . .

--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.9.15-slim as base
+FROM python:3.10.8-slim as base
 
 FROM base as builder
 

--- a/src/recommendationservice/Dockerfile
+++ b/src/recommendationservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.9.15-slim as base
+FROM python:3.10.8-slim as base
 
 FROM base as builder
 
@@ -38,7 +38,7 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /recommendationservice
 
 # Grab packages from builder
-COPY --from=builder /usr/local/lib/python3.9/ /usr/local/lib/python3.9/
+COPY --from=builder /usr/local/lib/python3.10/ /usr/local/lib/python3.10/
 
 # Add the application
 COPY . .


### PR DESCRIPTION
Python 3.10 for `emailservice`, `loadgenerator` and `recommendationservice`.

Thanks to https://github.com/GoogleCloudPlatform/microservices-demo/pull/1281 we could move forward with Python 3.10.

Note: same number of vulnerabilities still: 47 + the size of the container images increased a little bit with +1.6MB.