### PR TITLE
Fix Helm chart with advanced scenarios

### DIFF
--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -25,6 +25,8 @@ on:
       - '.github/workflows/kustomize-build-ci.yaml'
       - 'terraform/**'
       - '.github/workflows/terraform-validate-ci.yaml'
+      - 'helm-chart/**'
+      - '.github/workflows/helm-chart-ci.yaml'
 jobs:
   code-tests:
     runs-on: [self-hosted, is-enabled]

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -23,6 +23,8 @@ on:
       - '.github/workflows/kustomize-build-ci.yaml'
       - 'terraform/**'
       - '.github/workflows/terraform-validate-ci.yaml'
+      - 'helm-chart/**'
+      - '.github/workflows/helm-chart-ci.yaml'
 
 jobs:
   code-tests:

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -6,12 +6,15 @@ If you'd like to deploy Online Boutique via its Helm chart, you could leverage t
 
 Deploy the default setup of Online Boutique:
 ```sh
-helm install onlineboutique oci://us-docker.pkg.dev/online-boutique-ci/charts/onlineboutique
+helm upgrade onlineboutique oci://us-docker.pkg.dev/online-boutique-ci/charts/onlineboutique \
+    --install
 ```
 
 Deploy advanced scenario of Online Boutique:
 ```sh
-helm install onlineboutique oci://us-docker.pkg.dev/online-boutique-ci/charts/onlineboutique \
+helm upgrade onlineboutique oci://us-docker.pkg.dev/online-boutique-ci/charts/onlineboutique \
+    --install \
+    --create-namespace \
     --set images.repository=us-docker.pkg.dev/my-project/containers/onlineboutique \
     --set frontend.externalService=false \
     --set redis.create=false \
@@ -28,3 +31,8 @@ helm install onlineboutique oci://us-docker.pkg.dev/online-boutique-ci/charts/on
 ```
 
 For the full list of configurations, see [values.yaml](./values.yaml).
