### PR TITLE
fix: remove potentially unsafe external link

### DIFF
--- a/src/frontend/templates/ad.html
+++ b/src/frontend/templates/ad.html
@@ -18,7 +18,7 @@
 <div class="container py-3 px-lg-5 py-lg-5">
     <div role="alert">
         <strong>Ad</strong>
-        <a href="{{.RedirectUrl}}" rel="nofollow" target="_blank">
+        <a href="{{.RedirectUrl}}" rel="nofollow noopener noreferrer" target="_blank">
             {{.Text}}
         </a>
     </div>


### PR DESCRIPTION
### Background 
this updates the attributes associated with the anchor tag and addresses CWE-200 and CWE-1022 


### Fixes 
HTML links that open in a new tab or window allow the target page to access the DOM of the origin page using window.opener unless link type noopener or noreferrer is specified. This is a potential security risk.

### Change Summary
rel="noopener": This attribute enhances security. When a link opens in a new tab (often with target="_blank"), noopener prevents the newly opened webpage from accessing the window object of the original page. This mitigates a security vulnerability called "tabnabbing" where a malicious website could potentially steal information from the original webpage.

rel="noreferrer": Similar to noopener, this prevents the destination website from knowing that the link came from your webpage. Browsers typically send referrer information along with link clicks, which can be used by the destination site to track where their traffic originates from. With noreferrer, this information is withheld.

