### PR TITLE
Update values.yaml- increase memory request/limit for three services

### DIFF
--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -76,10 +76,10 @@ cartService:
   resources:
     requests:
       cpu: 200m
-      memory: 64Mi
+      memory: 128Mi
     limits:
       cpu: 300m
-      memory: 128Mi
+      memory: 256Mi
 
 checkoutService:
   create: true
@@ -98,10 +98,10 @@ currencyService:
   resources:
     requests:
       cpu: 100m
-      memory: 64Mi
+      memory: 128Mi
     limits:
       cpu: 200m
-      memory: 128Mi
+      memory: 256Mi
 
 emailService:
   create: true
@@ -157,10 +157,10 @@ paymentService:
   resources:
     requests:
       cpu: 100m
-      memory: 64Mi
+      memory: 128Mi
     limits:
       cpu: 200m
-      memory: 128Mi
+      memory: 256Mi
 
 productCatalogService:
   create: true


### PR DESCRIPTION
### Background 
While playing with the solution locally, I installed Prometheus/grafana to grasp the compute utilization better.
While enabling the load generator service, I observed three services consuming a lot of memory, which was very close to the memory limit.

![image](https://github.com/user-attachments/assets/cfccdfe6-2482-4787-a764-a7640ac3d180)

### Fixes 
Increase memory request and limit for three services to avoid OOM errors, like the following one:
![image](https://github.com/user-attachments/assets/0a32e891-dfe2-4ca1-99c3-93cef9806a53)


