### PR TITLE
Clone latest major tag in Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ Find **Protocol Buffers Descriptions** at the [`./protos` directory](/protos).
    - [Google Cloud project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project).
    - Shell environment with `gcloud`, `git`, and `kubectl`.
 
-2. Clone the repository.
+2. Clone the latest major version.
 
    ```sh
-   git clone https://github.com/GoogleCloudPlatform/microservices-demo
+   git clone --depth 1 --branch v0 https://github.com/GoogleCloudPlatform/microservices-demo.git
    cd microservices-demo/
    ```
+
+   The `--depth 1` argument skips downloading git history.
 
 3. Set the Google Cloud project and region and ensure the Google Kubernetes Engine API is enabled.
 


### PR DESCRIPTION
### Background 
* See step in [/docs/releasing about updating the "major" git tag during the release process](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/docs/releasing).

### Change Summary
* Use the latest major version in the root `/README.md` quickstart.

### Additional Notes
* More info about this `git clone --depth 1 --branch ...` command is in [this StackOverflow answer](https://stackoverflow.com/a/21699307).

### Testing Procedure
* I have tested this command manually:
```
git clone --depth 1 --branch v0 https://github.com/GoogleCloudPlatform/microservices-demo.git
```
