### PR TITLE
`adservice` - `ca-certificates` is already in the final base image

### DIFF
--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -27,8 +27,6 @@ RUN ./gradlew installDist
 
 FROM eclipse-temurin:21.0.3_9-jre-alpine@sha256:23467b3e42617ca197f43f58bc5fb03ca4cb059d68acd49c67128bfded132d67
 
-RUN apk add --no-cache ca-certificates
-
 # @TODO: https://github.com/GoogleCloudPlatform/microservices-demo/issues/2517
 # Download Stackdriver Profiler Java agent
 # RUN mkdir -p /opt/cprof && \


### PR DESCRIPTION
No need to add `ca-certificates` nor adding a container layer for this `RUN` statement since this package is already in the base container image (`eclipse-temurin:jre-alpine`).

Some space on disk is also saved, from `258 MB` to `230 MB` (-`28 MB`).