### PR TITLE
Remove confusing sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 ![Continuous Integration](https://github.com/GoogleCloudPlatform/microservices-demo/workflows/Continuous%20Integration%20-%20Main/Release/badge.svg)
 
-**Online Boutique** is a cloud-first microservices demo application.
-Online Boutique consists of an 11-tier microservices application. The application is a
+**Online Boutique** is a cloud-first microservices demo application.  The application is a
 web-based e-commerce app where users can browse items,
 add them to the cart, and purchase them.
 


### PR DESCRIPTION
Removed sentence which describes the application as "11 tiers", which is not a well-defined term and does not help explain the purpose of the application.  The existing explanation ("cloud-first microservices application...web-based e-commerce app") is sufficient.

### Background 

Remove [confusing](https://www.reddit.com/r/googlecloud/comments/18l7ohj/11_tier_application_on_gcp_confused/) reference to "11-tier" application.

### Change Summary

Remove reference to "11-tier" application, the architecture section explains the 11 microservices.


### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->

https://www.reddit.com/r/googlecloud/comments/18l7ohj/11_tier_application_on_gcp_confused/
