### PR TITLE
Fix `/hack/make-helm-chart.sh`

### DIFF
--- a/hack/make-helm-chart.sh
+++ b/hack/make-helm-chart.sh
@@ -25,9 +25,9 @@ TAG="${TAG:?TAG env variable must be specified}"
 HELM_CHART_REPO="us-docker.pkg.dev/online-boutique-ci/charts"
 
 cd helm-chart
-sed -i "s/^appVersion:.*/appVersion: \"${TAG}\"/" Chart.yaml
-sed -i "s/^version:.*/version: ${TAG:1}/" Chart.yaml
+gsed -i "s/^appVersion:.*/appVersion: \"${TAG}\"/" Chart.yaml
+gsed -i "s/^version:.*/version: ${TAG:1}/" Chart.yaml
 helm package .
-helm push onlineboutique-$TAG.tgz oci://$HELM_CHART_REPO
+helm push onlineboutique-${TAG:1}.tgz oci://$HELM_CHART_REPO
 
 log "Successfully built and pushed the Helm chart."

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.4.2"
+appVersion: "v0.5.0"

--- a/kustomize/base/adservice.yaml
+++ b/kustomize/base/adservice.yaml
@@ -41,7 +41,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/adservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.5.0
         ports:
         - containerPort: 9555
         env:

--- a/kustomize/base/cartservice.yaml
+++ b/kustomize/base/cartservice.yaml
@@ -41,7 +41,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.5.0
         ports:
         - containerPort: 7070
         env:

--- a/kustomize/base/checkoutservice.yaml
+++ b/kustomize/base/checkoutservice.yaml
@@ -40,7 +40,7 @@ spec:
                 - all
             privileged: false
             readOnlyRootFilesystem: true
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.4.2
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.5.0
           ports:
           - containerPort: 5050
           readinessProbe:
@@ -64,8 +64,6 @@ spec:
             value: "currencyservice:7000"
           - name: CART_SERVICE_ADDR
             value: "cartservice:7070"
-          - name: DISABLE_PROFILER
-            value: "1"
           resources:
             requests:
               cpu: 100m

--- a/kustomize/base/currencyservice.yaml
+++ b/kustomize/base/currencyservice.yaml
@@ -41,7 +41,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.5.0
         ports:
         - name: grpc
           containerPort: 7000

--- a/kustomize/base/emailservice.yaml
+++ b/kustomize/base/emailservice.yaml
@@ -41,7 +41,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.5.0
         ports:
         - containerPort: 8080
         env:

--- a/kustomize/base/frontend.yaml
+++ b/kustomize/base/frontend.yaml
@@ -42,7 +42,7 @@ spec:
                 - all
             privileged: false
             readOnlyRootFilesystem: true
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.4.2
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.5.0
           ports:
           - containerPort: 8080
           readinessProbe:

--- a/kustomize/base/loadgenerator.yaml
+++ b/kustomize/base/loadgenerator.yaml
@@ -67,7 +67,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.5.0
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/kustomize/base/paymentservice.yaml
+++ b/kustomize/base/paymentservice.yaml
@@ -41,7 +41,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.5.0
         ports:
         - containerPort: 50051
         env:

--- a/kustomize/base/productcatalogservice.yaml
+++ b/kustomize/base/productcatalogservice.yaml
@@ -41,12 +41,10 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.5.0
         ports:
         - containerPort: 3550
         env:
-        - name: COLLECTOR_SERVICE_ADDR
-          value: "opentelemetrycollector:4317"
         - name: PORT
           value: "3550"
         - name: DISABLE_PROFILER

--- a/kustomize/base/recommendationservice.yaml
+++ b/kustomize/base/recommendationservice.yaml
@@ -41,7 +41,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.5.0
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/kustomize/base/shippingservice.yaml
+++ b/kustomize/base/shippingservice.yaml
@@ -40,7 +40,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.5.0
         ports:
         - containerPort: 50051
         env:

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -47,7 +47,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.5.0
         ports:
         - containerPort: 8080
         env:
@@ -112,7 +112,7 @@ spec:
                 - all
             privileged: false
             readOnlyRootFilesystem: true
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.4.2
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.5.0
           ports:
           - containerPort: 5050
           readinessProbe:
@@ -136,8 +136,6 @@ spec:
             value: "currencyservice:7000"
           - name: CART_SERVICE_ADDR
             value: "cartservice:7070"
-          - name: DISABLE_PROFILER
-            value: "1"
           resources:
             requests:
               cpu: 100m
@@ -188,7 +186,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.5.0
         ports:
         - containerPort: 8080
         readinessProbe:
@@ -205,8 +203,6 @@ spec:
         - name: PRODUCT_CATALOG_SERVICE_ADDR
           value: "productcatalogservice:3550"
         - name: DISABLE_PROFILER
-          value: "1"
-        - name: DISABLE_DEBUGGER
           value: "1"
         resources:
           requests:
@@ -259,7 +255,7 @@ spec:
                 - all
             privileged: false
             readOnlyRootFilesystem: true
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.4.2
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.5.0
           ports:
           - containerPort: 8080
           readinessProbe:
@@ -366,15 +362,13 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.5.0
         ports:
         - containerPort: 50051
         env:
         - name: PORT
           value: "50051"
         - name: DISABLE_PROFILER
-          value: "1"
-        - name: DISABLE_DEBUGGER
           value: "1"
         readinessProbe:
           exec:
@@ -432,12 +426,10 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.5.0
         ports:
         - containerPort: 3550
         env:
-        - name: COLLECTOR_SERVICE_ADDR
-          value: "opentelemetrycollector:4317"
         - name: PORT
           value: "3550"
         - name: DISABLE_PROFILER
@@ -498,7 +490,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.5.0
         ports:
         - containerPort: 7070
         env:
@@ -590,7 +582,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.5.0
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"
@@ -633,7 +625,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.5.0
         ports:
         - name: grpc
           containerPort: 7000
@@ -641,8 +633,6 @@ spec:
         - name: PORT
           value: "7000"
         - name: DISABLE_PROFILER
-          value: "1"
-        - name: DISABLE_DEBUGGER
           value: "1"
         readinessProbe:
           exec:
@@ -699,7 +689,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.5.0
         ports:
         - containerPort: 50051
         env:
@@ -829,7 +819,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/adservice:v0.4.2
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.5.0
         ports:
         - containerPort: 9555
         env:


### PR DESCRIPTION
### Background 
* `make-helm-chart.sh` is run when a maintainer creates a new release of Online Boutique.
* `make-helm-chart.sh` bumps up the version of the Helm Chart published at [`oci://us-docker.pkg.dev/online-boutique-ci/charts/onlineboutique`](https://pantheon.corp.google.com/artifacts/docker/online-boutique-ci/us/charts/onlineboutique).
* This pull-requests makes minor fixes to `make-helm-chart.sh`.

### Change Summary
* See the comments I've made in the file changes.

### Testing Procedure
* No testing from reviewer required.
* These changes were tested when I did the previous release of Online Boutique.