### PR TITLE
Bump shoppingassistant deps

### DIFF
--- a/src/shoppingassistantservice/requirements.in
+++ b/src/shoppingassistantservice/requirements.in
@@ -1,6 +1,6 @@
 flask==3.0.3
-langchain-google-genai==0.0.11
-langchain==0.1.14
+langchain-google-genai==1.0.2
+langchain==0.1.16
 pillow==10.3.0
 langchain-google-alloydb-pg==0.2.0
 google-cloud-secret-manager==2.19.0

--- a/src/shoppingassistantservice/requirements.txt
+++ b/src/shoppingassistantservice/requirements.txt
@@ -43,24 +43,32 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-google-ai-generativelanguage==0.4.0
+google-ai-generativelanguage==0.6.2
     # via google-generativeai
 google-api-core[grpc]==2.18.0
     # via
     #   google-ai-generativelanguage
+    #   google-api-python-client
     #   google-cloud-secret-manager
     #   google-generativeai
+google-api-python-client==2.126.0
+    # via google-generativeai
 google-auth==2.29.0
     # via
+    #   google-ai-generativelanguage
     #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
     #   google-cloud-alloydb-connector
     #   google-cloud-secret-manager
     #   google-generativeai
+google-auth-httplib2==0.2.0
+    # via google-api-python-client
 google-cloud-alloydb-connector[asyncpg]==1.0.0
     # via langchain-google-alloydb-pg
 google-cloud-secret-manager==2.19.0
     # via -r requirements.in
-google-generativeai==0.4.1
+google-generativeai==0.5.1
     # via langchain-google-genai
 googleapis-common-protos[grpc]==1.63.0
     # via
@@ -79,11 +87,15 @@ grpcio==1.62.1
     #   grpcio-status
 grpcio-status==1.62.1
     # via google-api-core
+httplib2==0.22.0
+    # via
+    #   google-api-python-client
+    #   google-auth-httplib2
 idna==3.7
     # via
     #   requests
     #   yarl
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via flask
 jinja2==3.1.3
     # via flask
@@ -93,7 +105,7 @@ jsonpatch==1.33
     #   langchain-core
 jsonpointer==2.4
     # via jsonpatch
-langchain==0.1.14
+langchain==0.1.16
     # via -r requirements.in
 langchain-community==0.0.33
     # via
@@ -108,7 +120,7 @@ langchain-core==0.1.43
     #   langchain-text-splitters
 langchain-google-alloydb-pg==0.2.0
     # via -r requirements.in
-langchain-google-genai==0.0.11
+langchain-google-genai==1.0.2
     # via -r requirements.in
 langchain-text-splitters==0.0.1
     # via langchain
@@ -177,6 +189,8 @@ pydantic==2.7.0
     #   langsmith
 pydantic-core==2.18.1
     # via pydantic
+pyparsing==3.1.2
+    # via httplib2
 pyyaml==6.0.1
     # via
     #   langchain
@@ -212,6 +226,8 @@ typing-extensions==4.11.0
     #   typing-inspect
 typing-inspect==0.9.0
     # via dataclasses-json
+uritemplate==4.1.1
+    # via google-api-python-client
 urllib3==2.2.1
     # via requests
 werkzeug==3.0.2


### PR DESCRIPTION
This PR bumps all deps for the shopping assistant service.

I've testing this by manually deploying this on a cluster and making sure the assistant was returning results as expected.

The reason I wanted to test this manually was because of the bump from a patch (`0.0.11`) to a major (`1.0.2`) on the LangChain GoogleAI dep.