### PR TITLE
Downgrade grpc version in cartservice

### DIFF
--- a/src/cartservice/src/cartservice.csproj
+++ b/src/cartservice/src/cartservice.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.71.0" />
-    <PackageReference Include="Grpc.HealthCheck" Version="2.71.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.67.0" />
+    <PackageReference Include="Grpc.HealthCheck" Version="2.67.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.8" />
     <PackageReference Include="Google.Cloud.Spanner.Data" Version="5.1.0" />
     <PackageReference Include="Npgsql" Version="9.0.3" />


### PR DESCRIPTION
### Background 
Build fails on an Apple MacBook Air (M2)  with the following error:

```
 => [builder 4/6] RUN dotnet restore cartservice.csproj     -a arm64                                                                                                         5.6s
 => [builder 5/6] COPY . .                                                                                                                                                   0.0s 
 => ERROR [builder 6/6] RUN dotnet publish cartservice.csproj     -p:PublishSingleFile=true     -a arm64     --self-contained true     -p:PublishTrimmed=true     -p:TrimMo  3.9s 
------                                                                                                                                                                            
 > [builder 6/6] RUN dotnet publish cartservice.csproj     -p:PublishSingleFile=true     -a arm64     --self-contained true     -p:PublishTrimmed=true     -p:TrimMode=full     -c release     -o /cartservice:                                                                                                                                                     
0.419   Determining projects to restore...                                                                                                                                        
3.371   Restored /app/cartservice.csproj (in 2.77 sec).
3.695 /root/.nuget/packages/grpc.tools/2.71.0/build/_protobuf/Google.Protobuf.Tools.targets(291,5): error MSB6006: "/root/.nuget/packages/grpc.tools/2.71.0/tools/linux_arm64/protoc" exited with code 139. [/app/cartservice.csproj]
------
Dockerfile:23
--------------------
  22 |     COPY . .
  23 | >>> RUN dotnet publish cartservice.csproj \
  24 | >>>     -p:PublishSingleFile=true \
  25 | >>>     -a $TARGETARCH \
  26 | >>>     --self-contained true \
  27 | >>>     -p:PublishTrimmed=true \
  28 | >>>     -p:TrimMode=full \
  29 | >>>     -c release \
  30 | >>>     -o /cartservice
  31 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c dotnet publish cartservice.csproj     -p:PublishSingleFile=true     -a $TARGETARCH     --self-contained true     -p:PublishTrimmed=true     -p:TrimMode=full     -c release     -o /cartservice" did not complete successfully: exit code: 1
```

This has been reported to [grpc/grpc issues](https://github.com/grpc/grpc/issues/38538)

### Fixes 
<!-- Link the issue(s) this PR fixes-->
### Change Summary
Downgrade grpc to version 2.67

### Additional Notes
<!-- Any remaining concerns -->

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->
Successfully built on an Apple MacBook Air (M2). Deployed and running on my local Raspberry Pi 5 Kubernetes cluster.

### Related PRs or Issues 
[Regression against 2.68.1 - Grpc.Tools 2.69.0 stops working on ARM64](https://github.com/grpc/grpc/issues/38538)
