### PR TITLE
Remove 2> /dev/null in Terraform kubectl wait

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -84,7 +84,7 @@ resource "null_resource" "apply_deployment" {
 resource "null_resource" "wait_conditions" {
   provisioner "local-exec" {
     interpreter = ["bash", "-exc"]
-    command     = "kubectl wait --for=condition=ready pods --all -n ${var.namespace} --timeout=-1s 2> /dev/null"
+    command     = "kubectl wait --for=condition=ready pods --all -n ${var.namespace} --timeout=-1s"
   }
 
   depends_on = [


### PR DESCRIPTION
### Background 
* We added `2> /dev/null` to the end of the `kubectl wait` command in our Terraform in [when we added DeployStack support](https://github.com/GoogleCloudPlatform/microservices-demo/pull/1142/files#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028).
* Purpose of `2> /dev/null`: it silences standard errors logged by `kubectl wait`.
* I think we only did this to make the DeployStack output cleaner.
* But we should avoid silencing errors in general.

### Change Summary
* _Unsilence_ `kubectl wait` errors.

### Testing Procedure
* No testing necessary as this is a trivial change.

### Additional info
* This is the first step to investigating https://github.com/GoogleCloudPlatform/microservices-demo/issues/1813 — an error with the `kubectl wait` command.