### PR TITLE
Update renovate.json - to avoid too much digests in manifests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,18 +41,14 @@
     "addLabels": ["lang: nodejs"]
   },
   "docker": {
-    "pinDigests": true,
-    "ignorePaths": [
-      "release/**",
-      "kustomize/**",
-      "kubernetes-manifests/**"
-    ]
+    "pinDigests": true
   },
   "kubernetes": {
     "fileMatch": ["\\.yaml$"],
     "ignorePaths": [
       "release/**",
-      "kustomize/base/**"
+      "kustomize/base/**",
+      "kubernetes-manifests/**"
     ]
   },
   "regexManagers": [


### PR DESCRIPTION
Update renovate.json - to avoid too much digests in manifests.

The initial intent is to have digests in Dockerfiles, but because we also use the `kubernetes` rule, digests are updated in there. We want to keep this (both) for the `kustomize/components`, especially to catch the `otel-collector` image. So we are making a compromise here to only have digest in these manifests, not all the manifests.