### PR TITLE
AWS EKS IaC + Observability for Online Boutique

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,67 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# --- OS / IDE noise ---
 .DS_Store
-.eclipse.buildship.core.prefs
-.gradle/
 .idea/
-.kubernetes-manifests-*/
-.project
-.skaffold-*.yaml
-.terraform.lock.hcl
-.terraform/*
-.venv/
-.vs/
 .vscode/
+.vs/
 *.iml
 *.ipr
 *.iws
-*.pyc
 *.swp
-*.tfstate*
-*.tfvars
 *~
 bin/
 build/
-Dockerfile.pip
-node_modules/
 obj/
 pkg/
-release/wi-kubernetes-manifests.yaml
+
+# Eclipse / Gradle
+.project
+.gradle/
+.eclipse.buildship.core.prefs
+
+# Python
+__pycache__/
+*.pyc
+.venv/
+
+# Node
+node_modules/
+
+# Go / Vendor
 vendor/
+
+# Skaffold / Kubernetes
+.skaffold-*.yaml
+.kubernetes-manifests-*/
+release/wi-kubernetes-manifests.yaml
+
+# Docker
+Dockerfile.pip
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Important: keep lock file versioned
+!.terraform.lock.hcl

--- a/infra/aws-tf/.terraform.lock.hcl
+++ b/infra/aws-tf/.terraform.lock.hcl
@@ -1,0 +1,153 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/alekc/kubectl" {
+  version     = "2.1.3"
+  constraints = "2.1.3"
+  hashes = [
+    "h1:qIzszbVEM8XaNmSyNnQd/G+h+DcFYTmPaSh/2IM6yqs=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = ">= 4.33.0, ~> 5.0, >= 5.79.0, >= 5.95.0, < 6.0.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.3.7"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:iZ27qylcH/2bs685LJTKOKcQ+g7cF3VwN3kHMrzm4Ow=",
+    "zh:06f1c54e919425c3139f8aeb8fcf9bceca7e560d48c9f0c1e3bb0a8ad9d9da1e",
+    "zh:0e1e4cf6fd98b019e764c28586a386dc136129fef50af8c7165a067e7e4a31d5",
+    "zh:1871f4337c7c57287d4d67396f633d224b8938708b772abfc664d1f80bd67edd",
+    "zh:2b9269d91b742a71b2248439d5e9824f0447e6d261bfb86a8a88528609b136d1",
+    "zh:3d8ae039af21426072c66d6a59a467d51f2d9189b8198616888c1b7fc42addc7",
+    "zh:3ef4e2db5bcf3e2d915921adced43929214e0946a6fb11793085d9a48995ae01",
+    "zh:42ae54381147437c83cbb8790cc68935d71b6357728a154109d3220b1beb4dc9",
+    "zh:4496b362605ae4cbc9ef7995d102351e2fe311897586ffc7a4a262ccca0c782a",
+    "zh:652a2401257a12706d32842f66dac05a735693abcb3e6517d6b5e2573729ba13",
+    "zh:7406c30806f5979eaed5f50c548eced2ea18ea121e01801d2f0d4d87a04f6a14",
+    "zh:7848429fd5a5bcf35f6fee8487df0fb64b09ec071330f3ff240c0343fe2a5224",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.13"
+  hashes = [
+    "h1:K5FEjxvDnxb1JF1kG1xr8J3pNGxoaR3Z0IBG9Csm/Is=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.29"
+  hashes = [
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.13.1"
+  constraints = ">= 0.9.0"
+  hashes = [
+    "h1:+W+DMrVoVnoXo3f3M4W+OpZbkCrUn6PnqDF33D2Cuf0=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.1.0"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:Ka8mEwRFXBabR33iN/WTIEW6RP0z13vFsDlwn11Pf2I=",
+    "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
+    "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
+    "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",
+    "zh:35b5dc95bc75f0b3b9c5ce54d4d7600c1ebc96fbb8dfca174536e8bf103c8cdc",
+    "zh:38aa27c6a6c98f1712aa5cc30011884dc4b128b4073a4a27883374bfa3ec9fac",
+    "zh:51fb247e3a2e88f0047cb97bb9df7c228254a3b3021c5534e4563b4007e6f882",
+    "zh:62b981ce491e38d892ba6364d1d0cdaadcee37cc218590e07b310b1dfa34be2d",
+    "zh:bc8e47efc611924a79f947ce072a9ad698f311d4a60d0b4dfff6758c912b7298",
+    "zh:c149508bd131765d1bc085c75a870abb314ff5a6d7f5ac1035a8892d686b6297",
+    "zh:d38d40783503d278b63858978d40e07ac48123a2925e1a6b47e62179c046f87a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
+  ]
+}

--- a/infra/aws-tf/main.tf
+++ b/infra/aws-tf/main.tf
@@ -1,0 +1,520 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+locals {
+  tags = { 
+    Project = "OnlineBoutique", 
+    Owner = "Adithya", 
+    TTL = "today",
+    Environment = "demo",
+    CostCenter = "RD"
+  }
+}
+
+# ---------------- VPC ----------------
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name                    = var.name
+  cidr                    = "10.0.0.0/16"
+  azs                     = var.az
+  public_subnets          = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_subnets         = ["10.0.11.0/24", "10.0.12.0/24"]
+  
+  enable_nat_gateway      = true
+  single_nat_gateway      = true
+  enable_dns_support      = true
+  enable_dns_hostnames    = true
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${var.name}" = "shared"
+    "kubernetes.io/role/elb"            = "1"
+  }
+  
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${var.name}" = "owned"
+    "kubernetes.io/role/internal-elb"   = "1"
+  }
+
+  tags = local.tags
+}
+
+# ---------------- EKS ----------------
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  cluster_name                   = var.name
+  cluster_version                = "1.29"
+  cluster_endpoint_public_access = true
+  vpc_id                         = module.vpc.vpc_id
+  subnet_ids                     = module.vpc.private_subnets  # Use private subnets
+  enable_irsa                    = true
+
+  enable_cluster_creator_admin_permissions = true
+  cluster_enabled_log_types                = ["api", "audit", "authenticator"]
+  create_cloudwatch_log_group              = false
+
+  tags = local.tags
+
+  eks_managed_node_groups = {
+    general = {
+      capacity_type  = "ON_DEMAND"
+      instance_types = ["t3.xlarge", "t3a.xlarge"]  # 4 vCPU / 16 GiB - better for heavy workloads
+      desired_size   = 4    # Increased from 3
+      min_size       = 3    # Increased from 2  
+      max_size       = 6    # Room for scaling
+      
+      labels = { workload = "general" }
+      tags   = local.tags
+      
+      # Enable cluster autoscaler tags
+      tags = merge(local.tags, {
+        "k8s.io/cluster-autoscaler/enabled"                = "true"
+        "k8s.io/cluster-autoscaler/${var.name}"           = "owned"
+      })
+    }
+  }
+}
+
+# ---------------- Cost Monitoring ----------------
+resource "aws_cloudwatch_metric_alarm" "daily_cost_alert" {
+  alarm_name          = "daily-cost-alert-${var.name}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "EstimatedCharges"
+  namespace           = "AWS/Billing"
+  period              = "86400"
+  statistic           = "Maximum"
+  threshold           = "30"     # Lowered from $50 to $30 for tighter control
+  alarm_description   = "Daily AWS cost exceeded $30 for ${var.name} cluster"
+  
+  dimensions = {
+    Currency = "USD"
+  }
+
+  tags = local.tags
+}
+
+# ------------- EBS CSI addon -------------
+resource "aws_eks_addon" "ebs_csi" {
+  cluster_name                = module.eks.cluster_name
+  addon_name                  = "aws-ebs-csi-driver"
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+  service_account_role_arn    = aws_iam_role.ebs_csi_irsa.arn
+  tags                        = local.tags
+  depends_on                  = [module.eks, aws_iam_role_policy_attachment.ebs_csi_attach]
+}
+
+
+
+# ------- Standard StorageClass alias (for PVCs that request it) -------
+resource "kubernetes_storage_class_v1" "standard_alias" {
+  metadata { name = "standard" }
+  storage_provisioner   = "ebs.csi.aws.com"
+  reclaim_policy        = "Delete"
+  volume_binding_mode   = "WaitForFirstConsumer"
+  allow_volume_expansion = true
+  parameters = { type = "gp3", fsType = "ext4" }
+  depends_on = [aws_eks_addon.ebs_csi]
+}
+
+# ------- Default gp3 StorageClass (CSI) -------
+resource "kubernetes_storage_class_v1" "gp3" {
+  metadata {
+    name = "gp3"
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
+  }
+  storage_provisioner    = "ebs.csi.aws.com"
+  reclaim_policy         = "Delete"
+  volume_binding_mode    = "WaitForFirstConsumer"
+  allow_volume_expansion = true
+  parameters = {
+    type   = "gp3"
+    fsType = "ext4"
+  }
+  depends_on = [aws_eks_addon.ebs_csi]
+}
+
+# ---- IRSA for EBS CSI ----
+data "aws_iam_policy_document" "ebs_csi_trust" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    effect  = "Allow"
+    principals { 
+      type        = "Federated" 
+      identifiers = [module.eks.oidc_provider_arn] 
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ebs_csi_irsa" {
+  name               = "${var.name}-ebs-csi-irsa"
+  assume_role_policy = data.aws_iam_policy_document.ebs_csi_trust.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ebs_csi_attach" {
+  role       = aws_iam_role.ebs_csi_irsa.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+# ---------------- Namespaces ----------------
+resource "kubernetes_namespace" "monitoring" {
+  metadata { name = "monitoring" }
+  depends_on = [module.eks]
+}
+resource "kubernetes_namespace" "logging" {
+  metadata { name = "logging" }
+  depends_on = [module.eks]
+}
+resource "kubernetes_namespace" "tracing" {
+  metadata { name = "tracing" }
+  depends_on = [module.eks]
+}
+
+resource "helm_release" "kps" {
+  name       = "kube-prom"
+  namespace  = kubernetes_namespace.monitoring.metadata[0].name
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "kube-prometheus-stack"
+  timeout    = 3600  # Increased timeout
+  wait       = true
+  
+
+  values = [yamlencode({
+    admissionWebhooks = { patch = { enabled = false } }
+
+grafana = {
+  adminUser     = "admin"
+  adminPassword = "Admin123!"
+  service       = { type = "LoadBalancer" }
+
+  # expose /metrics and protect it with basic auth
+  "grafana.ini" = {
+    metrics = {
+      enabled             = true
+    }
+  }
+
+  metrics = { enabled = true }
+
+  serviceMonitor = {
+    enabled       = true
+    path          = "/metrics"
+    interval      = "30s"
+    scrapeTimeout = "10s"
+    labels        = { release = "kube-prom" }
+    basicAuth = {
+      username = { name = "kube-prom-grafana", key = "admin-user" }
+      password = { name = "kube-prom-grafana", key = "admin-password" }
+    }
+    jobLabel = "app.kubernetes.io/name"
+  }
+
+  resources = {
+    requests = { cpu = "200m", memory = "512Mi" }
+    limits   = { cpu = "500m", memory = "1Gi" }
+  }
+
+  persistence = {
+    enabled          = true
+    size             = "2Gi"
+    storageClassName = "gp3"
+  }
+
+  additionalDataSources = [
+    { name = "Loki",  type = "loki",  access = "proxy", url = "http://loki.logging.svc.cluster.local:3100" },
+    { name = "Tempo", type = "tempo", access = "proxy", url = "http://tempo.tracing.svc.cluster.local:3100" }
+  ]
+}
+
+    prometheus = {
+      prometheusSpec = {
+        retention      = "24h"  # Increased from 12h
+        scrapeInterval = "30s"
+        
+        # Significantly increased Prometheus resources
+        resources = {
+          requests = { cpu = "300m", memory = "1Gi" }   # Much higher
+          limits   = { cpu = "1", memory = "2Gi" }      # Better limits
+        }
+        
+        storageSpec = {
+          volumeClaimTemplate = {
+            spec = {
+              storageClassName = "gp3"
+              accessModes      = ["ReadWriteOnce"]
+              resources        = { requests = { storage = "20Gi" } }  # Increased storage
+            }
+          }
+        }
+      }
+    }
+
+    alertmanager = {
+      alertmanagerSpec = {
+        resources = {
+          requests = { cpu = "50m", memory = "128Mi" }   # Slightly increased
+          limits   = { cpu = "200m", memory = "256Mi" }
+        }
+        storage = {
+          volumeClaimTemplate = {
+            spec = {
+              storageClassName = "gp3"
+              accessModes      = ["ReadWriteOnce"]
+              resources        = { requests = { storage = "2Gi" } }
+            }
+          }
+        }
+      }
+    }
+
+    # Optimized component resources
+    kubeStateMetrics = {
+      resources = {
+        requests = { cpu = "100m", memory = "200Mi" }  # Increased
+        limits   = { cpu = "300m", memory = "400Mi" }
+      }
+    }
+
+    prometheusOperator = {
+      resources = {
+        requests = { cpu = "100m", memory = "200Mi" }  # Increased
+        limits   = { cpu = "300m", memory = "400Mi" }
+      }
+    }
+
+    nodeExporter = {
+      resources = {
+        requests = { cpu = "50m", memory = "64Mi" }    # Slightly increased
+        limits   = { cpu = "100m", memory = "128Mi" }
+      }
+    }
+  })]
+
+  depends_on = [
+    module.eks,
+    kubernetes_namespace.monitoring,
+    aws_eks_addon.ebs_csi,
+    kubernetes_storage_class_v1.gp3
+  ]
+}
+
+# ---------------- Metrics Server ----------------
+resource "helm_release" "metrics_server" {
+  name       = "metrics-server"
+  namespace  = "kube-system"
+  repository = "https://kubernetes-sigs.github.io/metrics-server/"
+  chart      = "metrics-server"
+  version    = "3.13.0"  # Updated to latest stable version
+  wait       = true
+  
+  values = [yamlencode({
+    args = [
+      "--kubelet-preferred-address-types=InternalIP,Hostname,InternalDNS,ExternalDNS,ExternalIP",
+      "--kubelet-insecure-tls"
+    ]
+  })]
+  
+  depends_on = [module.eks]
+}
+
+# --------------- Logs: Loki + Promtail ---------------
+resource "helm_release" "loki_stack" {
+  name       = "loki"
+  namespace  = kubernetes_namespace.logging.metadata[0].name
+  repository = "https://grafana.github.io/helm-charts"
+  chart      = "loki-stack"
+  timeout    = 2400
+
+  values = [yamlencode({
+    loki = {
+      auth_enabled = false
+      
+      # Add persistence to Loki
+      persistence = {
+        enabled      = true
+        size         = "10Gi"
+        storageClassName = "gp3"
+      }
+      
+      # Resource limits for Loki
+      resources = {
+        requests = { cpu = "100m", memory = "256Mi" }
+        limits   = { cpu = "300m", memory = "512Mi" }
+      }
+    }
+    
+    grafana = { enabled = false }
+    
+    promtail = {
+      enabled = true
+      resources = {
+        requests = { cpu = "50m", memory = "64Mi" }
+        limits   = { cpu = "100m", memory = "128Mi" }
+      }
+    }
+  })]
+
+  depends_on = [module.eks, kubernetes_namespace.logging]
+}
+
+# ---------------- Traces: Tempo ----------------
+resource "helm_release" "tempo" {
+  name       = "tempo"
+  namespace  = kubernetes_namespace.tracing.metadata[0].name
+  repository = "https://grafana.github.io/helm-charts"
+  chart      = "tempo"
+  timeout    = 2400
+
+  values = [yamlencode({
+    # Enable persistence for Tempo
+    persistence = {
+      enabled = true
+      size    = "10Gi"
+      storageClassName = "gp3"
+    }
+    
+    # Resource allocation for Tempo
+    resources = {
+      requests = { cpu = "100m", memory = "256Mi" }
+      limits   = { cpu = "300m", memory = "512Mi" }
+    }
+  })]
+
+  depends_on = [module.eks, kubernetes_namespace.tracing]
+}
+
+# --------------- OTel Collector ----------------
+resource "helm_release" "otel" {
+  name       = "otel-collector"
+  namespace  = kubernetes_namespace.tracing.metadata[0].name
+  repository = "https://open-telemetry.github.io/opentelemetry-helm-charts"
+  chart      = "opentelemetry-collector"
+  timeout    = 2400
+  wait       = true
+
+  values = [yamlencode({
+    mode         = "deployment"
+    replicaCount = 1
+    image        = { repository = "otel/opentelemetry-collector-contrib" }  # This is required!
+    
+    # Let the Helm chart use its default config, just override the Tempo endpoint
+    config = {
+      exporters = {
+        otlp = { 
+          endpoint = "tempo.tracing.svc.cluster.local:4317", 
+          tls = { insecure = true } 
+        }
+      }
+    }
+  })]
+
+  depends_on = [module.eks, kubernetes_namespace.tracing, helm_release.tempo]
+}
+
+# ---------- Beyla eBPF auto-instrumentation ----------
+resource "helm_release" "beyla" {
+  name       = "beyla"
+  namespace  = kubernetes_namespace.tracing.metadata[0].name
+  repository = "https://grafana.github.io/helm-charts"
+  chart      = "beyla"
+  timeout    = 2400  # Increase from default 900s to 30 minutes
+  wait       = true
+
+  values = [yamlencode({
+    config = {
+      discovery = {
+        instrument = [
+          { k8s_namespace = "default" }
+        ]
+      }
+      otel = {
+        traces_export = {
+          endpoint = "http://otel-collector.tracing.svc.cluster.local:4318"
+        }
+        service_name = "beyla-ebpf"
+      }
+    }
+  })]
+
+  depends_on = [module.eks, kubernetes_namespace.tracing, helm_release.otel]
+}
+
+# ------- Deploy Online Boutique (Split Multi-Doc) -------
+data "kubectl_file_documents" "online_boutique" {
+  content = file("${path.module}/../../release/kubernetes-manifests.yaml")
+}
+
+resource "kubectl_manifest" "online_boutique" {
+  for_each          = data.kubectl_file_documents.online_boutique.manifests
+  yaml_body         = each.value
+  server_side_apply = true
+  apply_only        = true
+  wait_for_rollout  = false
+  
+  depends_on = [
+    module.eks,
+    aws_eks_addon.ebs_csi,
+    kubernetes_storage_class_v1.gp3,
+    helm_release.kps,
+    helm_release.loki_stack,
+    helm_release.tempo,
+    helm_release.otel,
+    helm_release.beyla
+  ]
+}
+
+
+# ---------------- Read LB hostnames ----------------
+
+# delay to let ELB DNS publish
+resource "time_sleep" "lb_settle" {
+  depends_on      = [kubectl_manifest.online_boutique]
+  create_duration = "60s"
+}
+
+data "kubernetes_service" "grafana" {
+  metadata {
+    name      = "kube-prom-grafana"
+    namespace = "monitoring"
+  }
+  depends_on = [time_sleep.lb_settle]
+}
+
+# keep only this one block
+data "kubernetes_service" "frontend" {
+  metadata {
+    name      = "frontend-external"
+    namespace = "default"
+  }
+  depends_on = [time_sleep.lb_settle]
+}

--- a/infra/aws-tf/outputs.tf
+++ b/infra/aws-tf/outputs.tf
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+output "grafana_url" {
+  value       = "http://${try(data.kubernetes_service.grafana.status[0].load_balancer[0].ingress[0].hostname, "")}"
+  description = "Grafana URL"
+}
+
+output "app_url" {
+  value       = "http://${try(data.kubernetes_service.frontend.status[0].load_balancer[0].ingress[0].hostname, "")}"
+  description = "Online Boutique URL"
+}

--- a/infra/aws-tf/providers.tf
+++ b/infra/aws-tf/providers.tf
@@ -1,0 +1,70 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+terraform {
+  required_version = ">= 1.5.0"
+   required_providers {
+    aws        = { source = "hashicorp/aws", version = "~> 5.0" }
+    kubernetes = { source = "hashicorp/kubernetes", version = "~> 2.29" }
+    helm       = { source = "hashicorp/helm", version = "~> 2.13" }
+    kubectl = {
+      source = "alekc/kubectl"
+      version = "2.1.3"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "tf-state-xebia-shared"
+    key            = "online-boutique/aws-tf/terraform.tfstate" # no variables allowed
+    region         = "ap-south-1"
+    dynamodb_table = "tf-locks-xebia-shared"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  region  = var.region
+  profile = var.aws_profile
+}
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name, "--region", var.region, "--profile", var.aws_profile]
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name, "--region", var.region, "--profile", var.aws_profile]
+    }
+  }
+}
+
+data "aws_eks_cluster_auth" "this" { name = module.eks.cluster_name }
+
+provider "kubectl" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}

