### PR TITLE
Add demo link for Alpine, Distroless or Scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Find **Protocol Buffers Descriptions** at the [`./protos` directory](/protos).
 
 ## Demos featuring Online Boutique
 
+- [alpine, distroless or scratch?](https://medium.com/google-cloud/alpine-distroless-or-scratch-caac35250e0b)
 - [Platform Engineering in action: Deploy the Online Boutique sample apps with Score and Humanitec](https://medium.com/p/d99101001e69)
 - [The new Kubernetes Gateway API with Istio and Anthos Service Mesh (ASM)](https://medium.com/p/9d64c7009cd)
 - [Use Azure Redis Cache with the Online Boutique sample on AKS](https://medium.com/p/981bd98b53f8)


### PR DESCRIPTION
This blog post is the documentation of the optimization done on the container images for all the Golang app of this project: https://github.com/GoogleCloudPlatform/microservices-demo/pull/2512, adding the link here though.