### PR TITLE
Use gke-gcloud-auth-plugin in /.deploystack/test

### DIFF
--- a/.deploystack/test
+++ b/.deploystack/test
@@ -88,7 +88,7 @@ function generateProject(){
     local __DATELABEL=$(date +%F)
     local VALUE=ds-test-$__STACKSUFFIX-$__RANDOMSUFFIX
     local __BA=$(gcloud beta billing accounts list --format="value(ACCOUNT_ID)" --limit=1 | xargs)
-   
+
     gcloud projects create $VALUE --labels="deploystack-disposable-test-project=$__DATELABEL" --folder="155265971980"
     gcloud beta billing projects link $VALUE --billing-account=$__BA
     eval $__resultvar="'$VALUE'"
@@ -103,6 +103,10 @@ suffix=ms
 section_open "Generate random test project"
     generateProject PROJECT "$suffix"
 section_close
+
+# We need to force the use of gke-gcloud-auth-plugin (for GKE authentication)
+# if we're using kubectl 1.25 or lower.
+export USE_GKE_GCLOUD_AUTH_PLUGIN=True
 
 DIR="terraform"
 gcloud services enable cloudresourcemanager.googleapis.com --project=$PROJECT
@@ -162,7 +166,7 @@ section_open "Testing Google Kubernetes Engine cluster does NOT exist"
 section_close
 
 # This is only needed if you tests fail alot because of overlaping runs of the
-# same set of tests. Really don't do this if you don't want to severly irritate 
+# same set of tests. Really don't do this if you don't want to severly irritate
 # @tpryan
 section_open "Delete Test Project"
     gcloud projects delete $PROJECT -q


### PR DESCRIPTION
### Background 
* For the problem, please see https://github.com/GoogleCloudPlatform/microservices-demo/issues/1511.
* For the solution, please see [my comment in #1511](https://github.com/GoogleCloudPlatform/microservices-demo/issues/1511#issuecomment-1440552089).
* Please see Google Cloud Build [Trigger logs](https://pantheon.corp.google.com/cloud-build/builds;region=global/2b467224-45f6-4ff6-bb02-6710e5a5bcf7?project=ds-tester-microservices-demo&supportedpurview=project) from this `nimjay-deploystack-build` branch. The build was successful! 👍  

### Fixes 
https://github.com/GoogleCloudPlatform/microservices-demo/issues/1511

### Change Summary
* Force kubectl to use `gke-gcloud-auth-plugin` in `./deploystack/test`.

### Testing Procedure
* No testing necessary. Please see the Google Cloud Build [Trigger logs](https://pantheon.corp.google.com/cloud-build/builds;region=global/2b467224-45f6-4ff6-bb02-6710e5a5bcf7?project=ds-tester-microservices-demo&supportedpurview=project) from this `nimjay-deploystack-build` branch.
