### PR TITLE
Remove gcr.io references in docs and releasing

### DIFF
--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -70,7 +70,7 @@ jobs:
         echo "::set-env name=NAMESPACE::$NAMESPACE"
         echo "::set-env name=PR_NUMBER::$PR_NUMBER"
 
-        gcloud auth configure-docker us-central1-docker.pkg.dev
+        yes | gcloud auth configure-docker us-central1-docker.pkg.dev
         gcloud container clusters get-credentials $PR_CLUSTER --region $REGION --project $PROJECT_ID
         cat <<EOF | kubectl apply -f -
         apiVersion: v1

--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -70,6 +70,7 @@ jobs:
         echo "::set-env name=NAMESPACE::$NAMESPACE"
         echo "::set-env name=PR_NUMBER::$PR_NUMBER"
 
+        gcloud auth configure-docker us-central1-docker.pkg.dev
         gcloud container clusters get-credentials $PR_CLUSTER --region $REGION --project $PROJECT_ID
         cat <<EOF | kubectl apply -f -
         apiVersion: v1

--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -79,7 +79,7 @@ jobs:
         EOF
         echo Deploying application
         skaffold config set --global local-cluster false
-        skaffold run --default-repo=gcr.io/$PROJECT_ID/$GITHUB_REF --tag=$GITHUB_SHA --namespace=$NAMESPACE -p network-policies
+        skaffold run --default-repo=us-central1-docker.pkg.dev/$PROJECT_ID/$GITHUB_REF --tag=$GITHUB_SHA --namespace=$NAMESPACE -p network-policies
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PROJECT_ID: "online-boutique-ci"

--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -70,7 +70,7 @@ jobs:
         echo "::set-env name=NAMESPACE::$NAMESPACE"
         echo "::set-env name=PR_NUMBER::$PR_NUMBER"
 
-        yes | gcloud auth configure-docker us-central1-docker.pkg.dev
+        yes | gcloud auth configure-docker us-docker.pkg.dev
         gcloud container clusters get-credentials $PR_CLUSTER --region $REGION --project $PROJECT_ID
         cat <<EOF | kubectl apply -f -
         apiVersion: v1
@@ -80,7 +80,7 @@ jobs:
         EOF
         echo Deploying application
         skaffold config set --global local-cluster false
-        skaffold run --default-repo=us-central1-docker.pkg.dev/$PROJECT_ID/$GITHUB_REF --tag=$GITHUB_SHA --namespace=$NAMESPACE -p network-policies
+        skaffold run --default-repo=us-docker.pkg.dev/$PROJECT_ID/$GITHUB_REF --tag=$GITHUB_SHA --namespace=$NAMESPACE -p network-policies
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PROJECT_ID: "online-boutique-ci"

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -75,6 +75,7 @@ jobs:
         NAMESPACE="pr${PR_NUMBER}"
         echo "::set-env name=NAMESPACE::$NAMESPACE"
 
+        gcloud auth configure-docker us-central1-docker.pkg.dev
         gcloud container clusters get-credentials $PR_CLUSTER --region $REGION --project $PROJECT_ID
         cat <<EOF | kubectl apply -f -
         apiVersion: v1

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -84,7 +84,7 @@ jobs:
         EOF
         echo Deploying application
         skaffold config set --global local-cluster false
-        skaffold run --default-repo=gcr.io/$PROJECT_ID/refs/pull/$PR_NUMBER --tag=$PR_NUMBER --namespace=$NAMESPACE -p network-policies
+        skaffold run --default-repo=us-central1-docker.pkg.dev/$PROJECT_ID/refs/pull/$PR_NUMBER --tag=$PR_NUMBER --namespace=$NAMESPACE -p network-policies
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -75,7 +75,7 @@ jobs:
         NAMESPACE="pr${PR_NUMBER}"
         echo "::set-env name=NAMESPACE::$NAMESPACE"
 
-        yes | gcloud auth configure-docker us-central1-docker.pkg.dev
+        yes | gcloud auth configure-docker us-docker.pkg.dev
         gcloud container clusters get-credentials $PR_CLUSTER --region $REGION --project $PROJECT_ID
         cat <<EOF | kubectl apply -f -
         apiVersion: v1
@@ -85,7 +85,7 @@ jobs:
         EOF
         echo Deploying application
         skaffold config set --global local-cluster false
-        skaffold run --default-repo=us-central1-docker.pkg.dev/$PROJECT_ID/refs/pull/$PR_NUMBER --tag=$PR_NUMBER --namespace=$NAMESPACE -p network-policies
+        skaffold run --default-repo=us-docker.pkg.dev/$PROJECT_ID/refs/pull/$PR_NUMBER --tag=$PR_NUMBER --namespace=$NAMESPACE -p network-policies
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -75,7 +75,7 @@ jobs:
         NAMESPACE="pr${PR_NUMBER}"
         echo "::set-env name=NAMESPACE::$NAMESPACE"
 
