### PR TITLE
`loadgenerator` - Python 3.11

### DIFF
--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -16,10 +16,6 @@ FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b
 
 FROM base as builder
 
-RUN apt-get -qq update \
-    && apt-get install -y --no-install-recommends \
-        g++
-
 COPY requirements.txt .
 
 RUN pip install --prefix="/install" -r requirements.txt

--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.10.8-slim@sha256:ac482ce5c90d9cbb5afd90d801f66a56d7d92c5f761b7e025fd0d7a702c1368e as base
+FROM python:3.11.0-slim@sha256:b59417e37f49eaf8f60a68193f1b27ea4f4c996394e88535b45509c8322a0f8a as base
 
 FROM base as builder
 


### PR DESCRIPTION
`loadgenerator` - Python 3.11

Note: Same number of CVEs, 47 + size of the container image increased with +2.1MB.

Because we have issue with Cloud Profiler preventing both `emailservice` and `recommendationservice` to be upgraded to Python 3.11 (https://github.com/GoogleCloudPlatform/microservices-demo/pull/1318), proposing to at least go ahead with `loadgenerator` for now.

Also took the initiative to remove the unecessary/unused `g++` installation and dependencies update in the `builder` stage.