### PR TITLE
fix: when posting empty body to http://front/cart/checkout, the payme…

### DIFF
--- a/src/paymentservice/server.js
+++ b/src/paymentservice/server.js
@@ -45,6 +45,9 @@ class HipsterShopServer {
       callback(null, response);
     } catch (err) {
       console.warn(err);
+      if (!(err instanceof Error)) {
+        err = new Error(`An error occurred: ${err}`)
+      }
       callback(err);
     }
   }


### PR DESCRIPTION
fix: when posting empty body to http://front/cart/checkout, the paymentservice will crash. Because the raised error's type is string, however, the callback function only accepts error type)


### Testing Procedure

1. deploy the service by `skaffold run`
2. then use curl or postman, send an empty post request to the frontend/cart/checkout
<img width="1134" alt="image" src="https://github.com/GoogleCloudPlatform/microservices-demo/assets/53161583/169db29c-71fc-44a0-95ba-85294962b287">

3. run `kubectl get pods`, there will be the crashloopbackoff error in paymentservice. And the root cause is the code raise a string type of error.
```
    try {
      logger.info(`PaymentService#Charge invoked with request ${JSON.stringify(call.request)}`);
      const response = charge(call.request);
      callback(null, response);
    } catch (err) { // here
      console.warn(err);
      if (!(err instanceof Error)) {
        err = new Error(`An error occurred: ${err}`)
      }
      callback(err);
    }
```
