### PR TITLE
Add Route to Frontend service

### DIFF
--- a/helm-chart/templates/frontend.yaml
+++ b/helm-chart/templates/frontend.yaml
@@ -283,3 +283,24 @@ spec:
           number: 80
 {{- end }}
 {{- end }}
+{{- if .Values.frontend.route.create }}
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ .Values.frontend.route.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  to:
+    kind: Service
+    name: {{ .Values.frontend.name }}
+  host: {{ .Values.frontend.route.host }}
+  tls:
+    termination: {{ .Values.frontend.route.tls.termination }} # Edge, Passthrough, Reencrypt, InsecureEdge, or Redirect
+    insecureEdgeTerminationPolicy: {{ .Values.frontend.route.tls.insecureEdgeTerminationPolicy }} # None, Allow, Redirect
+    {{- if .Values.frontend.route.tls.destinationCACertificate }}
+    destinationCACertificate: {{ .Values.frontend.route.tls.destinationCACertificate | quote }}
+    {{- end }}
+  port:
+    targetPort: http
+{{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -131,6 +131,15 @@ frontend:
       namespace: asm-ingress
       labelKey: asm
       labelValue: ingressgateway
+  route:
+    # Specifies if a OpenShift route should be created or not.
+    create: false
+    name: frontend-route
+    host: frontend.example.com
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
+      destinationCACertificate: ""
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
### Background 
Adds a OpenShift Route to the Frontend service. It is disabled by default, and can be enabled by setting the `frontend.route.create` toggle to `true`

If this doesn't suit the project (because it's OpenShift only), I can understand. This PR can be closed then.