### PR TITLE
Add sample-public-image-... tag

### DIFF
--- a/docs/releasing/make-docker-images.sh
+++ b/docs/releasing/make-docker-images.sh
@@ -36,10 +36,12 @@ while IFS= read -d $'\0' -r dir; do
         builddir="${dir}/src"
     fi
     image="${REPO_PREFIX}/$svcname:$TAG"
+    image_with_sample_public_image_tag="${REPO_PREFIX}/$svcname:sample-public-image-$TAG"
     (
         cd "${builddir}"
         log "Building (and pushing) image on Google Cloud Build: ${image}"
         gcloud builds submit --project=${PROJECT_ID} --tag=${image}
+        gcloud artifacts docker tags add ${image} ${image_with_sample_public_image_tag}
     )
 done < <(find "${REPO_ROOT}/src" -mindepth 1 -maxdepth 1 -type d -print0)
 


### PR DESCRIPTION
### Background 
* Please see [this Google-internal comment](http://b/369909184#comment2).
* We need to include a tag for each public sample that contains the prefix `sample-public-image-`.
* This applies to the publicly accessible microservice images published per release of Online Boutique.

### Change Summary
* I've added a line to our release script to add a tag with the `sample-public-image-` prefix.

### Testing Procedure
* I have not tested the release script. 
* But I _have_ tested the [`gcloud artifacts docker tags add` command](https://cloud.google.com/sdk/gcloud/reference/artifacts/docker/tags/add).