### PR TITLE
IPv6 support

### DIFF
--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -47,7 +47,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/online-boutique-ci/refs/pull/1340/emailservice:1340
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.4.2
         ports:
         - containerPort: 8080
         env:
@@ -366,7 +366,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/online-boutique-ci/refs/pull/1340/paymentservice:1340
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.4.2
         ports:
         - containerPort: 50051
         env:
@@ -498,7 +498,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/online-boutique-ci/refs/pull/1340/cartservice:1340
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.4.2
         ports:
         - containerPort: 7070
         env:

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -229,33 +229,6 @@ spec:
     port: 8080
     targetPort: 8080
 ---
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
- - adservice.yaml
- - cartservice.yaml
- - checkoutservice.yaml
- - currencyservice.yaml
- - emailservice.yaml
- - frontend.yaml
-# - loadgenerator.yaml # During development, the loadgenerator module inside skaffold.yaml will be used.
- - paymentservice.yaml
- - productcatalogservice.yaml
- - recommendationservice.yaml
- - redis.yaml
- - shippingservice.yaml
-components:
-# - ../kustomize/components/cymbal-branding
-# - ../kustomize/components/google-cloud-operations
-# - ../kustomize/components/memorystore
-# - ../kustomize/components/network-policies
-# - ../kustomize/components/service-accounts
-# - ../kustomize/components/spanner
-# - ../kustomize/components/container-images-tag
-# - ../kustomize/components/container-images-tag-suffix
-# - ../kustomize/components/container-images-registry
-# - ../kustomize/components/native-grpc-health-check
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -525,7 +498,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.4.2
+        image: gcr.io/online-boutique-ci/refs/pull/1340/cartservice:1340
         ports:
         - containerPort: 7070
         env:

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -633,7 +633,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/online-boutique-ci/refs/pull/1340/currencyservice:1340
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.4.2
         ports:
         - name: grpc
           containerPort: 7000

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -47,7 +47,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.4.2
+        image: gcr.io/online-boutique-ci/refs/pull/1340/emailservice:1340
         ports:
         - containerPort: 8080
         env:
@@ -393,7 +393,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.4.2
+        image: gcr.io/online-boutique-ci/refs/pull/1340/paymentservice:1340
         ports:
         - containerPort: 50051
         env:
@@ -660,7 +660,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.4.2
+        image: gcr.io/online-boutique-ci/refs/pull/1340/currencyservice:1340
         ports:
         - name: grpc
           containerPort: 7000

--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Grpc.AspNetCore" Version="2.50.0" />
     <PackageReference Include="Grpc.HealthCheck" Version="2.50.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.0" />
-    # Add explicit direct dependency required for ipv6, see https://github.com/dotnet/aspnetcore/issues/45424
+    <!-- Add explicit direct dependency required for ipv6, see https://github.com/dotnet/aspnetcore/issues/45424 -->
     <PackageReference Include="StackExchange.Redis" Version="2.6.80" />
     <PackageReference Include="Google.Cloud.Spanner.Data" Version="4.2.0" />
   </ItemGroup>

--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Grpc.AspNetCore" Version="2.50.0" />
     <PackageReference Include="Grpc.HealthCheck" Version="2.50.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.0" />
+    # Add explicit direct dependency required for ipv6, see https://github.com/dotnet/aspnetcore/issues/45424
     <PackageReference Include="StackExchange.Redis" Version="2.6.80" />
     <PackageReference Include="Google.Cloud.Spanner.Data" Version="4.2.0" />
   </ItemGroup>

--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Grpc.AspNetCore" Version="2.50.0" />
     <PackageReference Include="Grpc.HealthCheck" Version="2.50.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.80" />
     <PackageReference Include="Google.Cloud.Spanner.Data" Version="4.2.0" />
   </ItemGroup>
 

--- a/src/currencyservice/server.js
+++ b/src/currencyservice/server.js
@@ -172,7 +172,7 @@ function main () {
   server.addService(healthProto.Health.service, {check});
 
   server.bindAsync(
-    `0.0.0.0:${PORT}`,
+    `[::]:${PORT}`,
     grpc.ServerCredentials.createInsecure(),
     function() {
       logger.info(`CurrencyService gRPC server started on port ${PORT}`);

--- a/src/emailservice/email_client.py
+++ b/src/emailservice/email_client.py
@@ -23,7 +23,7 @@ from logger import getJSONLogger
 logger = getJSONLogger('emailservice-client')
 
 def send_confirmation_email(email, order):
-  channel = grpc.insecure_channel('0.0.0.0:8080')
+  channel = grpc.insecure_channel('[::]:8080')
   stub = demo_pb2_grpc.EmailServiceStub(channel)
   try:
     response = stub.SendOrderConfirmation(demo_pb2.SendOrderConfirmationRequest(

--- a/src/paymentservice/server.js
+++ b/src/paymentservice/server.js
@@ -64,7 +64,7 @@ class HipsterShopServer {
     const server = this.server 
     const port = this.port
     server.bindAsync(
-      `0.0.0.0:${port}`,
+      `[::]:${port}`,
       grpc.ServerCredentials.createInsecure(),
       function () {
         logger.info(`PaymentService gRPC server started on port ${port}`);


### PR DESCRIPTION
Support IPv6 on single-stack clusters.

2 issues are fixed:
- https://github.com/GoogleCloudPlatform/microservices-demo/issues/599
- https://github.com/GoogleCloudPlatform/microservices-demo/issues/1221.

We set `[::]` instead of `0.0.0.0` and will see from there. It seems that `[::]` works for both stacks: IPv4 and IPv6 (the app on our GKE-IPv4 test environment here http://34.27.51.101/ is still working). It was already the case in the code for `recommendationservice` and `emailservice`:
- https://github.com/GoogleCloudPlatform/microservices-demo/blob/main/src/recommendationservice/recommendation_server.py#L143
- https://github.com/GoogleCloudPlatform/microservices-demo/blob/main/src/emailservice/email_server.py#L130

For the `StackExchange.Redis` issue, we need to add a direct dependency to `StackExchange.Redis`. See https://github.com/dotnet/aspnetcore/issues/45424.

**How to test this?** Good question, you just have to deploy the following images:
- `gcr.io/online-boutique-ci/refs/pull/1340/paymentservice:1340`
- `gcr.io/online-boutique-ci/refs/pull/1340/cartservice:1340`
- `gcr.io/online-boutique-ci/refs/pull/1340/currencyservice:1340`
- `gcr.io/online-boutique-ci/refs/pull/1340/emailservice:1340`

Also, capturing some findings/learnings/pointers here too:
- https://stackoverflow.com/questions/27480094/ipv6-is-equivalent-to-0-0-0-0-when-listening-for-connections
- https://www.grouparoo.com/blog/node-js-and-ipv6#ipv6-also-support-ipv4-addresses
- [GKE in dual-stack mode](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips#dual_stack_network), so we can't test the single-stack IPv6 scenario with GKE, apparently.