### PR TITLE
fix: display service name in Cloud Trace

### DIFF
--- a/helm-chart/templates/checkoutservice.yaml
+++ b/helm-chart/templates/checkoutservice.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.checkoutService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -77,6 +91,8 @@ spec:
         {{- if .Values.opentelemetryCollector.create }}
         - name: COLLECTOR_SERVICE_ADDR
           value: "{{ .Values.opentelemetryCollector.name }}:4317"
+        - name: OTEL_SERVICE_NAME
+          value: "{{ .Values.checkoutService.name }}"
         {{- end }}
         {{- if .Values.googleCloudOperations.tracing }}
         - name: ENABLE_TRACING

--- a/helm-chart/templates/currencyservice.yaml
+++ b/helm-chart/templates/currencyservice.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.currencyService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -61,6 +75,8 @@ spec:
         {{- if .Values.opentelemetryCollector.create }}
         - name: COLLECTOR_SERVICE_ADDR
           value: "{{ .Values.opentelemetryCollector.name }}:4317"
+        - name: OTEL_SERVICE_NAME
+          value: "{{ .Values.currencyService.name }}"
         {{- end }}
         {{- if .Values.googleCloudOperations.tracing }}
         - name: ENABLE_TRACING

--- a/helm-chart/templates/emailservice.yaml
+++ b/helm-chart/templates/emailservice.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.emailService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -60,6 +74,8 @@ spec:
         {{- if .Values.opentelemetryCollector.create }}
         - name: COLLECTOR_SERVICE_ADDR
           value: "{{ .Values.opentelemetryCollector.name }}:4317"
+        - name: OTEL_SERVICE_NAME
+          value: "{{ .Values.emailService.name }}"
         {{- end }}
         {{- if .Values.googleCloudOperations.tracing }}
         - name: ENABLE_TRACING

--- a/helm-chart/templates/frontend.yaml
+++ b/helm-chart/templates/frontend.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.frontend.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -93,6 +107,8 @@ spec:
           {{- if .Values.opentelemetryCollector.create }}
           - name: COLLECTOR_SERVICE_ADDR
             value: "{{ .Values.opentelemetryCollector.name }}:4317"
+          - name: OTEL_SERVICE_NAME
+            value: "{{ .Values.frontend.name }}"
           {{- end }}
           {{- if .Values.googleCloudOperations.tracing }}
           - name: ENABLE_TRACING

--- a/helm-chart/templates/paymentservice.yaml
+++ b/helm-chart/templates/paymentservice.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.paymentService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -60,6 +74,8 @@ spec:
         {{- if .Values.opentelemetryCollector.create }}
         - name: COLLECTOR_SERVICE_ADDR
           value: "{{ .Values.opentelemetryCollector.name }}:4317"
+        - name: OTEL_SERVICE_NAME
+          value: "{{ .Values.paymentService.name }}"
         {{- end }}
         {{- if .Values.googleCloudOperations.tracing }}
         - name: ENABLE_TRACING

--- a/helm-chart/templates/productcatalogservice.yaml
+++ b/helm-chart/templates/productcatalogservice.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.productCatalogService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -60,6 +74,8 @@ spec:
         {{- if .Values.opentelemetryCollector.create }}
         - name: COLLECTOR_SERVICE_ADDR
           value: "{{ .Values.opentelemetryCollector.name }}:4317"
+        - name: OTEL_SERVICE_NAME
+          value: "{{ .Values.productCatalogService.name }}"
         {{- end }}
         {{- if .Values.googleCloudOperations.tracing }}
         - name: ENABLE_TRACING

--- a/helm-chart/templates/recommendationservice.yaml
+++ b/helm-chart/templates/recommendationservice.yaml
@@ -1,3 +1,17 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 {{- if .Values.recommendationService.create }}
 {{- if .Values.serviceAccounts.create }}
 apiVersion: v1
@@ -70,6 +84,8 @@ spec:
         {{- if .Values.opentelemetryCollector.create }}
         - name: COLLECTOR_SERVICE_ADDR
           value: "{{ .Values.opentelemetryCollector.name }}:4317"
+        - name: OTEL_SERVICE_NAME
+          value: "{{ .Values.recommendationService.name }}"
         {{- end }}
         {{- if .Values.googleCloudOperations.tracing }}
         - name: ENABLE_TRACING

--- a/kustomize/components/google-cloud-operations/kustomization.yaml
+++ b/kustomize/components/google-cloud-operations/kustomization.yaml
@@ -32,6 +32,8 @@ patches:
               env:
               - name: COLLECTOR_SERVICE_ADDR
                 value: "opentelemetrycollector:4317"
+              - name: OTEL_SERVICE_NAME
+                value: "checkoutservice"
               - name: ENABLE_TRACING
                 value: "1"
               - name: ENABLE_PROFILER
@@ -50,6 +52,8 @@ patches:
               env:
               - name: COLLECTOR_SERVICE_ADDR
                 value: "opentelemetrycollector:4317"
+              - name: OTEL_SERVICE_NAME
+                value: "currencyservice"
               - name: ENABLE_TRACING
                 value: "1"
               - name: DISABLE_PROFILER
@@ -68,6 +72,8 @@ patches:
               env:
               - name: COLLECTOR_SERVICE_ADDR
                 value: "opentelemetrycollector:4317"
+              - name: OTEL_SERVICE_NAME
+                value: "emailservice"
               - name: ENABLE_TRACING
                 value: "1"
               - name: DISABLE_PROFILER
@@ -88,6 +94,8 @@ patches:
                 value: "1"
               - name: COLLECTOR_SERVICE_ADDR
                 value: "opentelemetrycollector:4317"
+              - name: OTEL_SERVICE_NAME
+                value: "frontend"
               - name: ENABLE_PROFILER
                 value: "1"
 # paymentservice - tracing, profiler
@@ -104,6 +112,8 @@ patches:
               env:
               - name: COLLECTOR_SERVICE_ADDR
                 value: "opentelemetrycollector:4317"
+              - name: OTEL_SERVICE_NAME
+                value: "paymentservice"
               - name: ENABLE_TRACING
                 value: "1"
               - name: DISABLE_PROFILER
@@ -122,6 +132,8 @@ patches:
               env:
               - name: COLLECTOR_SERVICE_ADDR
                 value: "opentelemetrycollector:4317"
+              - name: OTEL_SERVICE_NAME
+                value: "productcatalogservice"
               - name: ENABLE_TRACING
                 value: "1"
               - name: DISABLE_PROFILER
@@ -140,6 +152,8 @@ patches:
               env:
               - name: COLLECTOR_SERVICE_ADDR
                 value: "opentelemetrycollector:4317"
+              - name: OTEL_SERVICE_NAME
+                value: "recommendationservice"
               - name: ENABLE_TRACING
                 value: "1"
               - name: DISABLE_PROFILER


### PR DESCRIPTION
### Background 

Fixes the display of the correct service name in Cloud Trace when the app is deployed with tracing enabled.

### Fixes 
#2349 

### Change Summary
Manifests of the services that ingest traces to Cloud Trace are updated with additional environment variable (`OTEL_SERVICE_NAME`) that results in posting the `service.name` attribute with the correct value.

### Testing Procedure

Deploy the app (either using kustomize with `google-cloud-operations` component or using Helm with Google Cloud operations enabled and observe that all service names in the Trace details grid are known.

