### PR TITLE
feat: add 'app' label to Deployment and Service objects

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -16,6 +16,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: adservice
+  labels:
+    app: adservice
 spec:
   selector:
     matchLabels:
@@ -69,6 +71,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: adservice
+  labels:
+    app: adservice
 spec:
   type: ClusterIP
   selector:

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -16,6 +16,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cartservice
+  labels:
+    app: cartservice
 spec:
   selector:
     matchLabels:
@@ -68,6 +70,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cartservice
+  labels:
+    app: cartservice
 spec:
   type: ClusterIP
   selector:

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -16,6 +16,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: checkoutservice
+  labels:
+    app: checkoutservice
 spec:
   selector:
     matchLabels:
@@ -76,6 +78,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: checkoutservice
+  labels:
+    app: checkoutservice
 spec:
   type: ClusterIP
   selector:

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -16,6 +16,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: currencyservice
+  labels:
+    app: currencyservice
 spec:
   selector:
     matchLabels:
@@ -68,6 +70,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: currencyservice
+  labels:
+    app: currencyservice
 spec:
   type: ClusterIP
   selector:

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -16,6 +16,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: emailservice
+  labels:
+    app: emailservice
 spec:
   selector:
     matchLabels:
@@ -69,6 +71,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: emailservice
+  labels:
+    app: emailservice
 spec:
   type: ClusterIP
   selector:

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -16,6 +16,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
+  labels:
+    app: frontend
 spec:
   selector:
     matchLabels:
@@ -103,6 +105,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: frontend
+  labels:
+    app: frontend
 spec:
   type: ClusterIP
   selector:
@@ -116,6 +120,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: frontend-external
+  labels:
+    app: frontend
 spec:
   type: LoadBalancer
   selector:

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -15,6 +15,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: loadgenerator
+  labels:
+    app: loadgenerator
 spec:
   selector:
     matchLabels:

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -16,6 +16,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: paymentservice
+  labels:
+    app: paymentservice
 spec:
   selector:
     matchLabels:
@@ -67,6 +69,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: paymentservice
+  labels:
+    app: paymentservice
 spec:
   type: ClusterIP
   selector:

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -16,6 +16,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: productcatalogservice
+  labels:
+    app: productcatalogservice
 spec:
   selector:
     matchLabels:
@@ -67,6 +69,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: productcatalogservice
+  labels:
+    app: productcatalogservice
 spec:
   type: ClusterIP
   selector:

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -16,6 +16,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: recommendationservice
+  labels:
+    app: recommendationservice
 spec:
   selector:
     matchLabels:
@@ -71,6 +73,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: recommendationservice
+  labels:
+    app: recommendationservice
 spec:
   type: ClusterIP
   selector:

--- a/kubernetes-manifests/redis.yaml
+++ b/kubernetes-manifests/redis.yaml
@@ -16,6 +16,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-cart
+  labels:
+    app: redis-cart
 spec:
   selector:
     matchLabels:
@@ -68,6 +70,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis-cart
+  labels:
+    app: redis-cart
 spec:
   type: ClusterIP
   selector:

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -16,6 +16,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: shippingservice
+  labels:
+    app: shippingservice
 spec:
   selector:
     matchLabels:
@@ -67,6 +69,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: shippingservice
+  labels:
+    app: shippingservice
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
### Background 

When searching by the 'app' label, only pods would appear. To find the Service
or Deployment objects associated with the app, one would need to query by name.
In some cases (that is, 'frontend-external'), name is not sufficient.

Some tools, like the backstage.io kubernetes plugin, do not show the Deployment
and Service objects because they are missing these labels. This leads to
confusion about the service/deployment that owns the pods.

### Change Summary
<!-- Short summary of the changes submitted -->
Adds the 'app' label to all Service and Deployment objects

