### PR TITLE
Add line to "terraform apply" deletion_protection

### DIFF
--- a/.deploystack/test
+++ b/.deploystack/test
@@ -174,6 +174,13 @@ section_close
 
 # Uncomment the line: "deletion_protection = false"
 sed -i "s/# deletion_protection/deletion_protection/g" ${DIR}/main.tf
+terraform -chdir="$DIR" apply -auto-approve \
+    -var gcp_project_id="${PROJECT}" \
+    -var name="${NAME}" \
+    -var region="${REGION}" \
+    -var namespace="${NAMESPACE}"  \
+    -var filepath_manifest="${FILEPATH_MANIFEST}" \
+    -var memorystore="${MEMORYSTORE}"
 
 terraform -chdir="$DIR" destroy -auto-approve \
     -var gcp_project_id="${PROJECT}" \

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -83,6 +83,9 @@ To remove the individual resources created for by Terraform without deleting the
    ```bash
    # Uncomment the line: "deletion_protection = false"
    sed -i "s/# deletion_protection/deletion_protection/g" main.tf
+
+   # Re-apply the Terraform to update the state
+   terraform apply
    ```
 
 1. Run the following command:


### PR DESCRIPTION
### Background 
* This is a follow-up to https://github.com/GoogleCloudPlatform/microservices-demo/pull/2241 (where I didn't `terraform apply` the changes to `deletion_protection`).
* According to [this StackOverflow](https://stackoverflow.com/a/70944076), after setting `deletion_protection` to `true` (in the Terraform code), we have to then `terraform apply` _before_ `terraform destroy`. 

### Change Summary
* This pull-request updates:
    1. the instructions
    1. the DeployStack test

### Testing these changes
* I have manually triggered the DeployStack test to run against this branch (`nimjay-deletion-protection`). See [Cloud Build logs here](https://pantheon.corp.google.com/cloud-build/builds/337aca9b-a127-4231-bbd5-23c903df24d4;step=1?e=13803378&mods=dm_deploy_from_gcs&project=ds-tester-microservices-demo), or check the GitHub check success status below (for the `Test-Procedure (ds-tester-microservices-demo)` GitHub check). Ping me if you need access to the Cloud Build logs. 

<img width="815" alt="Screenshot 2023-11-02 at 2 43 35 PM" src="https://github.com/GoogleCloudPlatform/microservices-demo/assets/10292865/d0b5061a-5e03-484d-996b-4dc919f9d55e">
