### PR TITLE
`cartservice` - Memorystore (Redis) 7.0

### DIFF
--- a/kustomize/components/memorystore/README.md
+++ b/kustomize/components/memorystore/README.md
@@ -23,7 +23,7 @@ gcloud redis instances create redis-cart \
     --size=1 \
     --region=${REGION} \
     --zone=${ZONE} \
-    --redis-version=redis_6_x
+    --redis-version=redis_7_0
 ```
 
 _Note: You can also find in this repository the Terraform script to provision the Memorystore (Redis) instance alongside the GKE cluster, more information [here](/terraform)._

--- a/terraform/memorystore.tf
+++ b/terraform/memorystore.tf
@@ -22,7 +22,7 @@ resource "google_redis_instance" "redis-cart" {
   # if var.memorystore is true then the resource is enabled
   count          = var.memorystore ? 1 : 0
 
-  redis_version  = "REDIS_6_X"
+  redis_version  = "REDIS_7_0"
   project        = var.gcp_project_id
 
   depends_on = [


### PR DESCRIPTION
Memorstore (Redis) now [supports Redis 7.0](https://cloud.google.com/blog/products/databases/redis-7-0-comes-to-memorystore/).

The in-cluster version of the `redis-cart` has been using Redis 7.0 by default for a while now because of using [`redis:alpine`](https://github.com/GoogleCloudPlatform/microservices-demo/blob/main/kubernetes-manifests/redis.yaml#L42) (i.e. `latest` being 7.0). So this is confirming that `cartservice` is working well with Redis 7.0, no issues.

I also tested this as part of [this "tutorial" (provisioning via `gcloud`)](https://medium.com/google-cloud/use-google-cloud-memorystore-redis-with-the-online-boutique-sample-on-gke-82f7879a900d?sk=8874a67a93cf617367e744708d34ad44). I also did the test of provisioning a Memorystore (Redis) instance via Terraform. All good!