-        gcloud auth configure-docker us-central1-docker.pkg.dev
+        yes | gcloud auth configure-docker us-central1-docker.pkg.dev
         gcloud container clusters get-credentials $PR_CLUSTER --region $REGION --project $PROJECT_ID
         cat <<EOF | kubectl apply -f -
         apiVersion: v1

--- a/.github/workflows/push-deploy.yaml
+++ b/.github/workflows/push-deploy.yaml
@@ -27,9 +27,9 @@ jobs:
       timeout-minutes: 20
       run: |
         skaffold config set --global local-cluster false
-        yes | gcloud auth configure-docker us-central1-docker.pkg.dev
+        yes | gcloud auth configure-docker us-docker.pkg.dev
         # tag with git hash
-        skaffold build --default-repo=us-central1-docker.pkg.dev/$PROJECT_ID \
+        skaffold build --default-repo=us-docker.pkg.dev/$PROJECT_ID \
                        --tag=$GITHUB_SHA
       env:
         PROJECT_ID: "online-boutique-ci"

--- a/.github/workflows/push-deploy.yaml
+++ b/.github/workflows/push-deploy.yaml
@@ -27,7 +27,7 @@ jobs:
       timeout-minutes: 20
       run: |
         skaffold config set --global local-cluster false
-        gcloud auth configure-docker us-central1-docker.pkg.dev
+        yes | gcloud auth configure-docker us-central1-docker.pkg.dev
         # tag with git hash
         skaffold build --default-repo=us-central1-docker.pkg.dev/$PROJECT_ID \
                        --tag=$GITHUB_SHA

--- a/.github/workflows/push-deploy.yaml
+++ b/.github/workflows/push-deploy.yaml
@@ -27,6 +27,7 @@ jobs:
       timeout-minutes: 20
       run: |
         skaffold config set --global local-cluster false
+        gcloud auth configure-docker us-central1-docker.pkg.dev
         # tag with git hash
         skaffold build --default-repo=us-central1-docker.pkg.dev/$PROJECT_ID \
                        --tag=$GITHUB_SHA

--- a/.github/workflows/push-deploy.yaml
+++ b/.github/workflows/push-deploy.yaml
@@ -28,7 +28,7 @@ jobs:
       run: |
         skaffold config set --global local-cluster false
         # tag with git hash
-        skaffold build --default-repo=gcr.io/$PROJECT_ID \
+        skaffold build --default-repo=us-central1-docker.pkg.dev/$PROJECT_ID \
                        --tag=$GITHUB_SHA
       env:
         PROJECT_ID: "online-boutique-ci"

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -49,7 +49,7 @@ This doc explains how to build and run the Online Boutique source code locally u
     gcloud auth configure-docker -q
     ```
 
-3.  In the root of this repository, run `skaffold run --default-repo=gcr.io/[PROJECT_ID]`,
+3.  In the root of this repository, run `skaffold run --default-repo=us-central1-docker.pkg.dev/[PROJECT_ID]`,
     where [PROJECT_ID] is your GCP project ID.
 
     This command:
@@ -63,7 +63,7 @@ This doc explains how to build and run the Online Boutique source code locally u
     Cloud Shell, you can build the images on Google Cloud Build: [Enable the
     Cloud Build
     API](https://console.cloud.google.com/flows/enableapi?apiid=cloudbuild.googleapis.com),
-    then run `skaffold run -p gcb --default-repo=gcr.io/[PROJECT_ID]` instead.
+    then run `skaffold run -p gcb --default-repo=us-central1-docker.pkg.dev/[PROJECT_ID]` instead.
 
 4.  Find the IP address of your application, then visit the application on your
     browser to confirm installation.

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -30,32 +30,37 @@ This doc explains how to build and run the Online Boutique source code locally u
     ```
 
     ```sh
-    gcloud container clusters create demo --enable-autoupgrade \
-        --enable-autoscaling --min-nodes=3 --max-nodes=10 --num-nodes=5 --zone=us-central1-a
+    gcloud container clusters create-auto demo --region=us-central1
     ```
 
     ```
     kubectl get nodes
     ```
 
