### PR TITLE
Remove one-click deploy button inside README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ If you’re using this demo, please **★Star** this repository to show your int
 | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
 | [![Screenshot of store homepage](/docs/img/online-boutique-frontend-1.png)](/docs/img/online-boutique-frontend-1.png) | [![Screenshot of checkout screen](/docs/img/online-boutique-frontend-2.png)](/docs/img/online-boutique-frontend-2.png) |
 
-## Interactive quickstart (GKE)
-
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fmicroservices-demo&shellonly=true&cloudshell_image=gcr.io/ds-artifacts-cloudshell/deploystack_custom_image)
-
 ## Quickstart (GKE)
 
 1. Ensure you have the following requirements:


### PR DESCRIPTION
* See https://github.com/GoogleCloudPlatform/microservices-demo/issues/2378.
* No testing required. This is a simple documentation update.
* Note that we still have: https://github.com/GoogleCloudPlatform/microservices-demo/blob/main/docs/deploystack.md