### PR TITLE
Use strings for severity of `currencyservice` log output

### DIFF
--- a/src/currencyservice/client.js
+++ b/src/currencyservice/client.js
@@ -31,8 +31,11 @@ const client = new shopProto.CurrencyService(`localhost:${PORT}`,
 const logger = pino({
   name: 'currencyservice-client',
   messageKey: 'message',
-  changeLevelName: 'severity',
-  useLevelLabels: true
+  formatters: {
+    level (logLevelString, logLevelNum) {
+      return { severity: logLevelString }
+    }
+  }
 });
 
 const request = {

--- a/src/currencyservice/server.js
+++ b/src/currencyservice/server.js
@@ -67,8 +67,11 @@ const healthProto = _loadProto(HEALTH_PROTO_PATH).grpc.health.v1;
 const logger = pino({
   name: 'currencyservice-server',
   messageKey: 'message',
-  changeLevelName: 'severity',
-  useLevelLabels: true
+  formatters: {
+    level (logLevelString, logLevelNum) {
+      return { severity: logLevelString }
+    }
+  }
 });
 
 /**

--- a/src/paymentservice/charge.js
+++ b/src/paymentservice/charge.js
@@ -19,8 +19,11 @@ const pino = require('pino');
 const logger = pino({
   name: 'paymentservice-charge',
   messageKey: 'message',
-  changeLevelName: 'severity',
-  useLevelLabels: true
+  formatters: {
+    level (logLevelString, logLevelNum) {
+      return { severity: logLevelString }
+    }
+  }
 });
 
 

--- a/src/paymentservice/server.js
+++ b/src/paymentservice/server.js
@@ -22,8 +22,11 @@ const charge = require('./charge');
 const logger = pino({
   name: 'paymentservice-server',
   messageKey: 'message',
-  changeLevelName: 'severity',
-  useLevelLabels: true
+  formatters: {
+    level (logLevelString, logLevelNum) {
+      return { severity: logLevelString }
+    }
+  }
 });
 
 class HipsterShopServer {


### PR DESCRIPTION
### Background 
* Please see my comment in https://github.com/GoogleCloudPlatform/microservices-demo/issues/1274.

### Fixes 
https://github.com/GoogleCloudPlatform/microservices-demo/issues/1274

### Change Summary
* Use the new `formatters` option of `pino` to make sure `currencyservice`'s logs output severity as a string (e.g., `"info"`) — not a number (e.g., `30`).

### Additional Notes
* Let me know if you'd like me to clarify anything.

### Testing Procedure
* Check the [logs of the `currencyservice`](https://pantheon.corp.google.com/kubernetes/service/us-central1-c/online-boutique-prs/pr1344/currencyservice/logs?project=online-boutique-ci) of the staging deployment.

