### PR TITLE
chore: update config for metrics purposes

### DIFF
--- a/.deploystack/deploystack.yaml
+++ b/.deploystack/deploystack.yaml
@@ -1,6 +1,7 @@
 # The fields inside this deploystack.yaml file are documented in https://github.com/GoogleCloudPlatform/deploystack.
 
 title: Microservices Demo (Online Boutique)
+name: microservices-demo
 duration: 5
 collect_project: true
 collect_region: true


### PR DESCRIPTION
### Background 
Cannot record metric impact of running this through Deploystack - no way to count api usage without this string in the config file

### Change Summary
Added a line to the deploystack config to make sure that these calls are labeled properly in our systems.  This is a super minimal fix that only affects how this stack's deployments are metricked. 


