### PR TITLE
Only run PR CI on most recent commit

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -59,6 +59,7 @@ jobs:
       timeout-minutes: 10
       run: |
         dotnet test src/cartservice/
+
   deployment-tests:
     runs-on: [self-hosted, is-enabled]
     needs: code-tests

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -26,6 +26,11 @@ on:
       - 'helm-chart/**'
       - '.github/workflows/helm-chart-ci.yaml'
 
+# Ensure this workflow only runs for the most recent commit of a pull-request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   code-tests:
     runs-on: [self-hosted, is-enabled]


### PR DESCRIPTION
### Background 
* Today, the `code-tests` and `deployment-test` GitHub Actions jobs get queued up for _all_ commits of a pull-request.
* But we only care about running these jobs for the most recent commit of a pull-request.

### Change Summary
* In this pull-request, I'm making `.github/workflows/ci-pr.yaml` cancel a queued-up workflows if it's not the workflow isn't running on the most recent commit.
* See [this StackOverflow answer for an explanation](https://stackoverflow.com/a/72408109).

### Testing Procedure
* You'll see that it worked for the commits in this pull-request:

![image](https://github.com/GoogleCloudPlatform/microservices-demo/assets/10292865/24d6469b-bf15-45d3-847b-53c631a97953)
