### PR TITLE
Fix `/hack/make-helm-chart.sh`

### DIFF
--- a/hack/make-helm-chart.sh
+++ b/hack/make-helm-chart.sh
@@ -25,9 +25,9 @@ TAG="${TAG:?TAG env variable must be specified}"
 HELM_CHART_REPO="us-docker.pkg.dev/online-boutique-ci/charts"
 
 cd helm-chart
-sed -i "s/^appVersion:.*/appVersion: \"${TAG}\"/" Chart.yaml
-sed -i "s/^version:.*/version: ${TAG:1}/" Chart.yaml
+gsed -i "s/^appVersion:.*/appVersion: \"${TAG}\"/" Chart.yaml
+gsed -i "s/^version:.*/version: ${TAG:1}/" Chart.yaml
 helm package .
-helm push onlineboutique-$TAG.tgz oci://$HELM_CHART_REPO
+helm push onlineboutique-${TAG:1}.tgz oci://$HELM_CHART_REPO
 
 log "Successfully built and pushed the Helm chart."


### PR DESCRIPTION
### Background 
* `make-helm-chart.sh` is run when a maintainer creates a new release of Online Boutique.
* `make-helm-chart.sh` bumps up the version of the Helm Chart published at [`oci://us-docker.pkg.dev/online-boutique-ci/charts/onlineboutique`](https://pantheon.corp.google.com/artifacts/docker/online-boutique-ci/us/charts/onlineboutique).
* This pull-requests makes minor fixes to `make-helm-chart.sh`.

### Change Summary
* See the comments I've made in the file changes.

### Testing Procedure
* No testing from reviewer required.
* These changes were tested when I did the previous release of Online Boutique.