### PR TITLE
Fix credit card validation error

### DIFF
--- a/src/frontend/templates/cart.html
+++ b/src/frontend/templates/cart.html
@@ -164,9 +164,9 @@
                                 <label for="credit_card_number">Credit Card Number</label>
                                 <input type="text" id="credit_card_number"
                                     name="credit_card_number"
-                                    placeholder="0000-0000-0000-0000"
-                                    value="4432-8015-6152-0454"
-                                    required pattern="\d{4}-\d{4}-\d{4}-\d{4}">
+                                    placeholder="0000000000000000"
+                                    value="4432801561520454"
+                                    required pattern="\d{16}">
                             </div>
                         </div>
 


### PR DESCRIPTION
### Background 
* Current, checking out produces the following error:
<img width="753" alt="Screenshot 2024-04-08 at 2 04 03 PM" src="https://github.com/GoogleCloudPlatform/microservices-demo/assets/10292865/0ed85312-8310-4127-bef5-627fe3e18bd4">

### Change Summary
* Remove dashes ("-"s) in credit card during submission.

### Testing Procedure
* We just need to test that checking out (via the staging URL) works.
