### PR TITLE
fix(helm): move containers block outside securityContext condition in recommendation service

### DIFF
--- a/helm-chart/templates/recommendationservice.yaml
+++ b/helm-chart/templates/recommendationservice.yaml
@@ -59,8 +59,8 @@ spec:
         seccompProfile:
           type: {{ .Values.seccompProfile.type }}
         {{- end }}
-      containers:
       {{- end }}
+      containers:
       - name: server
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
### Background 
The Helm chart for the recommendationservice had a rendering issue. Specifically, when `.Values.securityContext.enable` is set to `false`, the `containers:` block is not rendered at all, resulting in an invalid Kubernetes manifest. This is because the `containers:` block is mistakenly placed inside the conditional that checks for `securityContext.enable`.

### Fixes 
N/A (No open issue linked to this bug)

### Change Summary
- Moved the `containers:` block (along with the container definition) outside the if `.Values.securityContext.enable` condition.
- Ensures that a valid Deployment manifest is rendered regardless of the securityContext setting.

### Additional Notes
This only affects the `recommendationservice` helm chart.

### Testing Procedure
- Set `securityContext.enable: false` in `values.yaml`
- Run `helm template helm-chart/templates/recommendationservice.yaml` to ensure valid manifest is rendered


### Related PRs or Issues 
N/A
