### PR TITLE
feat: Add support for overriding helm chart resource limits

### DIFF
--- a/helm-chart/templates/adservice.yaml
+++ b/helm-chart/templates/adservice.yaml
@@ -62,12 +62,7 @@ spec:
         - name: PORT
           value: "9555"
         resources:
-          requests:
-            cpu: 200m
-            memory: 180Mi
-          limits:
-            cpu: 300m
-            memory: 300Mi
+          {{- toYaml .Values.adService.resources | nindent 10 }}
         readinessProbe:
           initialDelaySeconds: 20
           periodSeconds: 15

--- a/helm-chart/templates/cartservice.yaml
+++ b/helm-chart/templates/cartservice.yaml
@@ -70,12 +70,7 @@ spec:
         {{- end }}
           value: {{ .Values.cartDatabase.connectionString | quote }}
         resources:
-          requests:
-            cpu: 200m
-            memory: 64Mi
-          limits:
-            cpu: 300m
-            memory: 128Mi
+          {{- toYaml .Values.cartService.resources | nindent 10 }}
         readinessProbe:
           initialDelaySeconds: 15
           {{- if .Values.nativeGrpcHealthCheck }}

--- a/helm-chart/templates/checkoutservice.yaml
+++ b/helm-chart/templates/checkoutservice.yaml
@@ -101,12 +101,7 @@ spec:
           value: "1"
         {{- end }}
         resources:
