### PR TITLE
Use dee-platform-ops in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-*                   @GoogleCloudPlatform/anthos-dpe
+*                   @GoogleCloudPlatform/dee-platform-ops


### PR DESCRIPTION
### Background 
* Our team is no longer called "[Anthos/GKE DPE](https://github.com/orgs/GoogleCloudPlatform/teams/anthos-dpe)" as our scope (product foci) has changed.
* Our team = [DEE Platform Ops](https://github.com/orgs/GoogleCloudPlatform/teams/dee-platform-ops).

### Change Summary
* Update the `CODEOWNERS` file to use [DEE Platform Ops](https://github.com/orgs/GoogleCloudPlatform/teams/dee-platform-ops).

### Additional Notes
* We have also recently cleaned up the list of [individuals/teams that have Admin access](https://github.com/GoogleCloudPlatform/microservices-demo/settings/access).
* This pull-request also fixes the following issue:
<img width="1356" alt="Screenshot 2022-12-22 at 9 42 18 AM" src="https://user-images.githubusercontent.com/10292865/209158566-9f97cef8-9a86-48ad-8550-bebb998cd3c5.png">

### Testing Procedure
* After this is merged, make sure the aforementioned error no longer shows up in the [`CODEOWNERS` file](https://github.com/GoogleCloudPlatform/microservices-demo/blob/main/CODEOWNERS).

