### PR TITLE
fix: Build Docker contains using gcloud for releases

### DIFF
--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -14,12 +14,14 @@ This document walks through the process of creating a new release of Online Bout
 
    - `TAG` - This is the new version (e.g., `v0.3.5`).
    - `REPO_PREFIX` - This is the Docker repository.
+   - `PROJECT_ID` - This is the Google Cloud project in which Google Cloud Build will be used to remotely build microservice Docker images.
 
    **Example:**
-   
+
    ```
    export TAG=v0.3.5
    export REPO_PREFIX=gcr.io/google-samples/microservices-demo
+   export PROJECT_ID=google-samples
    ```
 
 5. Run `./docs/releasing/make-release.sh`.

--- a/docs/releasing/make-docker-images.sh
+++ b/docs/releasing/make-docker-images.sh
@@ -24,6 +24,7 @@ log() { echo "$1" >&2; }
 
 TAG="${TAG:?TAG env variable must be specified}"
 REPO_PREFIX="${REPO_PREFIX:?REPO_PREFIX env variable must be specified}"
+PROJECT_ID="${PROJECT_ID:?PROJECT_ID env variable must be specified e.g. google-samples}"
 
 while IFS= read -d $'\0' -r dir; do
     # build image
@@ -37,11 +38,8 @@ while IFS= read -d $'\0' -r dir; do
     image="${REPO_PREFIX}/$svcname:$TAG"
     (
         cd "${builddir}"
-        log "Building: ${image}"
-        docker build --pull -t "${image}" .
-
-        log "Pushing: ${image}"
-        docker push "${image}"
+        log "Building (and pushing) image on Google Cloud Build: ${image}"
+        gcloud builds submit --project=${PROJECT_ID} --tag=${image}
     )
 done < <(find "${REPO_ROOT}/src" -mindepth 1 -maxdepth 1 -type d -print0)
 

--- a/docs/releasing/make-release.sh
+++ b/docs/releasing/make-release.sh
@@ -30,6 +30,7 @@ fail() { log "$1"; exit 1; }
 
 TAG="${TAG:?TAG env variable must be specified}"
 REPO_PREFIX="${REPO_PREFIX:?REPO_PREFIX env variable must be specified e.g. gcr.io\/google-samples\/microservices-demo}"
+PROJECT_ID="${PROJECT_ID:?PROJECT_ID env variable must be specified e.g. google-samples}"
 
 if [[ "$TAG" != v* ]]; then
     fail "\$TAG must start with 'v', e.g. v0.1.0 (got: $TAG)"


### PR DESCRIPTION
* Use Google Cloud Build to (remotely) build Docker container images — when creating a new release of Online Boutique.
* I have not tested this change — but it _will_ be tested when I create the next release (shortly).
