### PR TITLE
Remove `kustomization` `Kind` in  `release/kubernetes-manifests.yaml` in `v0.4.2` branch.

### DIFF
--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -229,33 +229,6 @@ spec:
     port: 8080
     targetPort: 8080
 ---
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
- - adservice.yaml
- - cartservice.yaml
- - checkoutservice.yaml
- - currencyservice.yaml
- - emailservice.yaml
- - frontend.yaml
-# - loadgenerator.yaml # During development, the loadgenerator module inside skaffold.yaml will be used.
- - paymentservice.yaml
- - productcatalogservice.yaml
- - recommendationservice.yaml
- - redis.yaml
- - shippingservice.yaml
-components:
-# - ../kustomize/components/cymbal-branding
-# - ../kustomize/components/google-cloud-operations
-# - ../kustomize/components/memorystore
-# - ../kustomize/components/network-policies
-# - ../kustomize/components/service-accounts
-# - ../kustomize/components/spanner
-# - ../kustomize/components/container-images-tag
-# - ../kustomize/components/container-images-tag-suffix
-# - ../kustomize/components/container-images-registry
-# - ../kustomize/components/native-grpc-health-check
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Remove `kustomization` `Kind` in  `release/kubernetes-manifests.yaml` in `v0.4.2` branch.

Otherwise, when doing `k apply -f https://github.com/GoogleCloudPlatform/microservices-demo/raw/release/v0.4.2/release/kubernetes-manifests.yaml` it will generate this warning (not a blocker, the other manifests are deployed successfully):
```
error: resource mapping not found for name: "" namespace: "" from "https://github.com/GoogleCloudPlatform/microservices-demo/raw/release/v0.4.2/release/kubernetes-manifests.yaml": no matches for kind "Kustomization" in version "kustomize.config.k8s.io/v1beta1"
ensure CRDs are installed first
```