### PR TITLE
Correct docs about native-gprc-health-check Kustomize component

### DIFF
--- a/kubernetes-manifests/kustomization.yaml
+++ b/kubernetes-manifests/kustomization.yaml
@@ -37,4 +37,3 @@ resources:
 # - ../kustomize/components/container-images-tag
 # - ../kustomize/components/container-images-tag-suffix
 # - ../kustomize/components/container-images-registry
-# - ../kustomize/components/native-grpc-health-check

--- a/kustomize/README.md
+++ b/kustomize/README.md
@@ -84,8 +84,6 @@ These changes directly affect `cartservice`.
   - Deploy fine granular `NetworkPolicies` for Online Boutique.
 - [**Create Kubernetes Service Accounts**](components/service-accounts)
   - Deploy fine granular `ServiceAccounts` for Online Boutique.
-- [**Support the native gRPC probes for Kubernetes 1.24+**](components/native-grpc-health-check)
-  - Deploy the Online Boutique apps by supporting the native gRPC probes for Kubernetes 1.24+.
 - [**Update the registry name of the container images**](components/container-images-registry)
 - [**Update the image tag of the container images**](components/container-images-tag)
 - [**Add an image tag suffix to the container images**](components/container-images-tag-suffix)


### PR DESCRIPTION
### Background 
* We removed the use of the gRPC health check binary inside all gRPC microservices via 
    * https://github.com/GoogleCloudPlatform/microservices-demo/pull/1837 and         
    * https://github.com/GoogleCloudPlatform/microservices-demo/pull/1840.

### Fixes 
https://github.com/GoogleCloudPlatform/microservices-demo/issues/1891

### Change Summary
* Remove out-dated documentation for the [native-grpc-health-check Kustomize component removed in pull 1837](https://github.com/GoogleCloudPlatform/microservices-demo/pull/1837/files#diff-74ae5f5068dd4e4c2ee7935ce25b21bc80b544bed590f5a0bec6e8b141df8a51).


### Testing Procedure
No testing needed.
