### PR TITLE
added imagepullsecrets to service accounts in helm chart

### DIFF
--- a/helm-chart/templates/adservice.yaml
+++ b/helm-chart/templates/adservice.yaml
@@ -25,6 +25,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- if .Values.serviceAccounts.imagePullSecrets }}
+imagePullSecrets:
+  {{ toYaml .Values.serviceAccounts.imagePullSecrets | indent 2 }}
+{{- end }}
 ---
 {{- end }}
 apiVersion: apps/v1

--- a/helm-chart/templates/cartservice.yaml
+++ b/helm-chart/templates/cartservice.yaml
@@ -23,6 +23,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if .Values.serviceAccounts.imagePullSecrets }}
+imagePullSecrets:
+  {{ toYaml .Values.serviceAccounts.imagePullSecrets | indent 2 }}
+{{- end }}
 ---
 {{- end }}
 apiVersion: apps/v1

--- a/helm-chart/templates/checkoutservice.yaml
+++ b/helm-chart/templates/checkoutservice.yaml
@@ -25,6 +25,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- if .Values.serviceAccounts.imagePullSecrets }}
+imagePullSecrets:
+  {{ toYaml .Values.serviceAccounts.imagePullSecrets | indent 2 }}
+{{- end }}
 ---
 {{- end }}
 apiVersion: apps/v1

--- a/helm-chart/templates/currencyservice.yaml
+++ b/helm-chart/templates/currencyservice.yaml
@@ -25,6 +25,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- if .Values.serviceAccounts.imagePullSecrets }}
+imagePullSecrets:
+  {{ toYaml .Values.serviceAccounts.imagePullSecrets | indent 2 }}
+{{- end }}
 ---
 {{- end }}
 apiVersion: apps/v1

--- a/helm-chart/templates/emailservice.yaml
+++ b/helm-chart/templates/emailservice.yaml
@@ -25,6 +25,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- if .Values.serviceAccounts.imagePullSecrets }}
+imagePullSecrets:
+  {{ toYaml .Values.serviceAccounts.imagePullSecrets | indent 2 }}
+{{- end }}
 ---
 {{- end }}
 apiVersion: apps/v1

--- a/helm-chart/templates/frontend.yaml
+++ b/helm-chart/templates/frontend.yaml
@@ -25,6 +25,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- if .Values.serviceAccounts.imagePullSecrets }}
+imagePullSecrets:
+  {{ toYaml .Values.serviceAccounts.imagePullSecrets | indent 2 }}
+{{- end }}
 ---
 {{- end }}
 apiVersion: apps/v1

--- a/helm-chart/templates/loadgenerator.yaml
+++ b/helm-chart/templates/loadgenerator.yaml
@@ -25,6 +25,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- if .Values.serviceAccounts.imagePullSecrets }}
+imagePullSecrets:
+  {{ toYaml .Values.serviceAccounts.imagePullSecrets | indent 2 }}
+{{- end }}
 ---
 {{- end }}
 apiVersion: apps/v1

--- a/helm-chart/templates/opentelemetry-collector.yaml
+++ b/helm-chart/templates/opentelemetry-collector.yaml
@@ -25,6 +25,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- if .Values.serviceAccounts.imagePullSecrets }}
+imagePullSecrets:
+  {{ toYaml .Values.serviceAccounts.imagePullSecrets | indent 2 }}
+{{- end }}
 ---
 {{- end }}
 apiVersion: apps/v1

--- a/helm-chart/templates/paymentservice.yaml
+++ b/helm-chart/templates/paymentservice.yaml
@@ -25,6 +25,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- if .Values.serviceAccounts.imagePullSecrets }}
+imagePullSecrets:
+  {{ toYaml .Values.serviceAccounts.imagePullSecrets | indent 2 }}
+{{- end }}
 ---
 {{- end }}
 apiVersion: apps/v1

--- a/helm-chart/templates/productcatalogservice.yaml
+++ b/helm-chart/templates/productcatalogservice.yaml
@@ -25,6 +25,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- if .Values.serviceAccounts.imagePullSecrets }}
+imagePullSecrets:
+  {{ toYaml .Values.serviceAccounts.imagePullSecrets | indent 2 }}
+{{- end }}
 ---
 {{- end }}
 apiVersion: apps/v1

--- a/helm-chart/templates/recommendationservice.yaml
+++ b/helm-chart/templates/recommendationservice.yaml
@@ -25,6 +25,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- if .Values.serviceAccounts.imagePullSecrets }}
+imagePullSecrets:
+  {{ toYaml .Values.serviceAccounts.imagePullSecrets | indent 2 }}
+{{- end }}
 ---
 {{- end }}
 apiVersion: apps/v1

--- a/helm-chart/templates/shippingservice.yaml
+++ b/helm-chart/templates/shippingservice.yaml
@@ -25,6 +25,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
+{{- if .Values.serviceAccounts.imagePullSecrets }}
+imagePullSecrets:
+  {{ toYaml .Values.serviceAccounts.imagePullSecrets | indent 2 }}
+{{- end }}
 ---
 {{- end }}
 apiVersion: apps/v1


### PR DESCRIPTION
### Background 
Added ability to add imagePullSecrets for service accounts if requried to specify it


### Testing Procedure
- Test as tested before to check it worked without specifying imagePullSecrets
- Create secret 
kubectl create secret generic $DOCKERCONFIG_SECRET_NAME \
  --from-file=.dockerconfigjson=$XDG_RUNTIME_DIR/containers/auth.json \
  --type=kubernetes.io/dockerconfigjson \
  -n your-namespace

do helm install providing values like in this argo app

```yaml
    helm:
      parameters:
      values: |
        serviceAccounts:
          imagePullSecrets:
          - name: secret-name
```
