### PR TITLE
Fix istio component instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Online Boutique** is a cloud-first microservices demo application.  The application is a
 web-based e-commerce app where users can browse items, add them to the cart, and purchase them.
 
-Google uses this application to demonstrate how developers can modernize enterprise applications using Google Cloud products, including: [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine), [Anthos Service Mesh (ASM)](https://cloud.google.com/service-mesh), [gRPC](https://grpc.io/), [Cloud Operations](https://cloud.google.com/products/operations), [Spanner](https://cloud.google.com/spanner), [Memorystore](https://cloud.google.com/memorystore), [AlloyDB](https://cloud.google.com/alloydb), and [Gemini](https://ai.google.dev/). This application works on any Kubernetes cluster.
+Google uses this application to demonstrate how developers can modernize enterprise applications using Google Cloud products, including: [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine), [Cloud Service Mesh (CSM)](https://cloud.google.com/service-mesh), [gRPC](https://grpc.io/), [Cloud Operations](https://cloud.google.com/products/operations), [Spanner](https://cloud.google.com/spanner), [Memorystore](https://cloud.google.com/memorystore), [AlloyDB](https://cloud.google.com/alloydb), and [Gemini](https://ai.google.dev/). This application works on any Kubernetes cluster.
 
 If you’re using this demo, please **★Star** this repository to show your interest!
 
@@ -129,7 +129,7 @@ Find **Protocol Buffers Descriptions** at the [`./protos` directory](/protos).
 ## Additional deployment options
 
 - **Terraform**: [See these instructions](/terraform) to learn how to deploy Online Boutique using [Terraform](https://www.terraform.io/intro).
-- **Istio / Anthos Service Mesh**: [See these instructions](/kustomize/components/service-mesh-istio/README.md) to deploy Online Boutique alongside an Istio-backed service mesh.
+- **Istio / Cloud Service Mesh**: [See these instructions](/kustomize/components/service-mesh-istio/README.md) to deploy Online Boutique alongside an Istio-backed service mesh.
 - **Non-GKE clusters (Minikube, Kind, etc)**: See the [Development guide](/docs/development-guide.md) to learn how you can deploy Online Boutique on non-GKE clusters.
 - **AI assistant using Gemini**: [See these instructions](/kustomize/components/shopping-assistant/README.md) to deploy a Gemini-powered AI assistant that suggests products to purchase based on an image.
 - **And more**: The [`/kustomize` directory](/kustomize) contains instructions for customizing the deployment of Online Boutique with other variations.
@@ -151,10 +151,10 @@ Find **Protocol Buffers Descriptions** at the [`./protos` directory](/protos).
 - [gRPC health probes with Kubernetes 1.24+](https://medium.com/p/b5bd26253a4c)
 - [Use Google Cloud Spanner with the Online Boutique sample](https://medium.com/p/f7248e077339)
 - [Seamlessly encrypt traffic from any apps in your Mesh to Memorystore (redis)](https://medium.com/google-cloud/64b71969318d)
-- [Strengthen your app's security with Anthos Service Mesh and Anthos Config Management](https://cloud.google.com/service-mesh/docs/strengthen-app-security)
+- [Strengthen your app's security with Cloud Service Mesh and Anthos Config Management](https://cloud.google.com/service-mesh/docs/strengthen-app-security)
 - [From edge to mesh: Exposing service mesh applications through GKE Ingress](https://cloud.google.com/architecture/exposing-service-mesh-apps-through-gke-ingress)
 - [Take the first step toward SRE with Cloud Operations Sandbox](https://cloud.google.com/blog/products/operations/on-the-road-to-sre-with-cloud-operations-sandbox)
-- [Deploying the Online Boutique sample application on Anthos Service Mesh](https://cloud.google.com/service-mesh/docs/onlineboutique-install-kpt)
+- [Deploying the Online Boutique sample application on Cloud Service Mesh](https://cloud.google.com/service-mesh/docs/onlineboutique-install-kpt)
 - [Anthos Service Mesh Workshop: Lab Guide](https://codelabs.developers.google.com/codelabs/anthos-service-mesh-workshop)
 - [KubeCon EU 2019 - Reinventing Networking: A Deep Dive into Istio's Multicluster Gateways - Steve Dake, Independent](https://youtu.be/-t2BfT59zJA?t=982)
 - Google Cloud Next'18 SF

--- a/docs/cloudshell-tutorial.md
+++ b/docs/cloudshell-tutorial.md
@@ -101,6 +101,6 @@ Congratulations! You've successfully deployed Online Boutique using Cloud Shell.
 ##### What's next?
 
 Try other deployment options for Online Boutique:
-- **Istio/Anthos Service Mesh**: <walkthrough-editor-open-file filePath="./kustomize/components/service-mesh-istio/README.md">See these instructions</walkthrough-editor-open-file>.
+- **Istio/Cloud Service Mesh**: <walkthrough-editor-open-file filePath="./kustomize/components/service-mesh-istio/README.md">See these instructions</walkthrough-editor-open-file>.
 
 Learn more about the [Cloud Shell](https://cloud.google.com/shell) IDE environment and the [Cloud Code](https://cloud.google.com/code) extension.

--- a/kustomize/components/service-mesh-istio/README.md
+++ b/kustomize/components/service-mesh-istio/README.md
@@ -1,203 +1,287 @@
-# Istio Service Mesh
+# Service mesh with Istio
 
-You can use [Istio](https://istio.io) to enable [service mesh features](https://cloud.google.com/service-mesh/docs/overview) such as traffic management, observability, and security. Istio can be provisioned using Anthos Service Mesh (ASM), the Open Source Software (OSS) istioctl tool, or via other Istio providers. You can then label individual namespaces for sidecar injection and configure an Istio gateway to replace the frontend-external load balancer.
+You can use [Istio](https://istio.io) to enable [service mesh features](https://cloud.google.com/service-mesh/docs/overview) such as traffic management, observability, and security. Istio can be provisioned using Cloud Service Mesh (CSM), the Open Source Software (OSS) istioctl tool, or via other Istio providers. You can then label individual namespaces for sidecar injection and configure an Istio gateway to replace the frontend-external load balancer.
+
+# Setup
+
+The following CLI tools needs to be installed and in the PATH:
+
+- `gcloud`
+- `kubectl`
+- `kustomize`
+- `istioctl` (optional)
+
+1. Set-up some default environment variables.
+
+   ```sh
+   PROJECT_ID="<your-project-id>"
+   REGION="<your-google-cloud-region"
+   CLUSTER_NAME="online-boutique"
+   gcloud config set project $PROJECT_ID
+   ```
 
 # Provision a GKE Cluster
- 
-Create a GKE cluster with at least 4 nodes, machine type `e2-standard-4`, [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity), and the [Kubernetes Gateway API resources](https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways):
 
-_Note: using the classic `istio-ingressgateway` instead of Gateway API is another option not covered in this component._
+1. Create an Autopilot GKE cluster.
 
-```bash
-PROJECT_ID="<your-project-id>"
-ZONE="<your-GCP-zone>"
-CLUSTER_NAME="onlineboutique"
+   ```sh
+   gcloud container clusters create-auto $CLUSTER_NAME \
+     --location=$REGION
+   ```
 
-gcloud container clusters create ${CLUSTER_NAME} \
-    --project=${PROJECT_ID} \
-    --zone=${ZONE} \
-    --machine-type=e2-standard-4 \
-    --num-nodes=4 \
-    --workload-pool ${PROJECT_ID}.svc.id.goog \
-    --gateway-api "standard"
-```
+   To make the best use of our service mesh, we need to have [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity), and the [Kubernetes Gateway API resource definitions](https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways) enabled. Autopilot takes care of this for us.
+
+1. Change our kubectl context for the newly created cluster.
+
+   ```sh
+   gcloud container clusters get-credentials $CLUSTER_NAME \
+     --region $REGION
+   ```
 
 # Provision and Configure Istio Service Mesh
 
-## Provision managed `Anthos Service Mesh` via Fleet feature API
+## (Option A) Provision managed Istio using Cloud Service Mesh
 
-ASM provides a managed service mesh experience that includes Managed Control Plane (MCP) and Managed Data Plane (MDP) upgrades.
+Cloud Service Mesh (CSM) provides a service mesh experience that includes a fully managed control plane and data plane. The recommended way to [install CSM](https://cloud.google.com/service-mesh/docs/onboarding/provision-control-plane) uses [fleet management](https://cloud.google.com/kubernetes-engine/fleet-management/docs/fleet-creation).
 
-The recommended way to [install ASM](https://cloud.google.com/service-mesh/docs/managed/provision-managed-anthos-service-mesh) is using the fleet feature API:
+1. Enable the Cloud Service Mesh and GKE Enterprise APIs.
 
-```bash
-# Enable ASM and Fleet APIs
-gcloud services enable mesh.googleapis.com --project ${PROJECT_ID}
+   ```sh
+   gcloud services enable mesh.googleapis.com anthos.googleapis.com
+   ```
 
-# Enable ASM on the project's Fleet
-gcloud container fleet mesh enable --project ${PROJECT_ID}
+1. Enable service mesh support fleet-wide.
 
-# Register GKE cluster with Fleet
-gcloud container fleet memberships register ${CLUSTER_NAME} \
-    --gke-cluster ${ZONE}/${CLUSTER_NAME} \
-    --enable-workload-identity
+   ```sh
+   gcloud container fleet mesh enable
+   ```
 
-FLEET_PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format 'value(projectNumber)')
-# Apply mesh_id label to clusters that should be added to the service mesh
-gcloud container clusters update --project ${PROJECT_ID} ${CLUSTER_NAME} \
-    --zone ${ZONE} --update-labels="mesh_id=proj-$FLEET_PROJECT_NUMBER"
+1. Register the GKE cluster to the fleet.
 
-# Enable managed Anthos Service Mesh on the cluster
-gcloud container fleet mesh update --project ${PROJECT_ID} \
-    --management automatic \
-    --memberships ${CLUSTER_NAME}
+   ```sh
+   gcloud container clusters update $CLUSTER_NAME \
+     --location $REGION \
+     --fleet-project $PROJECT_ID
 
-# Enable sidecar injection for Kubernetes namespace where workload is deployed
-kubectl label namespace default istio-injection- istio.io/rev=asm-managed --overwrite
-```
-_Note: You can ignore any label "istio-injection" not found errors. The istio-injection=enabled annotation would also work but ASM prefers revision labels._
+1. Enable automatic management of the service mesh feature in the cluster.
 
-Follow the [Managed ASM Verification](https://cloud.google.com/service-mesh/docs/managed/provision-managed-anthos-service-mesh#verify_the_control_plane_has_been_provisioned) steps to confirm it is working.
+   ```sh
+   gcloud container fleet mesh update \
+     --management automatic \
+     --memberships $CLUSTER_NAME \
+     --project $PROJECT_ID \
+     --location $REGION
+   ```
 
-## Provision OSS `Istio` via istioctl
+1. Add the Istio injection labels to the default namespace.
 
-Alternatively you can install OSS Istio by following the [getting started guide](https://istio.io/latest/docs/setup/getting-started/):
+   ```sh
+   kubectl label namespace default \
+     istio.io/rev- istio-injection=enabled --overwrite
+   ```
 
-```bash
-# Install istio 1.17 or above
-istioctl install --set profile=minimal -y
+1. Verify that the service mesh is fully provisioned. It will take several minutes for both the control plane and data plane to be ready.
 
-# Enable sidecar injection for Kubernetes namespace(s) where microservices-demo is deployed
-kubectl label namespace default istio-injection=enabled
+   ```sh
+   gcloud container fleet mesh describe
+   ```
 
-# Make sure the istiod injection webhook port 15017 is accessible via GKE master nodes
-# Otherwise your replicaset-controller may be blocked when trying to create new pods with: 
-#   Error creating: Internal error occurred: failed calling 
-#     webhook "namespace.sidecar-injector.istio.io" ... context deadline exceeded
-gcloud compute firewall-rules list --filter="name~gke-[0-9a-z-]*-master"
-NAME                          NETWORK  DIRECTION  PRIORITY  ALLOW              DENY  DISABLED
-gke-onlineboutique-c94d71e8-master  gke-vpc  INGRESS    1000      tcp:10250,tcp:443        False
+   The output should be similar to:
+   ```
+   createTime: '2024-09-18T15:52:36.133664725Z'
+   fleetDefaultMemberConfig:
+     mesh:
+       management: MANAGEMENT_AUTOMATIC
+   membershipSpecs:
+     projects/12345/locations/us-central1/memberships/online-boutique:
+       mesh:
+         management: MANAGEMENT_AUTOMATIC
+       origin:
+         type: USER
+   membershipStates:
+     projects/12345/locations/us-central1/memberships/online-boutique:
+       servicemesh:
+         conditions:
+         - code: VPCSC_GA_SUPPORTED
+           details: This control plane supports VPC-SC GA.
+           documentationLink: http://cloud.google.com/service-mesh/docs/managed/vpc-sc
+           severity: INFO
+         controlPlaneManagement:
+           details:
+           - code: REVISION_READY
+             details: 'Ready: asm-managed'
+           implementation: TRAFFIC_DIRECTOR
+           state: ACTIVE
+         dataPlaneManagement:
+           details:
+           - code: OK
+             details: Service is running.
+           state: ACTIVE
+       state:
+         code: OK
+         description: 'Revision ready for use: asm-managed.'
+         updateTime: '2024-09-18T16:30:37.632583401Z'
+   name: projects/my-project/locations/global/features/servicemesh
+   resourceState:
+     state: ACTIVE
+   spec: {}
+   updateTime: '2024-09-18T16:15:05.957266437Z'
+   ```
 
-# Update firewall rule (or create a new one) to allow webhook port 15017
-gcloud compute firewall-rules update gke-onlineboutique-c94d71e8-master \
+1. (Optional) If you require Certificate Authority Service, you can configure it by [following these instructions](https://cloud.google.com/service-mesh/docs/security/certificate-authority-service).
+
+## (Option B) Provision Istio using istioctl
+
+1. Alternatively you can install the open source version of Istio by following the [getting started guide](https://istio.io/latest/docs/setup/getting-started/).
+
+   ```sh
+   # Install istio 1.17 or above
+   istioctl install --set profile=minimal -y
+
+   # Enable sidecar injection for Kubernetes namespace(s) where microservices-demo is deployed
+   kubectl label namespace default istio-injection=enabled
+
+   # Make sure the istiod injection webhook port 15017 is accessible via GKE master nodes
+   # Otherwise your replicaset-controller may be blocked when trying to create new pods with: 
+   #   Error creating: Internal error occurred: failed calling 
+   #     webhook "namespace.sidecar-injector.istio.io" ... context deadline exceeded
+   gcloud compute firewall-rules list --filter="name~gke-[0-9a-z-]*-master"
+   NAME                          NETWORK  DIRECTION  PRIORITY  ALLOW              DENY  DISABLED
+   gke-online-boutique-c94d71e8-master  gke-vpc  INGRESS    1000      tcp:10250,tcp:443        False
+
+   # Update firewall rule (or create a new one) to allow webhook port 15017
+   gcloud compute firewall-rules update gke-online-boutique-c94d71e8-master \
     --allow tcp:10250,tcp:443,tcp:15017
-```
+   ```
 
-# Deploy and Validate Online Boutique with `Istio`
-
-## Deploy via Kustomize component
+# Deploy Online Boutique with the Istio component
 
 Once the service mesh and namespace injection are configured, you can then deploy the Istio manifests using Kustomize. You should also include the [service-accounts component](../service-accounts) if you plan on using AuthorizationPolicies.
 
-From the `kustomize/` folder at the root level of this repository, execute these commands:
-```bash
-kustomize edit add component components/service-mesh-istio
-```
+1. Enable the service-mesh-istio component.
 
-This will update the `kustomize/kustomization.yaml` file which could be similar to:
-```yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- base
-components:
-- components/service-mesh-istio
-```
+   ```sh
+   cd kustomize/
+   kustomize edit add component components/service-mesh-istio
+   ```
 
-_Note: `service-mesh-istio` component includes the same delete patch as the `non-public-frontend` component. Trying to use both those components in your kustomization.yaml file will result in an error._
+   This will update the `kustomize/kustomization.yaml` file which could be similar to:
+   ```yaml
+   apiVersion: kustomize.config.k8s.io/v1beta1
+   kind: Kustomization
+   resources:
+   - base
+   components:
+   - components/service-mesh-istio
+   ```
 
-You can locally render these manifests by running `kubectl kustomize .` or deploying them by running `kubectl apply -k .`
+   _Note: `service-mesh-istio` component includes the same delete patch as the `non-public-frontend` component. Trying to use both those components in your kustomization.yaml file will result in an error._
 
-The output should be similar to:
-```
-serviceaccount/adservice created
-serviceaccount/cartservice created
-serviceaccount/checkoutservice created
-serviceaccount/currencyservice created
-serviceaccount/emailservice created
-serviceaccount/frontend created
-serviceaccount/loadgenerator created
-serviceaccount/paymentservice created
-serviceaccount/productcatalogservice created
-serviceaccount/recommendationservice created
-serviceaccount/shippingservice created
-service/adservice created
-service/cartservice created
-service/checkoutservice created
-service/currencyservice created
-service/emailservice created
-service/frontend created
-service/paymentservice created
-service/productcatalogservice created
-service/recommendationservice created
-service/redis-cart created
-service/shippingservice created
-deployment.apps/adservice created
-deployment.apps/cartservice created
-deployment.apps/checkoutservice created
-deployment.apps/currencyservice created
-deployment.apps/emailservice created
-deployment.apps/frontend created
-deployment.apps/loadgenerator created
-deployment.apps/paymentservice created
-deployment.apps/productcatalogservice created
-deployment.apps/recommendationservice created
-deployment.apps/redis-cart created
-deployment.apps/shippingservice created
-gateway.gateway.networking.k8s.io/istio-gateway created
-httproute.gateway.networking.k8s.io/frontend-route created
-serviceentry.networking.istio.io/allow-egress-google-metadata created
-serviceentry.networking.istio.io/allow-egress-googleapis created
-virtualservice.networking.istio.io/frontend created
-```
+1. Deploy the manifests.
 
-# Verify Online Boutique Deployment
+   ```sh
+   kubectl apply -k
+   ```
 
-Run `kubectl get pods,gateway,svc` to see pods and gateway are in a healthy and ready state.
+   The output should be similar to:
+   ```
+   serviceaccount/adservice created
+   serviceaccount/cartservice created
+   serviceaccount/checkoutservice created
+   serviceaccount/currencyservice created
+   serviceaccount/emailservice created
+   serviceaccount/frontend created
+   serviceaccount/loadgenerator created
+   serviceaccount/paymentservice created
+   serviceaccount/productcatalogservice created
+   serviceaccount/recommendationservice created
+   serviceaccount/shippingservice created
+   service/adservice created
+   service/cartservice created
+   service/checkoutservice created
+   service/currencyservice created
+   service/emailservice created
+   service/frontend created
+   service/paymentservice created
+   service/productcatalogservice created
+   service/recommendationservice created
+   service/redis-cart created
+   service/shippingservice created
+   deployment.apps/adservice created
+   deployment.apps/cartservice created
+   deployment.apps/checkoutservice created
+   deployment.apps/currencyservice created
+   deployment.apps/emailservice created
+   deployment.apps/frontend created
+   deployment.apps/loadgenerator created
+   deployment.apps/paymentservice created
+   deployment.apps/productcatalogservice created
+   deployment.apps/recommendationservice created
+   deployment.apps/redis-cart created
+   deployment.apps/shippingservice created
+   gateway.gateway.networking.k8s.io/istio-gateway created
+   httproute.gateway.networking.k8s.io/frontend-route created
+   serviceentry.networking.istio.io/allow-egress-google-metadata created
+   serviceentry.networking.istio.io/allow-egress-googleapis created
+   virtualservice.networking.istio.io/frontend created
+   ```
 
-The output should be similar to:
-```
-NAME                                         READY   STATUS    RESTARTS   AGE
-pod/adservice-6cbd9794f9-8c4gv               2/2     Running   0          47s
-pod/cartservice-667bbd5f6-84j8v              2/2     Running   0          47s
-pod/checkoutservice-547557f445-bw46n         2/2     Running   0          47s
-pod/currencyservice-6bd8885d9c-2cszv         2/2     Running   0          47s
-pod/emailservice-64997dcf97-8fpsd            2/2     Running   0          47s
-pod/frontend-c54778dcf-wbgmr                 2/2     Running   0          46s
-pod/istio-gateway-istio-8577b948c6-cxl8j     1/1     Running   0          45s
-pod/loadgenerator-ccfd4d598-jh6xj            2/2     Running   0          46s
-pod/paymentservice-79b77cd7c-6hth7           2/2     Running   0          46s
-pod/productcatalogservice-5f75795545-nk5wv   2/2     Running   0          46s
-pod/recommendationservice-56dd4c7df5-gnwwr   2/2     Running   0          46s
-pod/redis-cart-799c85c644-pxsvt              2/2     Running   0          46s
-pod/shippingservice-64f8df74f5-7wllf         2/2     Running   0          45s
+# Verify that the deployment succeeded
 
-NAME                                              CLASS   ADDRESS          READY   AGE
-gateway.gateway.networking.k8s.io/istio-gateway   istio   35.247.123.146   True    45s
+1. Check that the pods and the gateway are in a healthy and ready state.
 
-NAME                            TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)                        AGE
-service/adservice               ClusterIP      10.68.231.142   <none>           9555/TCP                       49s
-service/cartservice             ClusterIP      10.68.184.25    <none>           7070/TCP                       49s
-service/checkoutservice         ClusterIP      10.68.177.213   <none>           5050/TCP                       49s
-service/currencyservice         ClusterIP      10.68.249.87    <none>           7000/TCP                       49s
-service/emailservice            ClusterIP      10.68.205.123   <none>           5000/TCP                       49s
-service/frontend                ClusterIP      10.68.94.203    <none>           80/TCP                         48s
-service/istio-gateway-istio     LoadBalancer   10.68.147.158   35.247.123.146   15021:30376/TCP,80:30332/TCP   45s
-service/kubernetes              ClusterIP      10.68.0.1       <none>           443/TCP                        65m
-service/paymentservice          ClusterIP      10.68.114.19    <none>           50051/TCP                      48s
-service/productcatalogservice   ClusterIP      10.68.240.153   <none>           3550/TCP                       48s
-service/recommendationservice   ClusterIP      10.68.117.97    <none>           8080/TCP                       48s
-service/redis-cart              ClusterIP      10.68.189.126   <none>           6379/TCP                       48s
-service/shippingservice         ClusterIP      10.68.221.62    <none>           50051/TCP                      48s
+   ```sh
+   kubectl get pods,gateways,services
+   ```
 
-```
-Find the IP address of your Istio gateway and visit the application frontend in a web browser.
+   The output should be similar to:
+   ```
+   NAME                                         READY   STATUS    RESTARTS   AGE
+   pod/adservice-6cbd9794f9-8c4gv               2/2     Running   0          47s
+   pod/cartservice-667bbd5f6-84j8v              2/2     Running   0          47s
+   pod/checkoutservice-547557f445-bw46n         2/2     Running   0          47s
+   pod/currencyservice-6bd8885d9c-2cszv         2/2     Running   0          47s
+   pod/emailservice-64997dcf97-8fpsd            2/2     Running   0          47s
+   pod/frontend-c54778dcf-wbgmr                 2/2     Running   0          46s
+   pod/istio-gateway-istio-8577b948c6-cxl8j     1/1     Running   0          45s
+   pod/loadgenerator-ccfd4d598-jh6xj            2/2     Running   0          46s
+   pod/paymentservice-79b77cd7c-6hth7           2/2     Running   0          46s
+   pod/productcatalogservice-5f75795545-nk5wv   2/2     Running   0          46s
+   pod/recommendationservice-56dd4c7df5-gnwwr   2/2     Running   0          46s
+   pod/redis-cart-799c85c644-pxsvt              2/2     Running   0          46s
+   pod/shippingservice-64f8df74f5-7wllf         2/2     Running   0          45s
 
-```sh
-INGRESS_HOST="$(kubectl get gateway istio-gateway \
-    -o jsonpath='{.status.addresses[*].value}')"
-curl -v "http://$INGRESS_HOST"
-```
+   NAME                                              CLASS   ADDRESS          READY   AGE
+   gateway.gateway.networking.k8s.io/istio-gateway   istio   35.247.123.146   True    45s
+
+   NAME                            TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)                        AGE
+   service/adservice               ClusterIP      10.68.231.142   <none>           9555/TCP                       49s
+   service/cartservice             ClusterIP      10.68.184.25    <none>           7070/TCP                       49s
+   service/checkoutservice         ClusterIP      10.68.177.213   <none>           5050/TCP                       49s
+   service/currencyservice         ClusterIP      10.68.249.87    <none>           7000/TCP                       49s
+   service/emailservice            ClusterIP      10.68.205.123   <none>           5000/TCP                       49s
+   service/frontend                ClusterIP      10.68.94.203    <none>           80/TCP                         48s
+   service/istio-gateway-istio     LoadBalancer   10.68.147.158   35.247.123.146   15021:30376/TCP,80:30332/TCP   45s
+   service/kubernetes              ClusterIP      10.68.0.1       <none>           443/TCP                        65m
+   service/paymentservice          ClusterIP      10.68.114.19    <none>           50051/TCP                      48s
+   service/productcatalogservice   ClusterIP      10.68.240.153   <none>           3550/TCP                       48s
+   service/recommendationservice   ClusterIP      10.68.117.97    <none>           8080/TCP                       48s
+   service/redis-cart              ClusterIP      10.68.189.126   <none>           6379/TCP                       48s
+   service/shippingservice         ClusterIP      10.68.221.62    <none>           50051/TCP                      48s
+   ```
+
+1. Find the external IP address of your Istio gateway.
+
+   ```sh
+   INGRESS_HOST="$(kubectl get gateway istio-gateway \
+       -o jsonpath='{.status.addresses[*].value}')"
+   ```
+
+1. Navigate to the frontend in a web browser.
+
+   ```
+   http://$INGRESS_HOST
+   ```
 
 # Additional service mesh demos using Online Boutique 
 
@@ -206,8 +290,8 @@ curl -v "http://$INGRESS_HOST"
 - [Cloud Operations (Stackdriver)](https://github.com/GoogleCloudPlatform/istio-samples/tree/master/istio-stackdriver)
 - [Stackdriver metrics (Open source Istio)](https://github.com/GoogleCloudPlatform/istio-samples/tree/master/stackdriver-metrics)
 
-# Related Resources
+# Related resources
 
 - [Deploying classic istio-ingressgateway in ASM](https://cloud.google.com/service-mesh/docs/gateways#deploy_gateways)
 - [Uninstall Istio via istioctl](https://istio.io/latest/docs/setup/install/istioctl/#uninstall-istio)
-- [Uninstall Anthos Service Mesh](https://cloud.google.com/service-mesh/docs/uninstall)
+- [Uninstall Cloud Service Mesh](https://cloud.google.com/service-mesh/docs/uninstall)


### PR DESCRIPTION
This PR fixes outdated instructions for the [service mesh / istio component](https://github.com/GoogleCloudPlatform/microservices-demo/tree/main/kustomize/components/service-mesh-istio).

In particular:
- Use Cloud Service Mesh (CSM) instead of Anthos Service Mesh (ASM)
- Add CLI tool requirements
- Use GKE Autopilot instead of GKE Standard
- Use ordered lists (1, 2, 3) for instructions instead of paragraphs that blend in
- Fix broken commands and missing APIs
- Expand the "Provision managed Istio" section with a series of individual commands to run, rather than a single block of code

Staged here: https://github.com/GoogleCloudPlatform/microservices-demo/blob/789958d9c673badb3466bc48ed747fb3bbff3cc5/kustomize/components/service-mesh-istio/README.md