### PR TITLE
Fix ./onlineboutique-0.8.0.tgz issue

### DIFF
--- a/docs/releasing/make-helm-chart.sh
+++ b/docs/releasing/make-helm-chart.sh
@@ -31,6 +31,6 @@ gsed -i "s/^version:.*/version: ${TAG:1}/" Chart.yaml
 helm package .
 helm push onlineboutique-${TAG:1}.tgz oci://$HELM_CHART_REPO
 
-rm ./helm-chart/onlineboutique-${TAG:1}.tgz
+rm ./onlineboutique-${TAG:1}.tgz
 
 log "Successfully built and pushed the Helm chart."


### PR DESCRIPTION
### Background 
* When we create a release of Online Boutique, we run `helm package` to build a `.tgz` file.
* This `.tgz` file is pushed to a registry but **is not** committed to this repo.
* So we have a line that removes the file locally: `rm ./onlineboutique-${TAG:1}.tgz`
* But I broke this line via [my "fix"/suggestion here](https://github.com/GoogleCloudPlatform/microservices-demo/pull/1822/files/79b2b75178788daa8b2f0f756022b7fbe540ebea#r1218020095).

### Change Summary
* Replace `rm ./helm-chart/onlineboutique-${TAG:1}.tgz` with `rm ./onlineboutique-${TAG:1}.tgz`.

### Testing Procedure
* This was tested by me during the previous Online Boutique release.
