### PR TITLE
Use skaffold 2.0.2+ in development-guide.md

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -6,7 +6,7 @@ This doc explains how to build and run the OnlineBoutique source code locally us
 
 - [Docker for Desktop](https://www.docker.com/products/docker-desktop).
 - kubectl (can be installed via `gcloud components install kubectl`)
-- [skaffold **2.0+**](https://skaffold.dev/docs/install/) (latest version recommended), a tool that builds and deploys Docker images in bulk. 
+- [skaffold **2.0.2+**](https://skaffold.dev/docs/install/) (latest version recommended), a tool that builds and deploys Docker images in bulk. 
 - A Google Cloud Project with Google Container Registry enabled. 
 - Enable GCP APIs for Cloud Monitoring, Tracing, Profiler:
 ```


### PR DESCRIPTION
### Background 
* When you deploy local Docker images into a `kind` cluster, those Docker images need to be "loaded" into the `kind` cluster.
* The command for loading a Docker image into a `kind` cluster looks like: `kind load docker-image my-local-image`
* When using `skaffold run` and `skaffold dev`, `skaffold` takes care of loading images to `kind` clusters for us. That is, we don't need to manually run the `kind load` commands ourselves. See [skaffold docs about local clusters](https://skaffold.dev/docs/environment/local-cluster/).
* Unfortunately, this "loading" of images was broken in skaffold 1.17.1 (see [skaffold/issues/5159](https://github.com/GoogleContainerTools/skaffold/issues/5159)) and skaffold 2.0.1 (see [microservices-demo/issues/1446](https://github.com/GoogleCloudPlatform/microservices-demo/issues/1446)).
    * skaffold [2.0.2 contains a fix!](https://github.com/GoogleContainerTools/skaffold/issues/5159#issuecomment-1322650808) 😄 

### Fixes 
https://github.com/GoogleCloudPlatform/microservices-demo/issues/1446

### Change Summary
* Recommend skaffold 2.0.2+ in `development-guide.md`.

### Testing Procedure
* I have already tested this on my local machine.
