### PR TITLE
Add .gitattributes to convert "CR + LF" to "LF"

### DIFF
--- a/. gitattributes
+++ b/. gitattributes
@@ -1,0 +1,4 @@
+# This file configures the git settings for this repository.
+
+# Converts CR + LF to LF when committing, for all "text" files.
+* text=auto


### PR DESCRIPTION
### Background 
* See my [GitHub comment here](https://github.com/GoogleCloudPlatform/microservices-demo/issues/1434#issuecomment-1377451183).
* LF = "Line Feed" character (moves the cursor to the next line)
* CR = "Carriage Return" character (brings the cursor to the start of the current line)
* For marking the end of a line:
    * Linux & Mac use LF.
    * Windows uses CRLF.
* For more context, see [this StackOverflow post](https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/).

### Fixes 

#1434

### Change Summary
* Add a `.gitattributes` file that converts "CR + LF" to "LF".

### Testing Procedure
* [This comment](https://github.com/GoogleCloudPlatform/microservices-demo/issues/1434#issuecomment-1377472080) confirms that this fix likely works.

### Related PRs or Issues 
* Old, similar issue: #196.
