### PR TITLE
Fix loadgenerator in skaffold.yaml

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -101,9 +101,13 @@ requires:
 - configs:
   - app
 build:
+  platforms: ["linux/amd64", "linux/arm64"]
   artifacts:
   - image: loadgenerator
     context: src/loadgenerator
+  local:
+    useDockerCLI: true
+    useBuildkit: true
 manifests:
   rawYaml:
   - ./kubernetes-manifests/loadgenerator.yaml


### PR DESCRIPTION
Fix `loadgenerator` in `skaffold.yaml`: https://github.com/GoogleCloudPlatform/microservices-demo/issues/2927.

Fixes #2927

I haven't tested it myself, but by looking at https://github.com/GoogleCloudPlatform/microservices-demo/pull/2589, that's the only differences and missing part I see between `loadgenerator` and the other services deployed via Skaffold.