-2.  Enable Google Container Registry (GCR) on your GCP project and configure the
-    `docker` CLI to authenticate to GCR:
+2.  Enable Artifact Registry (AR) on your GCP project and configure the
+    `docker` CLI to authenticate to AR:
 
     ```sh
-    gcloud services enable containerregistry.googleapis.com
+    gcloud services enable artifactregistry.googleapis.com
     ```
 
     ```sh
-    gcloud auth configure-docker -q
+    gcloud artifacts repositories create microservices-demo \
+      --repository-format=docker \
+      --location=us \
     ```
 
-3.  In the root of this repository, run `skaffold run --default-repo=us-central1-docker.pkg.dev/[PROJECT_ID]`,
+    ```sh
+    gcloud auth configure-docker -q 
+    ```
+
+3.  In the root of this repository, run `skaffold run --default-repo=us-docker.pkg.dev/[PROJECT_ID]/microservices-demo`,
     where [PROJECT_ID] is your GCP project ID.
 
     This command:
 
     - builds the container images
-    - pushes them to GCR
+    - pushes them to AR
     - applies the `./kubernetes-manifests` deploying the application to
       Kubernetes.
 
@@ -63,7 +68,7 @@ This doc explains how to build and run the Online Boutique source code locally u
     Cloud Shell, you can build the images on Google Cloud Build: [Enable the
     Cloud Build
     API](https://console.cloud.google.com/flows/enableapi?apiid=cloudbuild.googleapis.com),
-    then run `skaffold run -p gcb --default-repo=us-central1-docker.pkg.dev/[PROJECT_ID]` instead.
+    then run `skaffold run -p gcb --default-repo=us-docker.pkg.dev/[PROJECT_ID]/microservices-demo` instead.
 
 4.  Find the IP address of your application, then visit the application on your
     browser to confirm installation.

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -27,7 +27,7 @@ Run the `make-release.sh` script found inside the `docs/releasing/` directory:
 ```sh
 # assuming you are inside the root path of the bank-of-anthos repository
 export TAG=vX.Y.Z # This is the new version (e.g. `v0.3.5`)
-export REPO_PREFIX=gcr.io/google-samples/microservices-demo # This is the Docker repository for tagged images
+export REPO_PREFIX=us-central1-docker.pkg.dev/google-samples/microservices-demo # This is the Docker repository for tagged images
 export PROJECT_ID=google-samples # This is the Google Cloud project for the release CI
 ./docs/releasing/make-release.sh
 ```

--- a/docs/releasing/make-release-artifacts.sh
+++ b/docs/releasing/make-release-artifacts.sh
@@ -107,7 +107,7 @@ mk_kustomize_base() {
     image="$REPO_PREFIX/$service_name:$TAG"
 
     # Inside redis.yaml, we use the official `redis:alpine` Docker image.
-    # We don't use an image from `gcr.io/google-samples/microservices-demo`.
+    # We don't use an image from `us-central1-docker.pkg.dev/google-samples/microservices-demo`.
     if [[ $service_name == "redis" ]]; then
       continue
     fi

--- a/docs/releasing/make-release.sh
+++ b/docs/releasing/make-release.sh
@@ -29,7 +29,7 @@ log() { echo "$1" >&2; }
 fail() { log "$1"; exit 1; }
 
 TAG="${TAG:?TAG env variable must be specified}"
-REPO_PREFIX="${REPO_PREFIX:?REPO_PREFIX env variable must be specified e.g. gcr.io\/google-samples\/microservices-demo}"
+REPO_PREFIX="${REPO_PREFIX:?REPO_PREFIX env variable must be specified e.g. us-central1-docker.pkg.dev\/google-samples\/microservices-demo}"
 PROJECT_ID="${PROJECT_ID:?PROJECT_ID env variable must be specified e.g. google-samples}"
 
 if [[ "$TAG" != v* ]]; then

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -17,7 +17,7 @@
 # Declare variables to be passed into your templates.
 
 images:
-  repository: gcr.io/google-samples/microservices-demo
+  repository: us-central1-docker.pkg.dev/google-samples/microservices-demo
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 

--- a/kustomize/base/adservice.yaml
+++ b/kustomize/base/adservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/adservice:v0.10.1
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/adservice:v0.10.1
         ports:
         - containerPort: 9555
         env:

--- a/kustomize/base/cartservice.yaml
+++ b/kustomize/base/cartservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.10.1
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/cartservice:v0.10.1
         ports:
         - containerPort: 7070
         env:

--- a/kustomize/base/checkoutservice.yaml
+++ b/kustomize/base/checkoutservice.yaml
@@ -42,7 +42,7 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.10.1
+          image: us-central1-docker.pkg.dev/google-samples/microservices-demo/checkoutservice:v0.10.1
           ports:
           - containerPort: 5050
           readinessProbe:

--- a/kustomize/base/currencyservice.yaml
+++ b/kustomize/base/currencyservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.10.1
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/currencyservice:v0.10.1
         ports:
         - name: grpc
           containerPort: 7000

--- a/kustomize/base/emailservice.yaml
+++ b/kustomize/base/emailservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.10.1
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/emailservice:v0.10.1
         ports:
         - containerPort: 8080
         env:

--- a/kustomize/base/frontend.yaml
+++ b/kustomize/base/frontend.yaml
@@ -44,7 +44,7 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.10.1
+          image: us-central1-docker.pkg.dev/google-samples/microservices-demo/frontend:v0.10.1
           ports:
           - containerPort: 8080
           readinessProbe:

--- a/kustomize/base/loadgenerator.yaml
+++ b/kustomize/base/loadgenerator.yaml
@@ -77,7 +77,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/loadgenerator:v0.10.1
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/loadgenerator:v0.10.1
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/kustomize/base/paymentservice.yaml
+++ b/kustomize/base/paymentservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.10.1
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/paymentservice:v0.10.1
         ports:
         - containerPort: 50051
         env:

--- a/kustomize/base/productcatalogservice.yaml
+++ b/kustomize/base/productcatalogservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.10.1
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/productcatalogservice:v0.10.1
         ports:
         - containerPort: 3550
         env:

--- a/kustomize/base/recommendationservice.yaml
+++ b/kustomize/base/recommendationservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.10.1
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/recommendationservice:v0.10.1
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/kustomize/base/shippingservice.yaml
+++ b/kustomize/base/shippingservice.yaml
@@ -42,7 +42,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.10.1
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/shippingservice:v0.10.1
         ports:
         - containerPort: 50051
         env:

--- a/kustomize/components/container-images-registry/README.md
+++ b/kustomize/components/container-images-registry/README.md
@@ -1,6 +1,6 @@
 # Update the container registry of the Online Boutique apps
 
-By default, Online Boutique's services' container images are pulled from a public container registry (`gcr.io/google-samples/microservices-demo`). One best practice is to have these container images in your own private container registry. The Kustomize variation in this folder can help with using your own private container registry.
+By default, Online Boutique's services' container images are pulled from a public container registry (`us-central1-docker.pkg.dev/google-samples/microservices-demo`). One best practice is to have these container images in your own private container registry. The Kustomize variation in this folder can help with using your own private container registry.
 
 ## Change the default container registry via Kustomize
 
@@ -9,7 +9,7 @@ To automate the deployment of Online Boutique integrated with your own container
 From the `kustomize/` folder at the root level of this repository, execute this command:
 
 ```bash
-REGISTRY=my-registry # Example: gcr.io/my-project/my-directory
+REGISTRY=my-registry # Example: us-central1-docker.pkg.dev/my-project/my-directory
 sed -i "s|CONTAINER_IMAGES_REGISTRY|${REGISTRY}|g" components/container-images-registry/kustomization.yaml
 kustomize edit add component components/container-images-registry
 ```

--- a/kustomize/components/container-images-registry/kustomization.yaml
+++ b/kustomize/components/container-images-registry/kustomization.yaml
@@ -15,27 +15,27 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 images:
-- name: gcr.io/google-samples/microservices-demo/adservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/adservice
   newName: CONTAINER_IMAGES_REGISTRY/adservice
-- name: gcr.io/google-samples/microservices-demo/cartservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/cartservice
   newName: CONTAINER_IMAGES_REGISTRY/cartservice
-- name: gcr.io/google-samples/microservices-demo/checkoutservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/checkoutservice
   newName: CONTAINER_IMAGES_REGISTRY/checkoutservice
-- name: gcr.io/google-samples/microservices-demo/currencyservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/currencyservice
   newName: CONTAINER_IMAGES_REGISTRY/currencyservice
-- name: gcr.io/google-samples/microservices-demo/emailservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/emailservice
   newName: CONTAINER_IMAGES_REGISTRY/emailservice
-- name: gcr.io/google-samples/microservices-demo/frontend
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/frontend
   newName: CONTAINER_IMAGES_REGISTRY/frontend
-- name: gcr.io/google-samples/microservices-demo/loadgenerator
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/loadgenerator
   newName: CONTAINER_IMAGES_REGISTRY/loadgenerator
-- name: gcr.io/google-samples/microservices-demo/paymentservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/paymentservice
   newName: CONTAINER_IMAGES_REGISTRY/paymentservice
-- name: gcr.io/google-samples/microservices-demo/productcatalogservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/productcatalogservice
   newName: CONTAINER_IMAGES_REGISTRY/productcatalogservice
-- name: gcr.io/google-samples/microservices-demo/recommendationservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/recommendationservice
   newName: CONTAINER_IMAGES_REGISTRY/recommendationservice
-- name: gcr.io/google-samples/microservices-demo/shippingservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/shippingservice
   newName: CONTAINER_IMAGES_REGISTRY/shippingservice
 - name: redis
   newName: CONTAINER_IMAGES_REGISTRY/redis

--- a/kustomize/components/container-images-tag-suffix/kustomization.yaml
+++ b/kustomize/components/container-images-tag-suffix/kustomization.yaml
@@ -15,25 +15,25 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 images:
-- name: gcr.io/google-samples/microservices-demo/adservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/adservice
   tagSuffix: CONTAINER_IMAGES_TAG_SUFFIX
-- name: gcr.io/google-samples/microservices-demo/cartservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/cartservice
   tagSuffix: CONTAINER_IMAGES_TAG_SUFFIX
-- name: gcr.io/google-samples/microservices-demo/checkoutservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/checkoutservice
   tagSuffix: CONTAINER_IMAGES_TAG_SUFFIX
-- name: gcr.io/google-samples/microservices-demo/currencyservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/currencyservice
   tagSuffix: CONTAINER_IMAGES_TAG_SUFFIX
-- name: gcr.io/google-samples/microservices-demo/emailservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/emailservice
   tagSuffix: CONTAINER_IMAGES_TAG_SUFFIX
-- name: gcr.io/google-samples/microservices-demo/frontend
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/frontend
   tagSuffix: CONTAINER_IMAGES_TAG_SUFFIX
-- name: gcr.io/google-samples/microservices-demo/loadgenerator
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/loadgenerator
   tagSuffix: CONTAINER_IMAGES_TAG_SUFFIX
-- name: gcr.io/google-samples/microservices-demo/paymentservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/paymentservice
   tagSuffix: CONTAINER_IMAGES_TAG_SUFFIX
-- name: gcr.io/google-samples/microservices-demo/productcatalogservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/productcatalogservice
   tagSuffix: CONTAINER_IMAGES_TAG_SUFFIX
-- name: gcr.io/google-samples/microservices-demo/recommendationservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/recommendationservice
   tagSuffix: CONTAINER_IMAGES_TAG_SUFFIX
-- name: gcr.io/google-samples/microservices-demo/shippingservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/shippingservice
   tagSuffix: CONTAINER_IMAGES_TAG_SUFFIX

--- a/kustomize/components/container-images-tag/kustomization.yaml
+++ b/kustomize/components/container-images-tag/kustomization.yaml
@@ -15,25 +15,25 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 images:
-- name: gcr.io/google-samples/microservices-demo/adservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/adservice
   newTag: CONTAINER_IMAGES_TAG
-- name: gcr.io/google-samples/microservices-demo/cartservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/cartservice
   newTag: CONTAINER_IMAGES_TAG
-- name: gcr.io/google-samples/microservices-demo/checkoutservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/checkoutservice
   newTag: CONTAINER_IMAGES_TAG
-- name: gcr.io/google-samples/microservices-demo/currencyservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/currencyservice
   newTag: CONTAINER_IMAGES_TAG
-- name: gcr.io/google-samples/microservices-demo/emailservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/emailservice
   newTag: CONTAINER_IMAGES_TAG
-- name: gcr.io/google-samples/microservices-demo/frontend
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/frontend
   newTag: CONTAINER_IMAGES_TAG
-- name: gcr.io/google-samples/microservices-demo/loadgenerator
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/loadgenerator
   newTag: CONTAINER_IMAGES_TAG
-- name: gcr.io/google-samples/microservices-demo/paymentservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/paymentservice
   newTag: CONTAINER_IMAGES_TAG
-- name: gcr.io/google-samples/microservices-demo/productcatalogservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/productcatalogservice
   newTag: CONTAINER_IMAGES_TAG
-- name: gcr.io/google-samples/microservices-demo/recommendationservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/recommendationservice
   newTag: CONTAINER_IMAGES_TAG
-- name: gcr.io/google-samples/microservices-demo/shippingservice
+- name: us-central1-docker.pkg.dev/google-samples/microservices-demo/shippingservice
   newTag: CONTAINER_IMAGES_TAG


### PR DESCRIPTION
This PR removes references to `gcr.io` in the docs, as well as the workflows (which runs on new PRs).

I've also pushed the latest release to `us-central1-docker.pkg.dev/google-samples/microservices-demo` (and only the latest release) and modified those references too.

Note that previous releases are still using `gcr.io` which is still going to continue working for the foreseeable future. No need to hotfix previous releases in the repo.