### PR TITLE
Use new GKE cluster for ci-pr.yaml

### DIFF
--- a/.github/terraform/README.md
+++ b/.github/terraform/README.md
@@ -1,0 +1,15 @@
+This folder contains the Terraform for some of the infrastructure used by the CICD (continuous integration and continuous delivery/continuous deployment) of this repository.
+
+## Update this Terraform
+
+To make changes to this Terraform, follow these steps:
+
+1. Make sure you have access to the `online-boutique-ci` Google Cloud project.
+1. Move into this folder: `cd .github/terraform`
+1. Set the PROJECT_ID environment variable: `export PROJECT_ID=online-boutique-ci`
+1. Prepare Terraform and download the necessary Terraform dependencies (such as the "hashicorp/google" Terraform provider): `terraform init`
+1. Apply the Terraform: `terraform apply -var project_id=${PROJECT_ID}`
+    * Ideally, you would see `Apply complete! Resources: 0 added, 0 changed, 0 destroyed.` in the output.
+1. Make your desired changes to the Terraform code.
+1. Apply the Terraform: `terraform apply -var project_id=${PROJECT_ID}`
+    * This time, Terraform will prompt you confirm your changes before applying them.

--- a/.github/terraform/main.tf
+++ b/.github/terraform/main.tf
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Set defaults for the google Terraform provider.
+provider "google" {
+  project = var.project_id
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}
+
+terraform {
+  # Store the state inside a Google Cloud Storage bucket.
+  backend "gcs" {
+    bucket = "cicd-terraform-state"
+    prefix = "terraform-state"
+  }
+}
+
+# Enable Google Cloud APIs.
+module "enable_google_apis" {
+  source                      = "terraform-google-modules/project-factory/google//modules/project_services"
+  version                     = "~> 14.0"
+  disable_services_on_destroy = false
+  activate_apis = [
+    "cloudresourcemanager.googleapis.com",
+    "container.googleapis.com",
+    "iam.googleapis.com",
+    "storage.googleapis.com",
+  ]
+  project_id = var.project_id
+}
+
+# Google Cloud Storage for storing Terraform state (.tfstate).
+resource "google_storage_bucket" "terraform_state_storage_bucket" {
+  name          = "cicd-terraform-state"
+  location      = "us"
+  storage_class = "STANDARD"
+  force_destroy = false
+  public_access_prevention = "enforced"
+  uniform_bucket_level_access = true
+  versioning {
+    enabled = true
+  }
+}
+
+# Google Cloud IAM service account for GKE clusters.
+# We avoid using the Compute Engine default service account because it's too permissive.
+resource "google_service_account" "gke_clusters_service_account" {
+  account_id   = "gke-clusters-service-account"
+  display_name = "My Service Account"
+  depends_on = [
+    module.enable_google_apis
+  ]
+}
+
+# See https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
+resource "google_project_iam_member" "gke_clusters_service_account_role_metric_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.gke_clusters_service_account.email}"
+}
+
+# See https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
+resource "google_project_iam_member" "gke_clusters_service_account_role_logging_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.gke_clusters_service_account.email}"
+}
+
+# See https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
+resource "google_project_iam_member" "gke_clusters_service_account_role_monitoring_viewer" {
+  project = var.project_id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.gke_clusters_service_account.email}"
+}
+
+# See https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa
+resource "google_project_iam_member" "gke_clusters_service_account_role_stackdriver_writer" {
+  project = var.project_id
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.gke_clusters_service_account.email}"
+}
+
+# The GKE cluster used for pull-request (PR) staging deployments.
+resource "google_container_cluster" "prs_gke_cluster" {
+  name                = "prs-gke-cluster"
+  location            = "us-central1"
+  enable_autopilot    = true
+  project             = var.project_id
+  deletion_protection = true
+  depends_on = [
+    module.enable_google_apis
+  ]
+  cluster_autoscaling {
+    auto_provisioning_defaults {
+      service_account = google_service_account.gke_clusters_service_account.email
+    }
+  }
+  # Need an empty ip_allocation_policy to overcome an error related to autopilot node pool constraints.
+  # Workaround from https://github.com/hashicorp/terraform-provider-google/issues/10782#issuecomment-1024488630
+  ip_allocation_policy {
+  }
+}

--- a/.github/terraform/main.tf
+++ b/.github/terraform/main.tf
@@ -45,11 +45,11 @@ module "enable_google_apis" {
 
 # Google Cloud Storage for storing Terraform state (.tfstate).
 resource "google_storage_bucket" "terraform_state_storage_bucket" {
-  name          = "cicd-terraform-state"
-  location      = "us"
-  storage_class = "STANDARD"
-  force_destroy = false
-  public_access_prevention = "enforced"
+  name                        = "cicd-terraform-state"
+  location                    = "us"
+  storage_class               = "STANDARD"
+  force_destroy               = false
+  public_access_prevention    = "enforced"
   uniform_bucket_level_access = true
   versioning {
     enabled = true

--- a/.github/terraform/variables.tf
+++ b/.github/terraform/variables.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# This file lists variables that you can set using the -var flag during "terraform apply".
+# Example: terraform apply -var project_id="${PROJECT_ID}"
+
+variable "project_id" {
+  type        = string
+  description = "The Google Cloud project ID."
+}

--- a/.github/terraform/versions.tf
+++ b/.github/terraform/versions.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.4"
+    }
+  }
+}

