### PR TITLE
armアーキテクチャのcpuでもローカルでビルドできるように変更を加えました

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -42,6 +42,8 @@ build:
     context: src/cartservice/src
     docker:
       dockerfile: Dockerfile
+      buildArgs:
+        BUILDPLATFORM: linux/arm64
   - image: frontend
     context: src/frontend
   - image: adservice
@@ -49,7 +51,9 @@ build:
   tagPolicy:
     gitCommit: {}
   local:
-    useBuildkit: false
+    useBuildkit: true
+  platforms:
+    - linux/arm64
 manifests:
   kustomize:
     paths:

--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -12,20 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM eclipse-temurin:21@sha256:b5fc642f67dbbd1c4ce811388801cb8480aaca8aa9e56fd6dcda362cfea113f1 AS builder
+FROM --platform=linux/arm64 amazoncorretto:21 AS builder
 
 WORKDIR /app
+
+# デバック用の環境変数を設定
+ENV GRADLE_OPTS="-Dorg.gradle.logging.level=info"
+
+# システムプロパティの設定
+# ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0"
+# ENV GRADLE_OPTS="-Dorg.gradle.jvmargs=-Xmx2048m -Xms512m -XX:MaxMetaspaceSize=512m"
 
 COPY ["build.gradle", "gradlew", "./"]
 COPY gradle gradle
 RUN chmod +x gradlew
+# より詳細なログ出y録を得るためのオプションを追加
+RUN ./gradlew downloadRepos --stacktrace --info 
 RUN ./gradlew downloadRepos
 
 COPY . .
 RUN chmod +x gradlew
 RUN ./gradlew installDist
 
-FROM eclipse-temurin:21.0.4_7-jre-alpine@sha256:8cc1202a100e72f6e91bf05ab274b373a5def789ab6d9e3e293a61236662ac27
+FROM --platform=linux/arm64 amazoncorretto:21-alpine
 
 # @TODO: https://github.com/GoogleCloudPlatform/microservices-demo/issues/2517
 # Download Stackdriver Profiler Java agent

--- a/src/cartservice/src/Dockerfile
+++ b/src/cartservice/src/Dockerfile
@@ -13,24 +13,25 @@
 # limitations under the License.
 
 # https://mcr.microsoft.com/product/dotnet/sdk
-FROM mcr.microsoft.com/dotnet/sdk:9.0.100-noble@sha256:bd0365368f46274500ebb086f491703052b8ce23e3d52d3233a23b2020730057 AS builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS builder
 WORKDIR /app
+
+
 COPY cartservice.csproj .
-RUN dotnet restore cartservice.csproj \
-    -r linux-x64
+
+# 依存関係の復元
+RUN dotnet restore cartservice.csproj 
 COPY . .
 RUN dotnet publish cartservice.csproj \
-    -p:PublishSingleFile=true \
-    -r linux-x64 \
+    # -p:PublishSingleFile=true \
     --self-contained true \
-    -p:PublishTrimmed=true \
-    -p:TrimMode=full \
+    # -p:PublishTrimmed=true \
+    # -p:TrimMode=full \
     -c release \
     -o /cartservice
 
 # https://mcr.microsoft.com/product/dotnet/runtime-deps
-FROM mcr.microsoft.com/dotnet/runtime-deps:9.0.0-noble-chiseled@sha256:5cc893809e2d2869e1a98c1eecc4c6ff6978d53bc3e5342014eff28a058867a4
-
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/runtime-deps:8.0
 WORKDIR /app
 COPY --from=builder /cartservice .
 EXPOSE 7070

--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Background 
<!-- What was happening before this PR, and the problem(s) it solves -->
arm64アーキテクチャのPCではローカルでビルドできなかったが、ビルドできるようになった
### Fixes 
<!-- Link the issue(s) this PR fixes-->
### Change Summary
<!-- Short summary of the changes submitted -->
cartserviceおよびadserviceのdocker imageをarm64アーキテクチャ対応のものに修正
skaffold.yamlでBuildkitを使用するように変更、arm64アーキテクチャであることを明記
### Additional Notes
<!-- Any remaining concerns -->

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
