### PR TITLE
Upgrade AspNetCore to 2.51

### DIFF
--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.50.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.51.0" />
     <PackageReference Include="Grpc.HealthCheck" Version="2.51.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.3" />
     <!-- Add explicit direct dependency required for ipv6, see https://github.com/dotnet/aspnetcore/issues/45424 -->
     <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
-    <PackageReference Include="Google.Cloud.Spanner.Data" Version="4.2.0" />
+    <PackageReference Include="Google.Cloud.Spanner.Data" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/cartservice/tests/cartservice.tests.csproj
+++ b/src/cartservice/tests/cartservice.tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Net.Client" Version="2.50.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.51.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
This PR takes care of https://github.com/GoogleCloudPlatform/microservices-demo/pull/1520 and https://github.com/GoogleCloudPlatform/microservices-demo/pull/1439 simultaneously.

Needed to also upgrade the tests project config which Renovate didn't pick up.