### PR TITLE
Fix typo in managed data plane enablement

### DIFF
--- a/kustomize/components/service-mesh-istio/README.md
+++ b/kustomize/components/service-mesh-istio/README.md
@@ -44,14 +44,10 @@ FLEET_PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format 'value(pr
 gcloud container clusters update --project ${PROJECT_ID} ${CLUSTER_NAME} \
     --zone ${ZONE} --update-labels="mesh_id=proj-$FLEET_PROJECT_NUMBER"
 
-# Configure automatic control plane upgrades
+# Enable managed Anthos Service Mesh on the cluster
 gcloud container fleet mesh update --project ${PROJECT_ID} \
     --management automatic \
     --memberships ${CLUSTER_NAME}
-
-# Configure Managed Data Plane (automatic restart of workloads when envoy sidecar is updated)
-kubectl annotate --overwrite namespace default \
-    mesh.cloud.google.com/proxy='{"managed":"true"}'
 
 # Enable sidecar injection for Kubernetes namespace where workload is deployed
 kubectl label namespace default istio-injection- istio.io/rev=asm-managed --overwrite


### PR DESCRIPTION
### Background 
* ASM = Anthos Service Mesh
* The `mesh.cloud.google.com/proxy='{"managed":"false"}'` disables the ASM managed data plane. [Source](https://cloud.google.com/service-mesh/docs/managed/provision-managed-anthos-service-mesh#managed-data-plane).
* When you use the Fleet API to install managed ASM, the `--management automatic` flag ensures that the managed data plane is enabled (by default). See relevant [Google-internal Chat thread](https://chat.google.com/room/AAAAJlvKm1w/HqsLr5OxmxY).
* From [docs](https://cloud.google.com/service-mesh/docs/managed/provision-managed-anthos-service-mesh#managed-data-plane):
> If you use managed Anthos Service Mesh with fleet API, Google will fully manage upgrades of your proxies, unless you opt out at the namespace or workload level.

* "upgrades of your proxies" is referring to the managed data plane.

### Change Summary
* Remove the step that disables the ASM managed data plane.

### Testing Procedure
* No testing necessary. Please see ASM documentation linked above, as confirmation.

CC @gbrayut in case I'm mistaken about something.