--- a/infra/aws-tf/variables.tf
+++ b/infra/aws-tf/variables.tf
@@ -1,0 +1,33 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "name" {
+  type    = string
+  default = "online-boutique"
+}
+
+variable "region" {
+  type    = string
+  default = "ap-south-1"
+}
+
+variable "az" {
+  type    = list(string)
+  default = ["ap-south-1a", "ap-south-1b"]
+}
+
+variable "aws_profile" {
+  type    = string
+  default = "xebia-adithya"
+}


### PR DESCRIPTION
---

### Background

The original repo targets GKE. This PR adds a parallel, opt-in AWS path using Terraform to provision EKS plus a full observability stack (Prometheus/Grafana, Loki/Promtail, Tempo, OTel Collector, Beyla) and deploy the Online Boutique demo.

### Fixes

N/A (feature addition). Enables running the demo on AWS with one command.

### Change Summary

* `infra/aws-tf/` Terraform for:

  * VPC (2 public, 2 private subnets), NAT, tags
  * EKS (v1.29) with managed node group
  * IRSA + EBS CSI addon, default `gp3` StorageClasses
  * kube-prometheus-stack (Grafana LB, ServiceMonitor for /metrics)
  * Loki Stack (Promtail), Tempo, OTel Collector (OTLP to Tempo), Beyla eBPF
  * Online Boutique manifests (server-side apply; split multi-doc)
  * Outputs: ELB URLs for app and Grafana
