### PR TITLE
Manually set PROJECT_ID in push-deploy.yaml

### DIFF
--- a/.github/workflows/push-deploy.yaml
+++ b/.github/workflows/push-deploy.yaml
@@ -31,4 +31,4 @@ jobs:
         skaffold build --default-repo=gcr.io/$PROJECT_ID \
                        --tag=$GITHUB_SHA
       env:
-        PROJECT_ID: ${{ secrets.PROJECT_ID }}
+        PROJECT_ID: "online-boutique-ci"


### PR DESCRIPTION
* See Google-internal bug: [b/347294641](http://b/347294641)
* We've removed the GitHub Actions `PROJECT_ID` secret.