### PR TITLE
Shrink emailservice base image, to python:3.13.0-alpine

### DIFF
--- a/src/emailservice/Dockerfile
+++ b/src/emailservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.12.6-slim@sha256:ad48727987b259854d52241fac3bc633574364867b8e20aec305e6e7f4028b26 AS base
+FROM python:3.13.0-alpine@sha256:ad48727987b259854d52241fac3bc633574364867b8e20aec305e6e7f4028b26 AS base
 
 FROM base AS builder
 


### PR DESCRIPTION
### Background 

* `python...alpine` is one of the smallest `python...` images. See list of other `python...` images: https://hub.docker.com/_/python.
* Smaller the base image, the better —> fewer vulnerabilities, and faster build/push/pull time.
* According to [this article](https://medium.com/@arif.rahman.rhm/choosing-the-right-python-docker-image-slim-buster-vs-alpine-vs-slim-bullseye-5586bac8b4c9):
> Alpine takes the security crown with its minimal attack surface and frequent updates.
* See related Google-internal bug: b/378279353

### Change Summary
* This change shrinks the base image used by the `emailservice` (from `python:3.12.6-slim`).

### Testing Procedure
* The testing performed by our integration tests (in this PR's GitHub Actions) should suffice.
