### PR TITLE
Change live demo domain to cymbal.dev

### DIFF
--- a/.github/release-cluster/README.md
+++ b/.github/release-cluster/README.md
@@ -1,6 +1,6 @@
-# onlineboutique.dev manifests
+# cymbal-shops.retail.cymbal.dev manifests
 
-This directory contains extra deploy manifests for configuring Online Boutique solution on GKE for onlineboutique.dev.
+This directory contains extra deploy manifests for configuring Online Boutique solution on GKE for cymbal-shops.retail.cymbal.dev.
 
 _Note: before moving forward, the Online Boutique apps should already be deployed [on the online-boutique-release GKE cluster](/docs/releasing#10-deploy-releasekubernetes-manifestsyaml-to-our-online-boutique-release-gke-cluster)._
 

--- a/.github/release-cluster/backend-config.yaml
+++ b/.github/release-cluster/backend-config.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:

--- a/.github/release-cluster/frontend-config.yaml
+++ b/.github/release-cluster/frontend-config.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:

--- a/.github/release-cluster/frontend-ingress.yaml
+++ b/.github/release-cluster/frontend-ingress.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/.github/release-cluster/frontend-service.yaml
+++ b/.github/release-cluster/frontend-service.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/.github/release-cluster/managed-cert.yaml
+++ b/.github/release-cluster/managed-cert.yaml
@@ -4,4 +4,4 @@ metadata:
   name: online-boutique-certificate
 spec:
   domains:
-    - onlineboutique.dev
+    - cymbal-shops.retail.cymbal.dev

--- a/.github/release-cluster/managed-cert.yaml
+++ b/.github/release-cluster/managed-cert.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,7 +4,7 @@ This page describes the CI/CD workflows for the Online Boutique app, which run i
 
 ## Infrastructure
 
-The CI/CD pipelines for Online Boutique run in Github Actions, using a pool of two [self-hosted runners]((https://help.github.com/en/actions/automating-your-workflow-with-github-actions/about-self-hosted-runners)). These runners are GCE instances (virtual machines) that, for every open Pull Request in the repo, run the code test pipeline, deploy test pipeline, and (on main) deploy the latest version of the app to [onlineboutique.dev](https://onlineboutique.dev)
+The CI/CD pipelines for Online Boutique run in Github Actions, using a pool of two [self-hosted runners]((https://help.github.com/en/actions/automating-your-workflow-with-github-actions/about-self-hosted-runners)). These runners are GCE instances (virtual machines) that, for every open Pull Request in the repo, run the code test pipeline, deploy test pipeline, and (on main) deploy the latest version of the app to [cymbal-shops.retail.cymbal.dev](https://cymbal-shops.retail.cymbal.dev)
 
 We also host a test GKE cluster, which is where the deploy tests run. Every PR has its own namespace in the cluster.
 

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -62,6 +62,6 @@ This document walks through the process of creating a new release of Online Bout
    kubectl apply -f ./release/kubernetes-manifests.yaml
    ```
 
-12. Make sure [onlineboutique.dev](https://onlineboutique.dev) works.
+12. Make sure [cymbal-shops.retail.cymbal.dev](https://cymbal-shops.retail.cymbal.dev) works.
 
 13. [Publish your draft release on GitHub](https://github.com/GoogleCloudPlatform/microservices-demo/releases).


### PR DESCRIPTION
This PR changes the live demo URL from `onlineboutique.dev` to `cymbal-shops.retail.cymbal.dev`.

It also adds copyright headers on the `release-cluster/` manifests.