### PR TITLE
Update Dockerfile

### DIFF
--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -44,6 +44,6 @@ ENTRYPOINT ["/app/build/install/hipstershop/bin/AdService"]
 FROM without-grpc-health-probe-bin
 
 # renovate: datasource=github-releases depName=grpc-ecosystem/grpc-health-probe
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.14 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+ENV GRPC_HEALTH_PROBE_VERSION=v0.4.14
+RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /bin/grpc_health_probe


### PR DESCRIPTION
`GRPC_HEALTH_PROBE_VERSION` as `ENV` in Dockerfile for Dependabot bump.

Otherwise this config is not bumping the version: https://github.com/GoogleCloudPlatform/microservices-demo/blob/main/renovate.json#L54.

`grpc-health-probe` has a new version 0.4.15: https://github.com/grpc-ecosystem/grpc-health-probe/releases. Once this current PR merged into `main`, Dependabot should be able to bump this `GRPC_HEALTH_PROBE_VERSION` value.