+
+You could also find advanced scenarios with these blogs below:
+- [Online Boutique sample’s Helm chart, to simplify the setup of advanced and secured scenarios with Service Mesh and GitOps](https://medium.com/google-cloud/246119e46d53)
+- [gRPC health probes with Kubernetes 1.24+](https://medium.com/google-cloud/b5bd26253a4c)
+- [Use Google Cloud Spanner with the Online Boutique sample](https://medium.com/google-cloud/f7248e077339)

--- a/helm-chart/templates/adservice.yaml
+++ b/helm-chart/templates/adservice.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if .Values.adService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -151,6 +137,9 @@ spec:
   egress:
   - hosts:
     - istio-system/*
+    {{- if .Values.opentelemetryCollector.create }}
+    - ./{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- end }}
 {{- end }}
 {{- if .Values.authorizationPolicies.create }}
 ---

--- a/helm-chart/templates/cartservice.yaml
+++ b/helm-chart/templates/cartservice.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if .Values.cartService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -165,8 +151,11 @@ spec:
     {{- if .Values.cartDatabase.externalRedisTlsOrigination.enable }}
     - ./{{ .Values.cartDatabase.externalRedisTlsOrigination.name }}.{{ .Release.Namespace }}
     {{- else }}
-    - ./{{ .Values.redis.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    - ./{{ .Values.cartDatabase.inClusterRedis.name }}.{{ .Release.Namespace }}.svc.cluster.local
     {{- end }}
+    {{- end }}
+    {{- if .Values.opentelemetryCollector.create }}
+    - ./{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}.svc.cluster.local
     {{- end }}
 {{- end }}
 {{- if .Values.authorizationPolicies.create }}

--- a/helm-chart/templates/checkoutservice.yaml
+++ b/helm-chart/templates/checkoutservice.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if .Values.checkoutService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -176,6 +162,9 @@ spec:
     - ./{{ .Values.paymentService.name }}.{{ .Release.Namespace }}.svc.cluster.local
     - ./{{ .Values.productCatalogService.name }}.{{ .Release.Namespace }}.svc.cluster.local
     - ./{{ .Values.shippingService.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- if .Values.opentelemetryCollector.create }}
+    - ./{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- end }}
 {{- end }}
 {{- if .Values.authorizationPolicies.create }}
 ---

--- a/helm-chart/templates/common.yaml
+++ b/helm-chart/templates/common.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if .Values.networkPolicies.create }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -23,4 +9,13 @@ spec:
   policyTypes:
   - Ingress
   - Egress
+{{- end }}
+{{- if .Values.authorizationPolicies.create }}
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: deny-all
+  namespace: {{ .Release.Namespace }}
+spec: {}
 {{- end }}

--- a/helm-chart/templates/currencyservice.yaml
+++ b/helm-chart/templates/currencyservice.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if .Values.currencyService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -163,6 +149,9 @@ spec:
   egress:
   - hosts:
     - istio-system/*
+    {{- if .Values.opentelemetryCollector.create }}
+    - ./{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- end }}
 {{- end }}
 {{- if .Values.authorizationPolicies.create }}
 ---

--- a/helm-chart/templates/emailservice.yaml
+++ b/helm-chart/templates/emailservice.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if .Values.emailService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -161,6 +147,9 @@ spec:
   egress:
   - hosts:
     - istio-system/*
+    {{- if .Values.opentelemetryCollector.create }}
+    - ./{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- end }}
 {{- end }}
 {{- if .Values.authorizationPolicies.create }}
 ---

--- a/helm-chart/templates/frontend.yaml
+++ b/helm-chart/templates/frontend.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if .Values.frontend.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -182,10 +168,10 @@ spec:
     {{- if .Values.frontend.virtualService.create }}
     - namespaceSelector:
         matchLabels:
-          name: asm-ingress
+          name: {{ .Values.frontend.virtualService.gateway.namespace }}
       podSelector:
         matchLabels:
-          app: asm-ingressgateway
+          {{ .Values.frontend.virtualService.gateway.labelKey }}: {{ .Values.frontend.virtualService.gateway.labelValue }}
     {{- end }}
     ports:
      - port: 8080
@@ -215,6 +201,9 @@ spec:
     - ./{{ .Values.productCatalogService.name }}.{{ .Release.Namespace }}.svc.cluster.local
     - ./{{ .Values.recommendationService.name }}.{{ .Release.Namespace }}.svc.cluster.local
     - ./{{ .Values.shippingService.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- if .Values.opentelemetryCollector.create }}
+    - ./{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- end }}
 {{- end }}
 {{- if .Values.authorizationPolicies.create }}
 ---
@@ -228,22 +217,22 @@ spec:
     matchLabels:
       app: {{ .Values.frontend.name }}
   rules:
+  {{- if .Values.frontend.externalService }}
+  - to:
+  {{- else }}
   - from:
     - source:
         principals:
-        {{- if .Values.frontend.externalService }}
-        - '*'
-        {{- else }}
         {{- if .Values.serviceAccounts.create }}
         - cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Values.loadGenerator.name }}
         {{- else }}
         - cluster.local/ns/{{ .Release.Namespace }}/sa/default
         {{- end }}
-        {{- end }}
         {{- if .Values.frontend.virtualService.create }}
         - cluster.local/ns/{{ .Values.frontend.virtualService.gateway.namespace }}/sa/{{ .Values.frontend.virtualService.gateway.name }}
         {{- end }}
     to:
+  {{- end }}  
     - operation:
         methods:
         - GET

--- a/helm-chart/templates/loadgenerator.yaml
+++ b/helm-chart/templates/loadgenerator.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if .Values.loadGenerator.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -138,5 +124,8 @@ spec:
   - hosts:
     - istio-system/*
     - ./{{ .Values.frontend.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- if .Values.opentelemetryCollector.create }}
+    - ./{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-chart/templates/opentelemetry-collector.yaml
+++ b/helm-chart/templates/opentelemetry-collector.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if .Values.opentelemetryCollector.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1

--- a/helm-chart/templates/paymentservice.yaml
+++ b/helm-chart/templates/paymentservice.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if .Values.paymentService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -159,6 +145,9 @@ spec:
   egress:
   - hosts:
     - istio-system/*
+    {{- if .Values.opentelemetryCollector.create }}
+    - ./{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- end }}
 {{- end }}
 {{- if .Values.authorizationPolicies.create }}
 ---

--- a/helm-chart/templates/productcatalogservice.yaml
+++ b/helm-chart/templates/productcatalogservice.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if .Values.productCatalogService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -167,6 +153,9 @@ spec:
   egress:
   - hosts:
     - istio-system/*
+    {{- if .Values.opentelemetryCollector.create }}
+    - ./{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- end }}
 {{- end }}
 {{- if .Values.authorizationPolicies.create }}
 ---

--- a/helm-chart/templates/recommendationservice.yaml
+++ b/helm-chart/templates/recommendationservice.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if .Values.recommendationService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -164,6 +150,9 @@ spec:
   - hosts:
     - istio-system/*
     - ./{{ .Values.productCatalogService.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- if .Values.opentelemetryCollector.create }}
+    - ./{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- end }}
 {{- end }}
 {{- if .Values.authorizationPolicies.create }}
 ---

--- a/helm-chart/templates/redis.yaml
+++ b/helm-chart/templates/redis.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if eq .Values.cartDatabase.type "redis" }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1

--- a/helm-chart/templates/shippingservice.yaml
+++ b/helm-chart/templates/shippingservice.yaml
@@ -1,17 +1,3 @@
-# Copyright 2022 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 {{- if .Values.shippingService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -154,6 +140,9 @@ spec:
   egress:
   - hosts:
     - istio-system/*
+    {{- if .Values.opentelemetryCollector.create }}
+    - ./{{ .Values.opentelemetryCollector.name }}.{{ .Release.Namespace }}.svc.cluster.local
+    {{- end }}
 {{- end }}
 {{- if .Values.authorizationPolicies.create }}
 ---

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -82,6 +82,8 @@ frontend:
     gateway:
       name: asm-ingressgateway
       namespace: asm-ingress
+      labelKey: asm
+      labelValue: ingressgateway
 
 loadGenerator:
   create: true


### PR DESCRIPTION
- Fix issue when exposed behind an Istio Ingress Gateway
- Take into account `opentelemetryCollector` with `Sidecars`
- Fix `frontend`'s `AuthorizationPolicy` with Istio Ingress Gateway
- Add a `deny-all` `AuthorizationPolicy`
- Fix `cartservice`'s `Sidecar` with `redis` name
- Deploy the Helm chart via Config Sync (GitOps): errors with the license headers in empty file, we don't need these headers for these generated by Helm manifests
- Do not trigger `ci-main` nor `ci-pr` when only updates in `helm-chart/**`