### PR TITLE
`cartservice` - restore packages in `publish` + `full` `TrimMode`

### DIFF
--- a/src/cartservice/src/Dockerfile
+++ b/src/cartservice/src/Dockerfile
@@ -23,8 +23,8 @@ RUN dotnet publish cartservice.csproj \
     -p:PublishSingleFile=true \
     -r linux-x64 \
     --self-contained true \
-    -p:PublishTrimmed=True \
-    -p:TrimMode=Full \
+    -p:PublishTrimmed=true \
+    -p:TrimMode=full \
     -c release \
     -o /cartservice \
     --no-restore

--- a/src/cartservice/src/Dockerfile
+++ b/src/cartservice/src/Dockerfile
@@ -26,8 +26,7 @@ RUN dotnet publish cartservice.csproj \
     -p:PublishTrimmed=true \
     -p:TrimMode=full \
     -c release \
-    -o /cartservice \
-    --no-restore
+    -o /cartservice
 
 # https://mcr.microsoft.com/product/dotnet/runtime-deps
 FROM mcr.microsoft.com/dotnet/runtime-deps:8.0.6-noble-chiseled@sha256:1745aa8e322b6965ea3ec8524b9f9eb128f146c804e32b1fc2272ed07ada4c8e


### PR DESCRIPTION
`cartservice` - restore packages in `publish` + `full` `TrimMode`.

Size on disk saved: `-68.5 MB`:
```
REPOSITORY                                            TAG         IMAGE ID      CREATED        SIZE
gcr.io/online-boutique-ci/refs/pull/2599/cartservice  2599        240b1238d287  6 minutes ago  41.5 MB
gcr.io/google-samples/microservices-demo/cartservice  v0.10.0     e5e7c41475d3  8 weeks ago    110 MB
```

Application tested on the instance deployed by the CI associated to this PR: http://34.31.61.228.