### PR TITLE
Added Kubevious validation to Kubernetes manifests

### DIFF
--- a/.github/workflows/kubevious-manifests-ci.yaml
+++ b/.github/workflows/kubevious-manifests-ci.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/kubevious-manifests-ci.yaml
+++ b/.github/workflows/kubevious-manifests-ci.yaml
@@ -26,9 +26,12 @@ on:
       - 'helm-chart/**'
       - 'kustomize/**'
       - '.github/workflows/kubevious-manifests-ci.yaml'
+permissions:
+  contents: read
 jobs:
   kubevious-manifests-ci:
     runs-on: ubuntu-22.04
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/kubevious-manifests-ci.yaml
+++ b/.github/workflows/kubevious-manifests-ci.yaml
@@ -34,26 +34,26 @@ jobs:
 
       - name: Validate kubernetes-manifests
         id: kubernetes-manifests-validation
-        uses: kubevious/cli@main
+        uses: kubevious/cli@v1.0.58
         with:
           manifests: kubernetes-manifests
           skip_rules: container-latest-image
 
       - name: Validate helm-chart
         id: helm-chart-validation
-        uses: kubevious/cli@main
+        uses: kubevious/cli@v1.0.58
         with:
           manifests: helm-chart
 
       - name: Validate istio-manifests
         id: istio-manifests-validation
-        uses: kubevious/cli@main
+        uses: kubevious/cli@v1.0.58
         with:
           manifests: istio-manifests https://github.com/istio/istio/raw/master/manifests/charts/base/crds/crd-all.gen.yaml
 
       - name: Validate kustomize
         id: kustomize-validation
-        uses: kubevious/cli@main
+        uses: kubevious/cli@v1.0.58
         with:
           manifests: kustomize
           skip_rules: container-latest-image

--- a/.github/workflows/kubevious-manifests-ci.yaml
+++ b/.github/workflows/kubevious-manifests-ci.yaml
@@ -1,0 +1,59 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: kubevious-manifests-ci
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'helm-chart/**'
+      - 'kustomize/**'
+      - '.github/workflows/kubevious-manifests-ci.yaml'
+  pull_request:
+    paths:
+      - 'helm-chart/**'
+      - 'kustomize/**'
+      - '.github/workflows/kubevious-manifests-ci.yaml'
+jobs:
+  kubevious-manifests-ci:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Validate kubernetes-manifests
+        id: kubernetes-manifests-validation
+        uses: kubevious/cli@main
+        with:
+          manifests: kubernetes-manifests
+          skip_rules: container-latest-image
+
+      - name: Validate helm-chart
+        id: helm-chart-validation
+        uses: kubevious/cli@main
+        with:
+          manifests: helm-chart
+
+      - name: Validate istio-manifests
+        id: istio-manifests-validation
+        uses: kubevious/cli@main
+        with:
+          manifests: istio-manifests https://github.com/istio/istio/raw/master/manifests/charts/base/crds/crd-all.gen.yaml
+
+      - name: Validate kustomize
+        id: kustomize-validation
+        uses: kubevious/cli@main
+        with:
+          manifests: kustomize
+          skip_rules: container-latest-image


### PR DESCRIPTION
### Background 
Added a new workflow to validate Kubernetes manifests for syntax, semantical correctness, references and best-practices. Uses Kubevious under the hood. This is different from existing "helm-chart-ci", "kustomize-build-ci" because Kubevious would detects issues such as Services pointing to wrong labels, Deployments mounting a wrong ConfigMaps, etc.

Validates following directorines:
- kubernetes-manifests/
- helm-chart/
- istio-manifests/
- kustomize/

### Change Summary
Added a new workflow *kubevious-manifests-ci* to validate Kubernetes manifests.