-          requests:
-            cpu: 100m
-            memory: 64Mi
-          limits:
-            cpu: 200m
-            memory: 128Mi
+          {{- toYaml .Values.checkoutService.resources | nindent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm-chart/templates/currencyservice.yaml
+++ b/helm-chart/templates/currencyservice.yaml
@@ -91,12 +91,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:7000"]
           {{- end }}
         resources:
-          requests:
-            cpu: 100m
-            memory: 64Mi
-          limits:
-            cpu: 200m
-            memory: 128Mi
+          {{- toYaml .Values.currencyService.resources | nindent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm-chart/templates/emailservice.yaml
+++ b/helm-chart/templates/emailservice.yaml
@@ -92,12 +92,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:8080"]
           {{- end }}
         resources:
-          requests:
-            cpu: 100m
-            memory: 64Mi
-          limits:
-            cpu: 200m
-            memory: 128Mi
+          {{- toYaml .Values.emailService.resources | nindent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm-chart/templates/frontend.yaml
+++ b/helm-chart/templates/frontend.yaml
@@ -88,7 +88,7 @@ spec:
             value: "{{ .Values.checkoutService.name }}:5050"
           - name: AD_SERVICE_ADDR
             value: "{{ .Values.adService.name }}:9555"
-          - name: ENV_PLATFORM 
+          - name: ENV_PLATFORM
             value: {{ .Values.frontend.platform | quote }}
           {{- if .Values.opentelemetryCollector.create }}
           - name: COLLECTOR_SERVICE_ADDR
@@ -107,12 +107,7 @@ spec:
           - name: ENABLE_SINGLE_SHARED_SESSION
             value: {{ .Values.frontend.singleSharedSession | quote }}
           resources:
-            requests:
-              cpu: 100m
-              memory: 64Mi
-            limits:
-              cpu: 200m
-              memory: 128Mi
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
 ---
 apiVersion: v1
 kind: Service
@@ -232,7 +227,7 @@ spec:
         - cluster.local/ns/{{ .Values.frontend.virtualService.gateway.namespace }}/sa/{{ .Values.frontend.virtualService.gateway.name }}
         {{- end }}
     to:
-  {{- end }}  
+  {{- end }}
     - operation:
         methods:
         - GET

--- a/helm-chart/templates/loadgenerator.yaml
+++ b/helm-chart/templates/loadgenerator.yaml
@@ -87,12 +87,7 @@ spec:
         - name: USERS
           value: "10"
         resources:
-          requests:
-            cpu: 300m
-            memory: 256Mi
-          limits:
-            cpu: 500m
-            memory: 512Mi
+          {{- toYaml .Values.loadGenerator.resources | nindent 10 }}
 {{- if .Values.networkPolicies.create }}
 ---
 apiVersion: networking.k8s.io/v1

--- a/helm-chart/templates/paymentservice.yaml
+++ b/helm-chart/templates/paymentservice.yaml
@@ -90,12 +90,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]
           {{- end }}
         resources:
-          requests:
-            cpu: 100m
-            memory: 64Mi
-          limits:
-            cpu: 200m
-            memory: 128Mi
+          {{- toYaml .Values.paymentService.resources | nindent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm-chart/templates/productcatalogservice.yaml
+++ b/helm-chart/templates/productcatalogservice.yaml
@@ -92,12 +92,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:3550"]
           {{- end }}
         resources:
-          requests:
-            cpu: 100m
-            memory: 64Mi
-          limits:
-            cpu: 200m
-            memory: 128Mi
+          {{- toYaml .Values.productCatalogService.resources | nindent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm-chart/templates/recommendationservice.yaml
+++ b/helm-chart/templates/recommendationservice.yaml
@@ -94,12 +94,7 @@ spec:
           value: "1"
         {{- end }}
         resources:
-          requests:
-            cpu: 100m
-            memory: 220Mi
-          limits:
-            cpu: 200m
-            memory: 450Mi
+          {{- toYaml .Values.recommendationService.resources | nindent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm-chart/templates/shippingservice.yaml
+++ b/helm-chart/templates/shippingservice.yaml
@@ -82,12 +82,7 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:50051"]
           {{- end }}
         resources:
-          requests:
-            cpu: 100m
-            memory: 64Mi
-          limits:
-            cpu: 200m
-            memory: 128Mi
+          {{- toYaml .Values.shippingService.resources | nindent 10 }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -48,22 +48,57 @@ seccompProfile:
 adService:
   create: true
   name: adservice
+  resources:
+    requests:
+      cpu: 200m
+      memory: 180Mi
+    limits:
+      cpu: 300m
+      memory: 300Mi
 
 cartService:
   create: true
   name: cartservice
+  resources:
+    requests:
+      cpu: 200m
+      memory: 64Mi
+    limits:
+      cpu: 300m
+      memory: 128Mi
 
 checkoutService:
   create: true
   name: checkoutservice
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
 
 currencyService:
   create: true
   name: currencyservice
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
 
 emailService:
   create: true
   name: emailservice
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
 
 frontend:
   create: true
@@ -82,29 +117,71 @@ frontend:
       namespace: asm-ingress
       labelKey: asm
       labelValue: ingressgateway
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
 
 loadGenerator:
   create: true
   name: loadgenerator
   checkFrontendInitContainer: true
+  resources:
+    requests:
+      cpu: 300m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
 
 paymentService:
   create: true
   name: paymentservice
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
 
 productCatalogService:
   create: true
   name: productcatalogservice
   # Specifies an extra latency to any request on productcatalogservice, by default no extra latency.
   extraLatency: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
 
 recommendationService:
   create: true
   name: recommendationservice
+  resources:
+    requests:
+      cpu: 100m
+      memory: 220Mi
+    limits:
+      cpu: 200m
+      memory: 450Mi
 
 shippingService:
   create: true
   name: shippingservice
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
 
 cartDatabase:
   # Specifies the type of the cartservice's database, could be either redis or spanner.


### PR DESCRIPTION
- Allow overriding of default resource limits in deployment manifests for microservices demo applications.
add a resources section to each container in the manifests, with default values for CPU and memory limits.

### Background 
<!-- What was happening before this PR, and the problem(s) it solves -->
Before this PR, the resource limits for microservices demo applications were hard-coded in the deployment manifests. This made adjusting resource limits for specific use cases or environments difficult. The PR allows for overriding the default resource limits, providing greater flexibility for users.

### Fixes 
<!-- Link the issue(s) this PR fixes-->
### Change Summary
<!-- Short summary of the changes submitted -->
Add support for overriding resource limits in deployment manifests for microservices demo applications, allowing users to customize resource requirements for each application as needed.

### Additional Notes
<!-- Any remaining concerns -->
This change will make the microservices demo more flexible and customizable, and should make it easier for users to deploy and scale the application in different environments.

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->
1. Deploy the updated Helm chart to a test environment.
2. Verify that the Kubernetes resources are created with the expected resource limits and requests. 
```bash
kubectl get deployments -o name | xargs -I{} sh -c 'echo "Deployment: {}"; kubectl describe {} | grep -A4 "Limits\|Requests" | grep -v "Limits\|Requests\|--\|Type"' 
```

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
