### PR TITLE
Fix Terraform error caused by unavailable metrics.k8s.io/v1beta1

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -84,7 +84,10 @@ resource "null_resource" "apply_deployment" {
 resource "null_resource" "wait_conditions" {
   provisioner "local-exec" {
     interpreter = ["bash", "-exc"]
-    command     = "kubectl wait --for=condition=ready pods --all -n ${var.namespace} --timeout=-1s"
+    command     = <<-EOT
+    kubectl wait --for=condition=AVAILABLE apiservice/v1beta1.metrics.k8s.io --timeout=1200s
+    kubectl wait --for=condition=ready pods --all -n ${var.namespace} --timeout=1200s
+    EOT
   }
 
   depends_on = [

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -85,8 +85,8 @@ resource "null_resource" "wait_conditions" {
   provisioner "local-exec" {
     interpreter = ["bash", "-exc"]
     command     = <<-EOT
-    kubectl wait --for=condition=AVAILABLE apiservice/v1beta1.metrics.k8s.io --timeout=1200s
-    kubectl wait --for=condition=ready pods --all -n ${var.namespace} --timeout=1200s
+    kubectl wait --for=condition=AVAILABLE apiservice/v1beta1.metrics.k8s.io --timeout=180s
+    kubectl wait --for=condition=ready pods --all -n ${var.namespace} --timeout=280s
     EOT
   }
 


### PR DESCRIPTION
### Background 
* This fixed https://github.com/GoogleCloudPlatform/microservices-demo/issues/1813.
* Even though `terraform apply` would successfully deploy a functional Online Boutique, the Terraform output had errors:
```
│ Error running command 'kubectl wait --for=condition=ready pods --all -n default --timeout=-1s': exit status 1. Output: + kubectl wait
│ --for=condition=ready pods --all -n default --timeout=-1s
│ E0605 13:26:36.342439    2173 memcache.go:287] couldn't get resource list for metrics.k8s.io/v1beta1: the server is currently unable to handle the
│ request
```
* `kubectl wait ... pods ...` is failing because the `metrics.k8s.io/v1beta1` resource is not ready.
* See more logs in [this comment](https://github.com/GoogleCloudPlatform/microservices-demo/issues/1813#issuecomment-1576823565).
* According to [this StackOverflow post](https://stackoverflow.com/questions/63885034/gke-clusters-point-to-unavailable-apiservice-v1beta1-metrics-k8s-io) and my personal testing, this error happens on new clusters (_just_ created) — during the first few minutes.
* In the first few minutes after cluster creation, running `kubectl get apiservices` outputs:
```
NAME                               SERVICE                      AVAILABLE                  AGE
...
v1beta1.metrics.k8s.io             kube-system/metrics-server   False (MissingEndpoints)   39s
...
```
* After a few minutes, the output is:
```
NAME                               SERVICE                      AVAILABLE   AGE
...
v1beta1.metrics.k8s.io             kube-system/metrics-server   True        83m
...
```
* A solution is to wait until the `v1beta1.metrics.k8s.io` resource is ready before `kubectl wait ... pods ...`.

### Change Summary
* Before `kubectl wait`-ing for Pods, the Terraform now `kubectl wait`s for the `v1beta1.metrics.k8s.io` API service.
* We also add a timeout of 20 minutes (each) to both `kubectl wait` commands.

### Testing Procedure
* I've already tested `terraform apply` with this change, and [it worked](https://screenshot.googleplex.com/6AkrRfGHRnUYDUY.png)!
* Also, once this is merged, we can check the DeployStack build run against the `main` branch (to see if `terraform apply` works):
![image](https://github.com/GoogleCloudPlatform/microservices-demo/assets/10292865/00588f58-7bd3-4023-8ca6-6ad4fde17877)

### Additional info
* Running `kubectl get apiservice v1beta1.metrics.k8s.io -o yaml` during the first few minutes after cluster creation outputs:
```
apiVersion: apiregistration.k8s.io/v1
kind: APIService
metadata:
...
  name: v1beta1.metrics.k8s.io
...
status:
  conditions:
  - lastTransitionTime: "2023-06-05T13:25:13Z"
    message: endpoints for service/metrics-server in "kube-system" have no addresses
      with port name ""
    reason: MissingEndpoints
    status: "False"
    type: Available
```
