### PR TITLE
Enable ASM in Fleet, in service-mesh-istio/README.md

### DIFF
--- a/kustomize/components/service-mesh-istio/README.md
+++ b/kustomize/components/service-mesh-istio/README.md
@@ -34,6 +34,9 @@ The recommended way to [install ASM](https://cloud.google.com/service-mesh/docs/
 # Enable ASM and Fleet APIs
 gcloud services enable mesh.googleapis.com --project ${PROJECT_ID}
 
+# Enable ASM on the project's Fleet.
+gcloud container fleet mesh enable --project ${PROJECT_ID}
+
 # Register GKE cluster with Fleet
 gcloud container fleet memberships register ${CLUSTER_NAME} \
     --gke-cluster ${ZONE}/${CLUSTER_NAME} \

--- a/kustomize/components/service-mesh-istio/README.md
+++ b/kustomize/components/service-mesh-istio/README.md
@@ -34,7 +34,7 @@ The recommended way to [install ASM](https://cloud.google.com/service-mesh/docs/
 # Enable ASM and Fleet APIs
 gcloud services enable mesh.googleapis.com --project ${PROJECT_ID}
 
-# Enable ASM on the project's Fleet.
+# Enable ASM on the project's Fleet
 gcloud container fleet mesh enable --project ${PROJECT_ID}
 
 # Register GKE cluster with Fleet


### PR DESCRIPTION
### Background 
* See [the _Provision Anthos Service Mesh (ASM)_ section ASM quickstart](https://cloud.google.com/service-mesh/docs/unified-install/install-anthos-service-mesh-command#provision).
* We need to run the following command to enable ASM on the project's Fleet:
```
gcloud container fleet mesh enable --project PROJECT_ID
```
* We forgot this step in Online Boutique's ASM instructions.
* We didn't catch this issue before because we were testing on project that already had ASM enabled (on the project Fleet).

### Change Summary
* Add `gcloud container fleet mesh enable --project ${PROJECT_ID}` to the ASM instructions.

### Testing Procedure
* I don't think we need to do thorough testing here.
* The command is valid:

<img width="1034" alt="Screenshot 2023-11-01 at 5 19 30 PM" src="https://github.com/GoogleCloudPlatform/microservices-demo/assets/10292865/f38ae7b5-683c-48e8-8384-a700d0661c56">

---

CC: Thanks, @dkoss, for finding this issue.
