### PR TITLE
feat(loadgenerator): allow customizing frontend protocol

### DIFF
--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -32,4 +32,4 @@ COPY locustfile.py .
 # enable gevent support in debugger
 ENV GEVENT_SUPPORT=True
 
-ENTRYPOINT locust --host="http://${FRONTEND_ADDR}" --headless -u "${USERS:-10}" 2>&1
+ENTRYPOINT locust --host="${FRONTEND_PROTOCOL:-http}://${FRONTEND_ADDR}" --headless -u "${USERS:-10}" 2>&1


### PR DESCRIPTION
### Background 
<!-- What was happening before this PR, and the problem(s) it solves -->
I would like to point locust to my nginx ingress instead of the service.

### Change Summary
<!-- Short summary of the changes submitted -->
This PR adds support for customizing the protocol locust uses while querying the online-boutique website.

### Additional Notes
<!-- Any remaining concerns -->
Backwards compatible.

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->
- Deploy the app with:
```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
namespace: online-boutique
resources:
- https://github.com/GoogleCloudPlatform/microservices-demo//kustomize/base?ref=6af73dcf7fe1ca653d95ae7a29e12faf8cf02964
- ingress.yaml
components:
- https://github.com/GoogleCloudPlatform/microservices-demo//kustomize/components/network-policies?ref=6af73dcf7fe1ca653d95ae7a29e12faf8cf02964
- https://github.com/GoogleCloudPlatform/microservices-demo//kustomize/components/non-public-frontend?ref=6af73dcf7fe1ca653d95ae7a29e12faf8cf02964
patches:
- patch: |
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: loadgenerator
    labels:
      app: loadgenerator
  spec:
    template:
      spec:
        containers:
        - name: main
          env:
          - name: FRONTEND_PROTOCOL
            value: https
          - name: FRONTEND_ADDR
            value: shop.example.com
```
- Ensure the load testing is running correctly looking at the logs

