### PR TITLE
Add instructions for updating major tag during release

### DIFF
--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -66,14 +66,14 @@ This document walks through the process of creating a new release of Online Bout
 
 13. Update the relevant major tag (`v1`).
 
-    ```
-    export MAJOR_TAG=v0 # Edit this as needed (to v1/v2/v3/etc)
-    git checkout release/${TAG}
-    git pull
-    git push --delete origin ${MAJOR_TAG} # Delete the remote tag (if it exists)
-    git tag --delete ${MAJOR_TAG} # Delete the local tag (if it exists)
-    git tag -a ${MAJOR_TAG} -m "Updating ${MAJOR_TAG} to its most recent release: ${TAG}"
-    git push origin ${MAJOR_TAG} # Push the new tag to origin
-    ```
+  ```
+  export MAJOR_TAG=v0 # Edit this as needed (to v1/v2/v3/etc)
+  git checkout release/${TAG}
+  git pull
+  git push --delete origin ${MAJOR_TAG} # Delete the remote tag (if it exists)
+  git tag --delete ${MAJOR_TAG} # Delete the local tag (if it exists)
+  git tag -a ${MAJOR_TAG} -m "Updating ${MAJOR_TAG} to its most recent release: ${TAG}"
+  git push origin ${MAJOR_TAG} # Push the new tag to origin
+  ```
 
 14. [Publish your draft release on GitHub](https://github.com/GoogleCloudPlatform/microservices-demo/releases).

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -64,7 +64,7 @@ This document walks through the process of creating a new release of Online Bout
 
 12. Make sure [cymbal-shops.retail.cymbal.dev](https://cymbal-shops.retail.cymbal.dev) works.
 
-13. Update the relevant major tag (`v1`).
+13. Update the relevant major tag (for example, `v1`).
 
   ```
   export MAJOR_TAG=v0 # Edit this as needed (to v1/v2/v3/etc)

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -64,4 +64,16 @@ This document walks through the process of creating a new release of Online Bout
 
 12. Make sure [cymbal-shops.retail.cymbal.dev](https://cymbal-shops.retail.cymbal.dev) works.
 
-13. [Publish your draft release on GitHub](https://github.com/GoogleCloudPlatform/microservices-demo/releases).
+13. Update the relevant major tag (`v1`).
+
+    ```
+    export MAJOR_TAG=v0 # Edit this as needed (to v1/v2/v3/etc)
+    git checkout release/${TAG}
+    git pull
+    git push --delete origin ${MAJOR_TAG} # Delete the remote tag (if it exists)
+    git tag --delete ${MAJOR_TAG} # Delete the local tag (if it exists)
+    git tag -a ${MAJOR_TAG} -m "Updating ${MAJOR_TAG} to its most recent release: ${TAG}"
+    git push origin ${MAJOR_TAG} # Push the new tag to origin
+    ```
+
+15. [Publish your draft release on GitHub](https://github.com/GoogleCloudPlatform/microservices-demo/releases).

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -76,4 +76,4 @@ This document walks through the process of creating a new release of Online Bout
     git push origin ${MAJOR_TAG} # Push the new tag to origin
     ```
 
-15. [Publish your draft release on GitHub](https://github.com/GoogleCloudPlatform/microservices-demo/releases).
+14. [Publish your draft release on GitHub](https://github.com/GoogleCloudPlatform/microservices-demo/releases).


### PR DESCRIPTION
### Background 
* See this [Google-internal one-pager](https://docs.google.com/document/d/1num52anF6Jitf2tVeMzn-45sg_2fE6kgVHSs8fdl23E/edit?tab=t.0#heading=h.ehaews8n4juy).

### Change Summary
* I've introduced a `git tag` for each major release (currently just `v0`).

### Testing Procedure
* I have run these commands to successfully [create the `v0` tag](https://github.com/GoogleCloudPlatform/microservices-demo/releases/tag/v0).

