### PR TITLE
Add package rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -60,5 +60,10 @@
         "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s(?:ENV|ARG) .+?_VERSION[ =]\"?(?<currentValue>.+?)\"?\\s"
       ]
     }
-  ]
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true
+    }]
 }


### PR DESCRIPTION
### Background 
Fine tuning renovate bot to not be so noisy!

### Fixes 
<!-- Link the issue(s) this PR fixes-->
### Change Summary
Adding `packageRules` ([docs](https://docs.renovatebot.com/configuration-options/#packagerules)). 

### Additional Notes
~It wasn't 100% clear to me if that this rule will wait for the tests to pass, then merge.~ Found this actually![source](https://docs.renovatebot.com/key-concepts/automerge/). It does wait for the tests to pass before auto merging

### Testing Procedure
Keep an eye our for anything less than a minor bump PR, seeing if it behaves properly!

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
