### PR TITLE
`cartservice`: `alpine` --> `noble-chiseled`

### DIFF
--- a/src/cartservice/src/Dockerfile
+++ b/src/cartservice/src/Dockerfile
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 # https://mcr.microsoft.com/product/dotnet/sdk
-FROM mcr.microsoft.com/dotnet/sdk:8.0.300@sha256:935902ef9eee58a9226b906e3d6ff1b2abaca240c9d5b4ac8dca9943b26c8f33 as builder
+FROM mcr.microsoft.com/dotnet/sdk:8.0.301-noble@sha256:e6982f8da3f29407d73d737af120bff652658c6c985ccf63e62f12ce49127cc7 as builder
 WORKDIR /app
 COPY cartservice.csproj .
 RUN dotnet restore cartservice.csproj \
-    -r linux-musl-x64
+    -r linux-x64
 COPY . .
 RUN dotnet publish cartservice.csproj \
     -p:PublishSingleFile=true \
-    -r linux-musl-x64 \
+    -r linux-x64 \
     --self-contained true \
     -p:PublishTrimmed=True \
     -p:TrimMode=Full \
@@ -30,7 +30,7 @@ RUN dotnet publish cartservice.csproj \
     --no-restore
 
 # https://mcr.microsoft.com/product/dotnet/runtime-deps
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.5-alpine3.18-amd64@sha256:70fe5d6b27bc6a722d24a38865c6763b5bf6a368a8c320114ac4924b8d442378
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.6-noble-chiseled@8.0.6-noble-chiseled
 
 WORKDIR /app
 COPY --from=builder /cartservice .

--- a/src/cartservice/src/Dockerfile
+++ b/src/cartservice/src/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet publish cartservice.csproj \
     --no-restore
 
 # https://mcr.microsoft.com/product/dotnet/runtime-deps
-FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.6-noble-chiseled@8.0.6-noble-chiseled
+FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.6-noble-chiseled@sha256:1745aa8e322b6965ea3ec8524b9f9eb128f146c804e32b1fc2272ed07ada4c8e
 
 WORKDIR /app
 COPY --from=builder /cartservice .


### PR DESCRIPTION
For `cartservice`, moving from `alpine` to `chiseled` (i.e. `distroless`).

Resources:
- https://devblogs.microsoft.com/dotnet/whats-new-for-dotnet-in-ubuntu-2404/
- https://github.com/dotnet/dotnet-docker/blob/main/samples/aspnetapp/Dockerfile.chiseled
- https://build.microsoft.com/en-US/sessions/fe58e8ce-6a0d-42d9-911f-9ebfe44d6dad
- https://github.com/mathieu-benoit/sail-sharp/pull/130 (Note: Aot is not implemented here, but same approach)

## Size (+4 MB)

- Before: `110 MB`
- After: `114 MB` --> +4 MB, that's nothing for all the benefits!

## Packages (-10 packages)

