### PR TITLE
Remove `nativeGrpcHealthCheck` from Helm chart

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.7.0"
+appVersion: "v0.8.0"

--- a/helm-chart/templates/adservice.yaml
+++ b/helm-chart/templates/adservice.yaml
@@ -51,11 +51,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        {{- if .Values.nativeGrpcHealthCheck }}
-        image: {{ .Values.images.repository }}/{{ .Values.adService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}-native-grpc-probes
-        {{- else }}
         image: {{ .Values.images.repository }}/{{ .Values.adService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}
-        {{- end }}
         ports:
         - containerPort: 9555
         env:
@@ -66,23 +62,13 @@ spec:
         readinessProbe:
           initialDelaySeconds: 20
           periodSeconds: 15
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 9555
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:9555"]
-          {{- end }}
         livenessProbe:
           initialDelaySeconds: 20
           periodSeconds: 15
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 9555
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:9555"]
-          {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm-chart/templates/cartservice.yaml
+++ b/helm-chart/templates/cartservice.yaml
@@ -55,11 +55,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        {{- if .Values.nativeGrpcHealthCheck }}
-        image: {{ .Values.images.repository }}/{{ .Values.cartService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}-native-grpc-probes
-        {{- else }}
         image: {{ .Values.images.repository }}/{{ .Values.cartService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}
-        {{- end }}
         ports:
         - containerPort: 7070
         env:
@@ -73,23 +69,13 @@ spec:
           {{- toYaml .Values.cartService.resources | nindent 10 }}
         readinessProbe:
           initialDelaySeconds: 15
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 7070
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
-          {{- end }}
         livenessProbe:
           initialDelaySeconds: 15
           periodSeconds: 10
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 7070
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:7070", "-rpc-timeout=5s"]
-          {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/helm-chart/templates/checkoutservice.yaml
+++ b/helm-chart/templates/checkoutservice.yaml
@@ -50,29 +50,15 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        {{- if .Values.nativeGrpcHealthCheck }}
-        image: {{ .Values.images.repository }}/{{ .Values.checkoutService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}-native-grpc-probes
-        {{- else }}
         image: {{ .Values.images.repository }}/{{ .Values.checkoutService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}
-        {{- end }}
         ports:
         - containerPort: 5050
         readinessProbe:
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 5050
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:5050"]
-          {{- end }}
         livenessProbe:
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 5050
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:5050"]
-          {{- end }}
         env:
         - name: PORT
           value: "5050"

--- a/helm-chart/templates/currencyservice.yaml
+++ b/helm-chart/templates/currencyservice.yaml
@@ -51,11 +51,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        {{- if .Values.nativeGrpcHealthCheck }}
-        image: {{ .Values.images.repository }}/{{ .Values.currencyService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}-native-grpc-probes
-        {{- else }}
         image: {{ .Values.images.repository }}/{{ .Values.currencyService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}
-        {{- end }}
         ports:
         - name: grpc
           containerPort: 7000
@@ -75,21 +71,11 @@ spec:
           value: "1"
         {{- end }}
         readinessProbe:
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 7000
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:7000"]
-          {{- end }}
         livenessProbe:
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 7000
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:7000"]
-          {{- end }}
         resources:
           {{- toYaml .Values.currencyService.resources | nindent 10 }}
 ---

--- a/helm-chart/templates/emailservice.yaml
+++ b/helm-chart/templates/emailservice.yaml
@@ -51,11 +51,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        {{- if .Values.nativeGrpcHealthCheck }}
-        image: {{ .Values.images.repository }}/{{ .Values.emailService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}-native-grpc-probes
-        {{- else }}
         image: {{ .Values.images.repository }}/{{ .Values.emailService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}
-        {{- end }}
         ports:
         - containerPort: 8080
         env:
@@ -75,22 +71,12 @@ spec:
         {{- end }}
         readinessProbe:
           periodSeconds: 5
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 8080
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:8080"]
-          {{- end }}
         livenessProbe:
           periodSeconds: 5
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 8080
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:8080"]
-          {{- end }}
         resources:
           {{- toYaml .Values.emailService.resources | nindent 10 }}
 ---

--- a/helm-chart/templates/paymentservice.yaml
+++ b/helm-chart/templates/paymentservice.yaml
@@ -51,11 +51,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        {{- if .Values.nativeGrpcHealthCheck }}
-        image: {{ .Values.images.repository }}/{{ .Values.paymentService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}-native-grpc-probes
-        {{- else }}
         image: {{ .Values.images.repository }}/{{ .Values.paymentService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}
-        {{- end }}
         ports:
         - containerPort: 50051
         env:
@@ -74,21 +70,11 @@ spec:
           value: "1"
         {{- end }}
         readinessProbe:
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 50051
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:50051"]
-          {{- end }}
         livenessProbe:
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 50051
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:50051"]
-          {{- end }}
         resources:
           {{- toYaml .Values.paymentService.resources | nindent 10 }}
 ---

--- a/helm-chart/templates/productcatalogservice.yaml
+++ b/helm-chart/templates/productcatalogservice.yaml
@@ -51,11 +51,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        {{- if .Values.nativeGrpcHealthCheck }}
-        image: {{ .Values.images.repository }}/{{ .Values.productCatalogService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}-native-grpc-probes
-        {{- else }}
         image: {{ .Values.images.repository }}/{{ .Values.productCatalogService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}
-        {{- end }}
         ports:
         - containerPort: 3550
         env:
@@ -76,21 +72,11 @@ spec:
         - name: EXTRA_LATENCY
           value: {{ .Values.productCatalogService.extraLatency }}
         readinessProbe:
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 3550
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:3550"]
-          {{- end }}
         livenessProbe:
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 3550
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:3550"]
-          {{- end }}
         resources:
           {{- toYaml .Values.productCatalogService.resources | nindent 10 }}
 ---

--- a/helm-chart/templates/recommendationservice.yaml
+++ b/helm-chart/templates/recommendationservice.yaml
@@ -51,31 +51,17 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        {{- if .Values.nativeGrpcHealthCheck }}
-        image: {{ .Values.images.repository }}/{{ .Values.recommendationService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}-native-grpc-probes
-        {{- else }}
         image: {{ .Values.images.repository }}/{{ .Values.recommendationService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}
-        {{- end }}
         ports:
         - containerPort: 8080
         readinessProbe:
           periodSeconds: 5
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 8080
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:8080"]
-          {{- end }}
         livenessProbe:
           periodSeconds: 5
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 8080
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:8080"]
-          {{- end }}
         env:
         - name: PORT
           value: "8080"

--- a/helm-chart/templates/shippingservice.yaml
+++ b/helm-chart/templates/shippingservice.yaml
@@ -50,11 +50,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        {{- if .Values.nativeGrpcHealthCheck }}
-        image: {{ .Values.images.repository }}/{{ .Values.shippingService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}-native-grpc-probes
-        {{- else }}
         image: {{ .Values.images.repository }}/{{ .Values.shippingService.name }}:{{ .Values.images.tag | default .Chart.AppVersion }}
-        {{- end }}
         ports:
         - containerPort: 50051
         env:
@@ -66,21 +62,11 @@ spec:
         {{- end }}
         readinessProbe:
           periodSeconds: 5
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 50051
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:50051"]
-          {{- end }}
         livenessProbe:
-          {{- if .Values.nativeGrpcHealthCheck }}
           grpc:
             port: 50051
-          {{- else }}
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:50051"]
-          {{- end }}
         resources:
           {{- toYaml .Values.shippingService.resources | nindent 10 }}
 ---

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -15,9 +15,6 @@ serviceAccounts:
   # Annotations to add only for the cartservice app. This allows to follow the least privilege principle where only cartservice needs to connect to external database for example via Workload Identity.
   annotationsOnlyForCartservice: false
 
-# Specifies if the livenessProbe and readinessProbe are using the native gRPC support with Kubernetes 1.24.
-nativeGrpcHealthCheck: false
-
 networkPolicies:
   # Specifies if the NetworkPolicies are created or not. If true, one fine granular NetworkPolicy per app is created.
   create: false


### PR DESCRIPTION
Remove `nativeGrpcHealthCheck` from Helm chart, following up on https://github.com/GoogleCloudPlatform/microservices-demo/pull/1837.