### PR TITLE
Base resource requests on actual usage

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -51,8 +51,8 @@ spec:
           value: "9555"
         resources:
           requests:
-            cpu: 200m
-            memory: 180Mi
+            cpu: 60m
+            memory: 80Mi
           limits:
             cpu: 300m
             memory: 300Mi

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -134,8 +134,8 @@ spec:
             memory: 256Mi
             cpu: 125m
           requests:
-            cpu: 70m
-            memory: 200Mi
+            cpu: 20m
+            memory: 70Mi
       volumes:
       - name: redis-data
         emptyDir: {}

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -68,8 +68,8 @@ spec:
             value: "cartservice:7070"
           resources:
             requests:
-              cpu: 100m
-              memory: 64Mi
+              cpu: 10m
+              memory: 20Mi
             limits:
               cpu: 200m
               memory: 128Mi

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -60,8 +60,8 @@ spec:
             port: 7000
         resources:
           requests:
-            cpu: 100m
-            memory: 64Mi
+            cpu: 20m
+            memory: 40Mi
           limits:
             cpu: 200m
             memory: 128Mi

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -61,8 +61,8 @@ spec:
             port: 8080
         resources:
           requests:
-            cpu: 100m
-            memory: 64Mi
+            cpu: 10m
+            memory: 50Mi
           limits:
             cpu: 200m
             memory: 128Mi

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -99,8 +99,8 @@ spec:
           #   value: "" # This value would look like "http://123.123.123"
           resources:
             requests:
-              cpu: 100m
-              memory: 64Mi
+              cpu: 20m
+              memory: 20Mi
             limits:
               cpu: 200m
               memory: 128Mi

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -85,8 +85,8 @@ spec:
           value: "10"
         resources:
           requests:
-            cpu: 300m
-            memory: 256Mi
+            cpu: 10m
+            memory: 200Mi
           limits:
             cpu: 500m
             memory: 512Mi

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -59,8 +59,8 @@ spec:
             port: 50051
         resources:
           requests:
-            cpu: 100m
-            memory: 64Mi
+            cpu: 10m
+            memory: 30Mi
           limits:
             cpu: 200m
             memory: 128Mi

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -59,8 +59,8 @@ spec:
             port: 3550
         resources:
           requests:
-            cpu: 100m
-            memory: 64Mi
+            cpu: 10m
+            memory: 20Mi
           limits:
             cpu: 200m
             memory: 128Mi

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -63,8 +63,8 @@ spec:
           value: "1"
         resources:
           requests:
-            cpu: 100m
-            memory: 220Mi
+            cpu: 10m
+            memory: 10Mi
           limits:
             cpu: 200m
             memory: 450Mi

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -59,8 +59,8 @@ spec:
             port: 50051
         resources:
           requests:
-            cpu: 100m
-            memory: 64Mi
+            cpu: 10m
+            memory: 10Mi
           limits:
             cpu: 200m
             memory: 128Mi


### PR DESCRIPTION
### Background 
* This fixes https://github.com/GoogleCloudPlatform/microservices-demo/issues/591.
* I looked at a deployment of Online Boutique from 4 days ago — looks at the max (actually used) vCPU and memory values of each microservice. The deployment included the loadgenerator.
* I rounded up to the next `10m` (for CPU) and the next `10MiB` for memory — to add a buffer.

### Change Summary
* I've updates the `resource.requests.cpu` and `resource.requests.memory` values of each default microservices's Deployment.

### Testing Procedure
* We just have to make sure the staging URL works fine. :)
