### PR TITLE
Specify name of kustomize-build-ci job

### DIFF
--- a/.github/workflows/kustomize-build-ci.yaml
+++ b/.github/workflows/kustomize-build-ci.yaml
@@ -25,7 +25,7 @@ on:
       - 'kustomize/**'
       - '.github/workflows/kustomize-build-ci.yaml'
 jobs:
-  job:
+  kustomize-build-ci:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/terraform-validate-ci.yaml
+++ b/.github/workflows/terraform-validate-ci.yaml
@@ -25,7 +25,7 @@ on:
       - 'terraform/**'
       - '.github/workflows/terraform-validate-ci.yaml'
 jobs:
-  job:
+  terraform-validate-ci:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Background 
* Check out [this old invocation](https://github.com/GoogleCloudPlatform/microservices-demo/actions/runs/3594369585/jobs/6052539581) of the `kustomize-build-ci` GitHub Action.
* You'll notice the list of jobs on the left side.
* It says "job".
* We want it to be more specific.
<img width="168" alt="Screenshot 2022-12-01 at 11 21 58 AM" src="https://user-images.githubusercontent.com/10292865/205105367-f8424bc6-9b0e-4bbd-844e-bc1ade53bddf.png">

* This is true for the `terraform-validate-ci` GitHub Action too.

### Change Summary
* Give names to the 2 jobs:
    * `terraform-validate-ci`
    * `kustomize-build-ci`

### Additional Notes
* We are hoping that these new names (for the 2 jobs) will help us locate these GitHub Actions inside "Require status checks to pass before merging" search bar inside the [`main` branch's protection rules](https://github.com/GoogleCloudPlatform/microservices-demo/settings/branch_protection_rules/2126074).

### Testing Procedure
* Check the CI checks of this pull-request. Check that the jobs have names.
