### PR TITLE
Fix file targeted by sed in DeployStack test

### DIFF
--- a/.deploystack/test
+++ b/.deploystack/test
@@ -173,7 +173,7 @@ section_open "Testing Online Boutique's front-end is working"
 section_close
 
 # Uncomment the line: "deletion_protection = false"
-sed -i "s/# deletion_protection/deletion_protection/g" main.tf
+sed -i "s/# deletion_protection/deletion_protection/g" ${DIR}/main.tf
 
 terraform -chdir="$DIR" destroy -auto-approve \
     -var gcp_project_id="${PROJECT}" \


### PR DESCRIPTION
* I made a slight error in https://github.com/GoogleCloudPlatform/microservices-demo/pull/2241.
* See there [build logs that ran on the most recent `main` commit](https://pantheon.corp.google.com/cloud-build/builds/f50fea67-7ae2-4e3f-90e8-55e6891ee388;step=1?e=13803378&mods=dm_deploy_from_gcs&project=ds-tester-microservices-demo). The following error occurred:
```
sed: can't read main.tf: No such file or directory
```
