### PR TITLE
Remove explicit checkout ref

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -36,8 +36,6 @@ jobs:
     runs-on: [self-hosted, is-enabled]
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{github.event.pull_request.head.sha}}
     - uses: actions/setup-dotnet@v4
       env:
         DOTNET_INSTALL_DIR: "./.dotnet"


### PR DESCRIPTION
By default, the PR will be checked-out, so there is no need to explicitly specify the ref.