### PR TITLE
Python container images upgrade to latest minor version (security upgrade)

### DIFF
--- a/src/emailservice/Dockerfile
+++ b/src/emailservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.10.8-slim@sha256:abf96998af340975c26177b900c10cfb40716c985325303c063736f0f5cf3171 as base
+FROM python:3.10.13-slim@sha256:1d517e04d033a04d86f7de57bf41cae166ca362b37a1cb229e326bc1d754db55 as base
 
 FROM base as builder
 

--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.11.1-slim@sha256:33a1008485e1a2dc565be79ece483b240cbc4d6266d6144a57a5a9965ede9bbf as base
+FROM python:3.11.5-slim@sha256:a28fdf3bde6c0c97b656841669f6b4cc8164d0f34067c6ce6b5532effe94f8a7 as base
 
 FROM base as builder
 

--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.11.5-slim@sha256:a28fdf3bde6c0c97b656841669f6b4cc8164d0f34067c6ce6b5532effe94f8a7 as base
+FROM python:3.11.6-slim@sha256:e932b9a0f25c306d542fc69133d24b872a6a264810e300b553e7ecd027599ca5 as base
 
 FROM base as builder
 

--- a/src/recommendationservice/Dockerfile
+++ b/src/recommendationservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.10.8-slim@sha256:abf96998af340975c26177b900c10cfb40716c985325303c063736f0f5cf3171 as base
+FROM python:3.10.13-slim@sha256:1d517e04d033a04d86f7de57bf41cae166ca362b37a1cb229e326bc1d754db55 as base
 
 FROM base as builder
 


### PR DESCRIPTION
Python container images upgrade:
- `loadgenerator`: `3.11.1` --> `3.11.6`
- `emailservice` and `recommendationservice`: `3.10.8` --> `3.10.13`

It's just a security upgrade to the latest patch version for the 3 apps mentioned above. Not trying to upgrade to latest minor version. Upgrading to next or latest minor versions involves more work/research, you can see for example that the current tentative by Renovate is failing on trying to do this: https://github.com/GoogleCloudPlatform/microservices-demo/pull/2226.

https://www.python.org/downloads/:
- `3.10.13`: https://docs.python.org/release/3.10.13/whatsnew/changelog.html#python-3-10-13-final
- `3.11.6`: https://docs.python.org/release/3.11.6/whatsnew/changelog.html#python-3-11-6

Currently, the GKE Security Posture feature highlights this:
<img width="515" alt="image" src="https://github.com/GoogleCloudPlatform/microservices-demo/assets/11720844/fc9f152c-4577-4861-9876-115b9895d2e8">

With this PR, we are now at 0 vulnerabilities.