--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -70,7 +70,7 @@ jobs:
         echo "::set-env name=NAMESPACE::$NAMESPACE"
         echo "::set-env name=PR_NUMBER::$PR_NUMBER"
 
-        gcloud container clusters get-credentials $PR_CLUSTER --zone $ZONE --project $PROJECT_ID
+        gcloud container clusters get-credentials $PR_CLUSTER --region $REGION --project $PROJECT_ID
         cat <<EOF | kubectl apply -f -
         apiVersion: v1
         kind: Namespace
@@ -83,8 +83,8 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PROJECT_ID: "online-boutique-ci"
-        PR_CLUSTER: "online-boutique-prs"
-        ZONE: "us-central1-c"
+        PR_CLUSTER: "prs-gke-cluster"
+        REGION: "us-central1"
     - name: Wait For Pods
       timeout-minutes: 20
       run: |

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -71,7 +71,7 @@ jobs:
         NAMESPACE="pr${PR_NUMBER}"
         echo "::set-env name=NAMESPACE::$NAMESPACE"
 
-        gcloud container clusters get-credentials $PR_CLUSTER --zone $ZONE --project $PROJECT_ID
+        gcloud container clusters get-credentials $PR_CLUSTER --region $REGION --project $PROJECT_ID
         cat <<EOF | kubectl apply -f -
         apiVersion: v1
         kind: Namespace
@@ -85,8 +85,8 @@ jobs:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PR_NUMBER: ${{ github.event.pull_request.number }}
         PROJECT_ID: "online-boutique-ci"
-        PR_CLUSTER: "online-boutique-prs"
-        ZONE: "us-central1-c"
+        PR_CLUSTER: "prs-gke-cluster"
+        REGION: "us-central1-a"
     - name: Wait For Pods
       timeout-minutes: 20
       run: |

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -86,7 +86,7 @@ jobs:
         PR_NUMBER: ${{ github.event.pull_request.number }}
         PROJECT_ID: "online-boutique-ci"
         PR_CLUSTER: "prs-gke-cluster"
-        REGION: "us-central1-a"
+        REGION: "us-central1"
     - name: Wait For Pods
       timeout-minutes: 20
       run: |

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -34,11 +34,11 @@ jobs:
         timeout-minutes: 20
         run: |
           gcloud container clusters get-credentials $PR_CLUSTER \
-              --zone $ZONE --project $PROJECT_ID
+              --region $REGION --project $PROJECT_ID
           NAMESPACE="pr${PR_NUMBER}"
           kubectl delete namespace $NAMESPACE
         env:
           PROJECT_ID: "online-boutique-ci"
-          PR_CLUSTER: "online-boutique-prs"
-          ZONE: "us-central1-c"
+          PR_CLUSTER: "prs-gke-cluster"
+          REGION: "us-central1"
           PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
### Background
* Currently, the `deployment-tests` GitHub Action is broken — for other pull-requests (see [example error logs](https://github.com/GoogleCloudPlatform/microservices-demo/actions/runs/8254896693/job/22580132965?pr=2406)).
* Specifically, deployment of the `adservice` (Java microservice) is failing:
* The error we're seeing in the GKE cluster:
```
pod/adservice-746b58f97b-gsxzr: container server terminated with exit code 139 ...
A fatal error has been detected by the Java Runtime Environment: ...
Problematic frame:
      > [adservice-746b58f97b-gsxzr server] # C  [profiler_java_agent.so+0x897522]  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::assign(char const*)+0xc ...
Can not save log file, dump to screen...
VM state: not at safepoint (not fully initialized) ...
VM Mutex/Monitor currently owned by a thread: None ...
```
* Based on our investigation, this seems like an issue with the Nodes currently used by the "online-boutique-prs" GKE cluster. Reason for conclusion: the images deploy fine in other clusters.

### Changes from this PR
* In this PR, we:
   * Add Terraform for a new autopilot GKE cluster ("prs-gke-cluster"). I have `terraform apply`-ed.
   * Update GitHub Actions to use the new GKE cluster instead of the existing "online-boutique-prs" cluster.
   * Add a README.md about using the Terraform.

### How to test
* We have to make sure the GitHub checks work (in this pull-request). Passed. ✅ 
* We should also check the staging URL. Works. ✅ 
* After merging, we should check that:
    * `cleanup.yaml` successfully cleans up the staging deployment created by _this_ pull-request.
    * `ci-main.yaml` successfully deploys the HEAD commit in `main` to the new cluster (prs-gke-cluster).

### Additional info
* Just so we can track the gains from switching to autopilot, I've created a billing report (Jan 1, 2023 to Mar 14, 2024). See [Google-internal report at go/online-boutique-ci-billing-report-2023](http://go/online-boutique-ci-billing-report-2023).
* I have updated [go/sample-app-ci](http://go/sample-app-ci) (Google-internal doc).