### PR TITLE
Fix deprecated methods in productcatalog

### DIFF
--- a/src/productcatalogservice/product_catalog.go
+++ b/src/productcatalogservice/product_catalog.go
@@ -62,7 +62,6 @@ func (p *productCatalog) GetProduct(ctx context.Context, req *pb.GetProductReque
 func (p *productCatalog) SearchProducts(ctx context.Context, req *pb.SearchProductsRequest) (*pb.SearchProductsResponse, error) {
 	time.Sleep(extraLatency)
 
-	// Interpret query as a substring match in name or description.
 	var ps []*pb.Product
 	for _, product := range p.parseCatalog() {
 		if strings.Contains(strings.ToLower(product.Name), strings.ToLower(req.Query)) ||


### PR DESCRIPTION
This PR fixes a few deprecated methods in the `productcatalog`:
- The gRPC `WithInsecure()` now takes credentials as argument
- `ReadFile()` should now be called form the `os` package