### PR TITLE
Add platformAutomerge in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,5 +65,7 @@
     {
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true
-    }]
+    }
+  ],
+  "platformAutomerge": true
 }


### PR DESCRIPTION
### Background 
We were not seeing the expected automerge behavior 

### Fixes 
<!-- Link the issue(s) this PR fixes-->
### Change Summary
Added the platform automerge field in the `renovate.json`. [ Doc here](https://docs.renovatebot.com/configuration-options/#platformautomerge)
```
platformAutomerge will configure PRs to be merged after all (if any) branch policies have been me
```

### Additional Notes
<!-- Any remaining concerns -->

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
