### PR TITLE
Add "# deletion_protection = false" to main.tf

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -49,6 +49,10 @@ resource "google_container_cluster" "my_cluster" {
   ip_allocation_policy {
   }
 
+  # Avoid setting deletion_protection to false
+  # until you're ready (and certain you want) to destroy the cluster.
+  # deletion_protection = false
+
   depends_on = [
     module.enable_google_apis
   ]


### PR DESCRIPTION
### Background 
* See https://github.com/GoogleCloudPlatform/microservices-demo/issues/2240 for more details.
* This fixes https://github.com/GoogleCloudPlatform/microservices-demo/issues/2240.

### Change Summary
* We're adding instructions to explicitly set `deletion_protection` (of the `google_container_cluster`/GKE clusterr) to `false` before running `terraform destroy`.

### Testing Procedure
* If you want to be thorough, you can run the instructions .
* But I don't think it's necessary since this is a minor bug/fix.
