### PR TITLE
fix: Add gcb skaffold profile to loadgenerator module

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -69,7 +69,7 @@ profiles:
       diskSizeGb: 300
       machineType: N1_HIGHCPU_32
       timeout: 4000s
-# "debug" profile replaces the default Dockerfile in cartservice with Dockerfile.debug, 
+# "debug" profile replaces the default Dockerfile in cartservice with Dockerfile.debug,
 # which enables debugging via skaffold.
 #
 # This profile is used by default when running skaffold debug.
@@ -105,3 +105,10 @@ manifests:
   - ./kubernetes-manifests/loadgenerator.yaml
 deploy:
   kubectl: {}
+profiles:
+- name: gcb
+  build:
+    googleCloudBuild:
+      diskSizeGb: 300
+      machineType: N1_HIGHCPU_32
+      timeout: 4000s


### PR DESCRIPTION
### Background 
* Today, the `/skaffold.yaml` file contains two "modules" (or `Config`s):
    * `app` (all microservices except loadgenerator) and `loadgenerator`
    * To target (only build and deploy) a specific module, run: `skaffold run --module=app ...`
* Skaffold also has a concept called "Profile"s which you can target using `skaffold run --profile=name-of-profile ...`.

### Problem
* Currently the Profile called `gcb` (which tells skaffold to use Google Cloud Build for building microservices' Docker images) is only defined for the `app` module/Config.
* So when I ran `skaffold run -p gcb --default-repo=gcr.io/${MY_PROJECT_ID}`, skaffold was still trying to build `loadgenerator` service locally — instead of via Google Cloud Build.

### Change Summary
* Define `gcb` Profile for the `loadgenerator` modules as well.

