### PR TITLE
Bump Go version in workflows

### DIFF
--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -39,7 +39,7 @@ jobs:
         dotnet-version: '8.0'
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.19'
+        go-version: '1.22'
     - name: Go Unit Tests
       timeout-minutes: 10
       run: |

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -45,7 +45,7 @@ jobs:
         dotnet-version: '8.0'
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.19'
+        go-version: '1.22'
     - name: Go Unit Tests
       timeout-minutes: 10
       run: |


### PR DESCRIPTION
This PR bumps the Go version used in workflows for testing from 19 to 22.