_Note: [`syft`](https://github.com/anchore/syft) was used._

Before:
```
✔ Packages                               [17 packages]
   ├── ✔ File digests                    [81 files]
   ├── ✔ File metadata                   [81 locations]
   └── ✔ Executables                     [20 executables]
NAME                    VERSION                 TYPE
alpine-baselayout       3.4.3-r1                apk
alpine-baselayout-data  3.4.3-r1                apk
alpine-keys             2.4-r1                  apk
apk-tools               2.14.0-r2               apk
busybox                 1.36.1-r5               apk
busybox-binsh           1.36.1-r5               apk
ca-certificates-bundle  20240226-r0             apk
libc-utils              0.7.2-r5                apk
libcrypto3              3.1.4-r5                apk
libgcc                  12.2.1_git20220924-r10  apk
libssl3                 3.1.4-r5                apk
libstdc++               12.2.1_git20220924-r10  apk
musl                    1.2.4-r2                apk
musl-utils              1.2.4-r2                apk
scanelf                 1.3.7-r1                apk
ssl_client              1.36.1-r5               apk
zlib                    1.2.13-r1               apk
```

After:
```
✔ Packages                               [7 packages]
   └── ✔ Executables                     [30 executables]
NAME             VERSION                TYPE
base-files       13ubuntu10             deb
ca-certificates  20240203               deb
libc6            2.39-0ubuntu8.1        deb
libgcc-s1        14-20240412-0ubuntu1   deb
libssl3t64       3.0.13-0ubuntu3.1      deb
libstdc++6       14-20240412-0ubuntu1   deb
zlib1g           1:1.3.dfsg-3.1ubuntu2  deb
```

## CVEs (+2 `LOW` and -5 `MEDIUM`)

_Note: [`trivy`](https://aquasecurity.github.io/trivy) was used._

Before:
```
gcr.io/google-samples/microservices-demo/cartservice:v0.10.0 (alpine 3.18.6)

Total: 7 (UNKNOWN: 0, LOW: 2, MEDIUM: 5, HIGH: 0, CRITICAL: 0)

┌───────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│    Library    │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├───────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ busybox       │ CVE-2023-42366 │ MEDIUM   │ fixed  │ 1.36.1-r5         │ 1.36.1-r6     │ busybox: A heap-buffer-overflow                           │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                │
├───────────────┤                │          │        │                   │               │                                                           │
│ busybox-binsh │                │          │        │                   │               │                                                           │
│               │                │          │        │                   │               │                                                           │
├───────────────┼────────────────┤          │        ├───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ libcrypto3    │ CVE-2024-4603  │          │        │ 3.1.4-r5          │ 3.1.5-r0      │ openssl: Excessive time spent checking DSA keys and       │
│               │                │          │        │                   │               │ parameters                                                │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4603                 │
│               ├────────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2024-2511  │ LOW      │        │                   │ 3.1.4-r6      │ openssl: Unbounded memory growth with session handling in │
│               │                │          │        │                   │               │ TLSv1.3                                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-2511                 │
├───────────────┼────────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│ libssl3       │ CVE-2024-4603  │ MEDIUM   │        │                   │ 3.1.5-r0      │ openssl: Excessive time spent checking DSA keys and       │
│               │                │          │        │                   │               │ parameters                                                │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4603                 │
│               ├────────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2024-2511  │ LOW      │        │                   │ 3.1.4-r6      │ openssl: Unbounded memory growth with session handling in │
│               │                │          │        │                   │               │ TLSv1.3                                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-2511                 │
├───────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ ssl_client    │ CVE-2023-42366 │ MEDIUM   │        │ 1.36.1-r5         │ 1.36.1-r6     │ busybox: A heap-buffer-overflow                           │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                │
└───────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘
```

After:
```
gcr.io/online-boutique-ci/refs/pull/2568/cartservice:2568 (ubuntu 24.04)

Total: 4 (UNKNOWN: 0, LOW: 4, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌────────────┬────────────────┬──────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │  Status  │ Installed Version │ Fixed Version │                           Title                            │
├────────────┼────────────────┼──────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ libc6      │ CVE-2016-20013 │ LOW      │ affected │ 2.39-0ubuntu8.1   │               │ sha256crypt and sha512crypt through 0.6 allow attackers to │
│            │                │          │          │                   │               │ cause a denial of...                                       │
│            │                │          │          │                   │               │ https://avd.aquasec.com/nvd/cve-2016-20013                 │
├────────────┼────────────────┤          │          ├───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ libssl3t64 │ CVE-2024-2511  │          │          │ 3.0.13-0ubuntu3.1 │               │ openssl: Unbounded memory growth with session handling in  │
│            │                │          │          │                   │               │ TLSv1.3                                                    │
│            │                │          │          │                   │               │ https://avd.aquasec.com/nvd/cve-2024-2511                  │
│            ├────────────────┤          │          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2024-4603  │          │          │                   │               │ openssl: Excessive time spent checking DSA keys and        │
│            │                │          │          │                   │               │ parameters                                                 │
│            │                │          │          │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4603                  │
│            ├────────────────┤          │          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2024-4741  │          │          │                   │               │ openssl: Use After Free with SSL_free_buffers              │
│            │                │          │          │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4741                  │
└────────────┴────────────────┴──────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘
```