### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# The .editorconfig is used to maintain consistent code style.
+# The .editorconfig file is supported by most text editors.
+# See https://editorconfig.org
+
+root = true
+
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.cs]
+indent_size = 4
+
+[Dockerfile*]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,6 @@ indent_size = 4
 
 [*.go]
 indent_style = tab
+
+[*.py]
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -19,5 +19,8 @@ indent_size = 4
 [*.go]
 indent_style = tab
 
+[*.java]
+indent_size = 4
+
 [*.py]
 indent_size = 4


### PR DESCRIPTION
### Background 
* Online Boutique's (and Bank of Anthos's) 2022 roadmap mentions ["Lint to match Google’s internal code style"](https://docs.google.com/document/d/18emYbuVqXvRo2FtbqbZItUskBza4-N4xBNXtRyvfOaY/edit?resourcekey=0-7eQ7ZjEY2eP85qhWZvfqkg#bookmark=id.gqveqtnnferc) as a backlogged project.
* Adding automation to ensure the code style (of the various languages used in this repo) matches Google's style guides is a large project.
* This pull-request provide a temporary band-aid by introducing a `.editorconfig` file.

### Choosing Indentation Rules

I think consistency (i.e., having rules around code style) is more important than getting the rules right. Nonetheless, here's how I've made the decisions about indentation spacing:
 
* C#'s official docs recommend 4-space indents. [Source](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions#layout-conventions).
* Golang's official docs recommend tabs. [Source](https://go.dev/doc/effective_go#formatting).
* Google's Python style guide recommends 4-space indents. [Source](https://google.github.io/styleguide/pyguide.html#34-indentation).
* Google's JavaScript style guide recommends 2-space indents. [Source](https://google.github.io/styleguide/jsguide.html#formatting-block-indentation).
* Google's Java style guide recommends 2-space indents. [Source](https://google.github.io/styleguide/javaguide.html#s4.2-block-indentation). But we have chosen 4 spaces (see [relevant thread](https://github.com/GoogleCloudPlatform/microservices-demo/pull/1421#pullrequestreview-1224985148)).
* Google's HTML and CSS style guide recommends 2-space indents. [Source](https://google.github.io/styleguide/htmlcssguide.html#General_Formatting_Rules).
* Dockerfiles' official docs alternate between 6 spaces, 4 spaces, 2 spaces, etc. [Source](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#sort-multi-line-arguments). Let's just go with 4 spaces because it's what Online Boutique is [currently using](https://github.com/GoogleCloudPlatform/microservices-demo/blob/release/v0.5.0/src/frontend/Dockerfile#L31).

Note: For both Google's JavaScript and Java Style Guides, 4-space indents are recommended for line continuations. [Source for JavaScript](https://google.github.io/styleguide/jsguide.html#formatting-indent). [Source for Java](https://google.github.io/styleguide/javaguide.html#s4.5.2-line-wrapping-indent).
```javascript
function foo() {
  bar( // 2 spaces
      baz); // 2 spaces + 4 spaces (because it's a continuation of the previous line — not a new line)
}
```
But .editorconfig doesn't support a [continuation_indent_size](https://github.com/editorconfig/editorconfig/issues/412) field (yet).

### Change Summary
* This pull-request introduces an [`.editorconfig` file](https://editorconfig.org/).

### Additional Notes
* For Visual Studio Code (and some [other IDEs and text editors](https://editorconfig.org/#download)), you will need to download a plugin. See [Visual Studio Code's .editorconfig plugin here](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig).
* Ideally, code style wouldn't be something engineers think about. That is, it should be fully automated and we should inherit a pre-written list of rules (e.g., [Google ESLint](https://github.com/google/eslint-config-google#usage) for JavaScript).

### Testing Procedure
* See [.editorconfig docs here](https://editorconfig.org/#file-format-details). Make sure there aren't any typos in this pull-request's `.editconfig` file, etc.