* Remote state (S3) + locking (DynamoDB) backend (documented)
* Workspace-safe layout: state key includes `${terraform.workspace}`
* Tags for cost/audit: `Project, Owner, TTL, Environment, CostCenter`
* Helpful scripts/docs for teardown/rebuild (doc in README snippet below)
* `.gitignore` updated to exclude `.terraform/`, state files, IDE artifacts

### Additional Notes

* No secrets committed. Auth uses AWS profiles (`var.aws_profile`) and IAM exec for K8s providers.
* Multiple devs can share the repo safely via:

  * **Workspaces** (`terraform workspace select <name>`)
  * **Unique `var.name`** per env if you want separate clusters
  * Shared single cluster also supported (same workspace & profile)
* `gavinbunney/kubectl` provider is pinned; if registry hiccups occur, re-run `terraform init` (or swap to `alekc/kubectl` in a follow-up if maintainers prefer).

### Testing Procedure

1. **One-time (platform team):** create S3 bucket & DynamoDB table for state/locks:

   ```bash
   aws s3 mb s3://tf-state-xebia-shared --region ap-south-1
   aws dynamodb create-table --table-name tf-locks-xebia-shared \
     --attribute-definitions AttributeName=LockID,AttributeType=S \
     --key-schema AttributeName=LockID,KeyType=HASH \
     --billing-mode PAY_PER_REQUEST --region ap-south-1
   ```
