### PR TITLE
Update renovate.json for Kubernetes manifests (`ignorePaths`)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,8 +46,8 @@
   "kubernetes": {
     "fileMatch": ["\\.yaml$"],
     "ignorePaths": [
-      "^release/**",
-      "^kustomize/base/**"
+      "release/**",
+      "kustomize/base/**"
     ]
   },
   "regexManagers": [


### PR DESCRIPTION
Update renovate.json for Kubernetes manifests (`ignorePaths`). Needs to be merged into `main` branch to be tested.