### PR TITLE
Release v0.8.1

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v2
 name: onlineboutique
 description: A Helm chart for Kubernetes for Online Boutique

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.8.0"
+appVersion: "v0.8.1"

--- a/kustomize/base/adservice.yaml
+++ b/kustomize/base/adservice.yaml
@@ -41,7 +41,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/adservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.8.1
         ports:
         - containerPort: 9555
         env:

--- a/kustomize/base/cartservice.yaml
+++ b/kustomize/base/cartservice.yaml
@@ -41,7 +41,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.8.1
         ports:
         - containerPort: 7070
         env:

--- a/kustomize/base/checkoutservice.yaml
+++ b/kustomize/base/checkoutservice.yaml
@@ -40,7 +40,7 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.8.0
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.8.1
           ports:
           - containerPort: 5050
           readinessProbe:

--- a/kustomize/base/currencyservice.yaml
+++ b/kustomize/base/currencyservice.yaml
@@ -41,7 +41,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.8.1
         ports:
         - name: grpc
           containerPort: 7000

--- a/kustomize/base/emailservice.yaml
+++ b/kustomize/base/emailservice.yaml
@@ -41,7 +41,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.8.1
         ports:
         - containerPort: 8080
         env:

--- a/kustomize/base/frontend.yaml
+++ b/kustomize/base/frontend.yaml
@@ -42,7 +42,7 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.8.0
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.8.1
           ports:
           - containerPort: 8080
           readinessProbe:

--- a/kustomize/base/loadgenerator.yaml
+++ b/kustomize/base/loadgenerator.yaml
@@ -67,7 +67,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.8.1
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/kustomize/base/paymentservice.yaml
+++ b/kustomize/base/paymentservice.yaml
@@ -41,7 +41,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.8.1
         ports:
         - containerPort: 50051
         env:

--- a/kustomize/base/productcatalogservice.yaml
+++ b/kustomize/base/productcatalogservice.yaml
@@ -41,7 +41,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.8.1
         ports:
         - containerPort: 3550
         env:

--- a/kustomize/base/recommendationservice.yaml
+++ b/kustomize/base/recommendationservice.yaml
@@ -41,7 +41,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.8.1
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/kustomize/base/shippingservice.yaml
+++ b/kustomize/base/shippingservice.yaml
@@ -40,7 +40,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.8.1
         ports:
         - containerPort: 50051
         env:

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -47,7 +47,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.8.1
         ports:
         - containerPort: 8080
         env:
@@ -112,7 +112,7 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.8.0
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.8.1
           ports:
           - containerPort: 5050
           readinessProbe:
@@ -186,7 +186,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.8.1
         ports:
         - containerPort: 8080
         readinessProbe:
@@ -255,7 +255,7 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.8.0
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.8.1
           ports:
           - containerPort: 8080
           readinessProbe:
@@ -364,7 +364,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.8.1
         ports:
         - containerPort: 50051
         env:
@@ -428,7 +428,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.8.1
         ports:
         - containerPort: 3550
         env:
@@ -492,7 +492,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.8.1
         ports:
         - containerPort: 7070
         env:
@@ -584,7 +584,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.8.1
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"
@@ -627,7 +627,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.8.1
         ports:
         - name: grpc
           containerPort: 7000
@@ -691,7 +691,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.8.1
         ports:
         - containerPort: 50051
         env:
@@ -821,7 +821,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/adservice:v0.8.0
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.8.1
         ports:
         - containerPort: 9555
         env:


### PR DESCRIPTION
We're creating a new release: `v0.8.1`.

## Patch version bump
* No user-facing features have been added since the last release; hence, we're just doing a patch release (see [semantic versioning rules here](https://semver.org/)).

## How to review this pull-request
* [x] Make sure [Draft release notes](https://github.com/GoogleCloudPlatform/microservices-demo/releases) look good. 
* [x] Make sure the files changes look good (e.g., include all **11** microservices).
* [x] Make sure all 11 microservices have `v0.8.1` Docker images in [our Container Registry](https://pantheon.corp.google.com/gcr/images/google-samples/global/microservices-demo?project=google-samples).