2. **Init & workspace:**

   ```bash
   cd infra/aws-tf
   terraform workspace new adithya || terraform workspace select adithya
   terraform init
   ```
3. **Apply (no `-target`):**

   ```bash
   terraform apply -auto-approve \
     -var='name=online-boutique' \
     -var='region=ap-south-1' \
     -var='aws_profile=xebia-adithya'
   ```
4. **Kubeconfig for CLI (Terraform providers don’t need this, but kubectl does):**

   ```bash
   aws eks update-kubeconfig --profile xebia-adithya --region ap-south-1 --name online-boutique
   ```
5. **Verify:**

   ```bash
   terraform output app_url
   terraform output grafana_url
   # optional local checks
   kubectl -n monitoring port-forward svc/kube-prom-kube-prometheus-prometheus 9091:9090 &
   xdg-open 'http://127.0.0.1:9091/targets?search=grafana'
   ```
6. **Teardown (clean):**

   ```bash
   kubectl delete -f ../../release/kubernetes-manifests.yaml --ignore-not-found
   helm -n monitoring uninstall kube-prom || true
   helm -n logging uninstall loki || true
   helm -n tracing uninstall tempo otel-collector beyla || true
   helm -n kube-system uninstall metrics-server || true
   kubectl delete ns monitoring logging tracing --ignore-not-found
   terraform destroy -auto-approve
   ```

### Related PRs or Issues

* None. Follow-ups welcome for:

  * CI docs (skip Terraform apply in CI; lint/validate only)
  * Option to reuse existing VPC/subnets
  * Provider swap for `kubectl` if maintainers prefer only HashiCorp-namespace providers

---
