### PR TITLE
Add imagePullSecret option and dockerhub proxy option

### DIFF
--- a/helm-chart/templates/adservice.yaml
+++ b/helm-chart/templates/adservice.yaml
@@ -60,6 +60,10 @@ spec:
         seccompProfile:
           type: {{ .Values.seccompProfile.type }}
         {{- end }}
+      {{- if .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.images.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: server
         securityContext:

--- a/helm-chart/templates/cartservice.yaml
+++ b/helm-chart/templates/cartservice.yaml
@@ -64,6 +64,10 @@ spec:
         seccompProfile:
           type: {{ .Values.seccompProfile.type }}
         {{- end }}
+      {{- if .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.images.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: server
         securityContext:
@@ -242,6 +246,10 @@ spec:
         seccompProfile:
           type: {{ .Values.seccompProfile.type }}
         {{- end }}
+      {{- if .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.images.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: redis
         securityContext:
@@ -253,6 +261,8 @@ spec:
           readOnlyRootFilesystem: true
         {{- if .Values.cartDatabase.inClusterRedis.publicRepository }}
         image: redis:alpine@sha256:c35af3bbcef51a62c8bae5a9a563c6f1b60d7ebaea4cb5a3ccbcc157580ae098
+        {{- else if .Values.cartDatabase.inClusterRedis.imageRepository }}
+        image: {{ .Values.cartDatabase.inClusterRedis.imageRepository }}/redis:alpine
         {{- else }}
         image: {{ .Values.images.repository }}/redis:alpine
         {{- end }}

--- a/helm-chart/templates/checkoutservice.yaml
+++ b/helm-chart/templates/checkoutservice.yaml
@@ -59,6 +59,10 @@ spec:
         seccompProfile:
           type: {{ .Values.seccompProfile.type }}
         {{- end }}
+      {{- if .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.images.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: server
         securityContext:

--- a/helm-chart/templates/currencyservice.yaml
+++ b/helm-chart/templates/currencyservice.yaml
@@ -60,6 +60,10 @@ spec:
         seccompProfile:
           type: {{ .Values.seccompProfile.type }}
         {{- end }}
+      {{- if .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.images.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: server
         securityContext:

--- a/helm-chart/templates/emailservice.yaml
+++ b/helm-chart/templates/emailservice.yaml
@@ -60,6 +60,10 @@ spec:
         seccompProfile:
           type: {{ .Values.seccompProfile.type }}
         {{- end }}
+      {{- if .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.images.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: server
         securityContext:

--- a/helm-chart/templates/frontend.yaml
+++ b/helm-chart/templates/frontend.yaml
@@ -61,6 +61,10 @@ spec:
         seccompProfile:
           type: {{ .Values.seccompProfile.type }}
         {{- end }}
+      {{- if .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.images.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
         - name: server
           securityContext:

--- a/helm-chart/templates/loadgenerator.yaml
+++ b/helm-chart/templates/loadgenerator.yaml
@@ -64,6 +64,10 @@ spec:
         seccompProfile:
           type: {{ .Values.seccompProfile.type }}
         {{- end }}
+      {{- if .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.images.imagePullSecrets | nindent 8 }}
+      {{- end }}
       {{- if .Values.loadGenerator.checkFrontendInitContainer }}
       initContainers:
       - command:

--- a/helm-chart/templates/opentelemetry-collector.yaml
+++ b/helm-chart/templates/opentelemetry-collector.yaml
@@ -56,6 +56,10 @@ spec:
         seccompProfile:
           type: {{ .Values.seccompProfile.type }}
         {{- end }}
+      {{- if .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.images.imagePullSecrets | nindent 8 }}
+      {{- end }}
       {{- if eq .Values.opentelemetryCollector.projectId "PROJECT_ID" }}
       initContainers:
       # Init container retrieves the current cloud project id from the metadata server
@@ -136,7 +140,7 @@ data:
   collector-gateway-config-template.yaml: |
     receivers:
       otlp:
-        protocols: 
+        protocols:
           grpc:
     processors:
     exporters:

--- a/helm-chart/templates/paymentservice.yaml
+++ b/helm-chart/templates/paymentservice.yaml
@@ -58,6 +58,10 @@ spec:
         seccompProfile:
           type: {{ .Values.seccompProfile.type }}
         {{- end }}
+      {{- if .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.images.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: server
         securityContext:

--- a/helm-chart/templates/productcatalogservice.yaml
+++ b/helm-chart/templates/productcatalogservice.yaml
@@ -60,6 +60,10 @@ spec:
         seccompProfile:
           type: {{ .Values.seccompProfile.type }}
         {{- end }}
+      {{- if .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.images.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: server
         securityContext:

--- a/helm-chart/templates/recommendationservice.yaml
+++ b/helm-chart/templates/recommendationservice.yaml
@@ -60,6 +60,10 @@ spec:
         seccompProfile:
           type: {{ .Values.seccompProfile.type }}
         {{- end }}
+      {{- if .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.images.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: server
         securityContext:

--- a/helm-chart/templates/shippingservice.yaml
+++ b/helm-chart/templates/shippingservice.yaml
@@ -59,6 +59,10 @@ spec:
         seccompProfile:
           type: {{ .Values.seccompProfile.type }}
         {{- end }}
+      {{- if .Values.images.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.images.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: server
         securityContext:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -20,6 +20,7 @@ images:
   repository: us-central1-docker.pkg.dev/google-samples/microservices-demo
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  imagePullSecrets: []
 
 serviceAccounts:
   # Specifies whether service accounts should be created.
@@ -206,6 +207,7 @@ cartDatabase:
     name: redis-cart
     # Uses the public redis image from Docker Hub, otherwise will use the images.repository.
     publicRepository: true
+    imageRepository: ''
   externalRedisTlsOrigination:
     enable: false
     name: exernal-redis-tls-origination


### PR DESCRIPTION
### Background 
Add option for adding imagePullSecrets for pulling from private registries and/or private proxy caches. 
Also added a separate imageRegistry option for the redis image in the cart service db, since this image comes from Dockerhub instead of gcr. If you pull by a proxy cache, you often need to specify a different proxy cache. 