### PR TITLE
Shrink recommendationservice base image to python:3.12.8-alpine

### DIFF
--- a/src/recommendationservice/Dockerfile
+++ b/src/recommendationservice/Dockerfile
@@ -23,7 +23,7 @@ RUN apk update \
         gcc \
         make \
         libc-dev \
-    && rm -rf /var/cache/apk/* # Clean APK cache
+    && rm -rf /var/cache/apk/*
 
 # get packages
 COPY requirements.txt .

--- a/src/recommendationservice/Dockerfile
+++ b/src/recommendationservice/Dockerfile
@@ -16,7 +16,7 @@ FROM python:3.12.8-alpine@sha256:f92e36f6569658ba9501e2e1e3ca780d61faea8e84edd99
 
 FROM base AS builder
 
-RUN apk update \ # Update the package list
+RUN apk update \
     && apk add --no-cache \
         wget \
         g++ \

--- a/src/recommendationservice/Dockerfile
+++ b/src/recommendationservice/Dockerfile
@@ -12,14 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.12.6-slim@sha256:ad48727987b259854d52241fac3bc633574364867b8e20aec305e6e7f4028b26 AS base
+FROM python:3.12.8-alpine@sha256:f92e36f6569658ba9501e2e1e3ca780d61faea8e84edd990a0ed70d0ca8add4a AS base
 
 FROM base AS builder
 
-RUN apt-get -qq update \
-    && apt-get install -y --no-install-recommends \
-        wget g++ \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk update \ # Update the package list
+    && apk add --no-cache \
+        wget \
+        g++ \
+        gcc \
+        make \
+        libc-dev \
+    && rm -rf /var/cache/apk/* # Clean APK cache
 
 # get packages
 COPY requirements.txt .

--- a/src/recommendationservice/Dockerfile
+++ b/src/recommendationservice/Dockerfile
@@ -20,9 +20,6 @@ RUN apk update \
     && apk add --no-cache \
         wget \
         g++ \
-        gcc \
-        make \
-        libc-dev \
     && rm -rf /var/cache/apk/*
 
 # get packages


### PR DESCRIPTION
### Background 
* `python...alpine` is one of the smallest `python...` images. See list of other `python...` images: https://hub.docker.com/_/python.
* Smaller the base image, the better —> fewer vulnerabilities, and faster build/push/pull time.
* According to [this article](https://medium.com/@arif.rahman.rhm/choosing-the-right-python-docker-image-slim-buster-vs-alpine-vs-slim-bullseye-5586bac8b4c9):
> Alpine takes the security crown with its minimal attack surface and frequent updates.
* See Google-internal bug: b/378279625

### Change Summary
* This change shrinks the base image used by the `recommendationservice` (from `python:3.12.7-slim`).
* This brings the CVE count down [from 49](https://console.cloud.google.com/artifacts/docker/google-samples/us-central1/microservices-demo/recommendationservice/sha256:cbfbae73941038ba462165d67502d737810bc5867dbda0ed9b523f9ff5dac555;tab=vulnerabilities) to [5 (more importantly, 0 HIGH/CRITICAL CVEs)](https://console.cloud.google.com/artifacts/docker/online-boutique-ci/us/refs/pull%2F2832%2Frecommendationservice/sha256:6efd86d31af43512d3c14fc9a246f0a3d6c20a4bd3e94771b2dc4c8005a755f9;tab=vulnerabilities).

### Testing Procedure
* The testing performed by our integration tests (in this PR's GitHub Actions) should suffice.
* I've also smoke tested the staging URL. 👍  Works.

### Related PRs or Issues 
* We already made a similar update to emailservice: https://github.com/GoogleCloudPlatform/microservices-demo/pull/2813.