### PR TITLE
Comment out profiler in adservice

### DIFF
--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -29,11 +29,12 @@ FROM eclipse-temurin:21.0.3_9-jre-alpine@sha256:23467b3e42617ca197f43f58bc5fb03c
 
 RUN apk add --no-cache ca-certificates
 
+# @TODO: https://github.com/GoogleCloudPlatform/microservices-demo/issues/2517
 # Download Stackdriver Profiler Java agent
-RUN mkdir -p /opt/cprof && \
-    wget -q -O- https://storage.googleapis.com/cloud-profiler/java/latest/profiler_java_agent_alpine.tar.gz \
-    | tar xzv -C /opt/cprof && \
-    rm -rf profiler_java_agent.tar.gz
+# RUN mkdir -p /opt/cprof && \
+#     wget -q -O- https://storage.googleapis.com/cloud-profiler/java/latest/profiler_java_agent_alpine.tar.gz \
+#     | tar xzv -C /opt/cprof && \
+#     rm -rf profiler_java_agent.tar.gz
 
 WORKDIR /app
 COPY --from=builder /app .

--- a/src/adservice/build.gradle
+++ b/src/adservice/build.gradle
@@ -97,8 +97,9 @@ task adService(type: CreateStartScripts) {
     applicationName = 'AdService'
     outputDir = new File(project.buildDir, 'tmp')
     classpath = startScripts.classpath
-    defaultJvmOpts =
-             ["-agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=adservice,-cprof_service_version=1.0.0"]
+    // @TODO: https://github.com/GoogleCloudPlatform/microservices-demo/issues/2517
+    // defaultJvmOpts =
+    //          ["-agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=adservice,-cprof_service_version=1.0.0"]
 }
 
 task adServiceClient(type: CreateStartScripts) {
@@ -106,8 +107,9 @@ task adServiceClient(type: CreateStartScripts) {
     applicationName = 'AdServiceClient'
     outputDir = new File(project.buildDir, 'tmp')
     classpath = startScripts.classpath
-    defaultJvmOpts =
-             ["-agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=adserviceclient,-cprof_service_version=1.0.0"]
+    // @TODO: https://github.com/GoogleCloudPlatform/microservices-demo/issues/2517
+    // defaultJvmOpts =
+    //          ["-agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=adserviceclient,-cprof_service_version=1.0.0"]
 }
 
 applicationDistribution.into('bin') {


### PR DESCRIPTION
The profiler in the adservice is causing seg faults in some distributions of Kubernetes. It currently blocks deployments of v0.10.0. I've decided to comment it out, and will silently backport this fix into the `release/v0.10.0` branch (since that release is currently broken).

Created https://github.com/GoogleCloudPlatform/microservices-demo/issues/2517 to look into this further.

Fixes #2511

### ToDo
- [x] Rebuild the adservice image and push it to GCR
- [x] Update the release image manifests for the adservice
- [x] Deploy on the release cluster
- [x] Merge this PR
- [ ] Cherry-pick into the `release/v0.10.0` branch
- [ ] Update the `v0.10.0` tag to that commit
- [ ] Update the `v0` tag to that commit