### PR TITLE
`golang:1.25.5`

### DIFF
--- a/src/checkoutservice/Dockerfile
+++ b/src/checkoutservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.25.4-alpine@sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /src

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.25.4-alpine@sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /src

--- a/src/productcatalogservice/Dockerfile
+++ b/src/productcatalogservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.25.4-alpine@sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/src/shippingservice/Dockerfile
+++ b/src/shippingservice/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.25.4-alpine@sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.5-alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /src


### PR DESCRIPTION
`golang:1.25.5` as base image of the `builder` target in `Dockerfile` to complete https://github.com/GoogleCloudPlatform/microservices-demo/pull/3160 and fix CVEs.

While writing this blog post [Security hardening of the OnlineBoutique sample apps with the Docker Hardened Images (DHI)](https://medium.com/google-cloud/security-hardening-of-the-onlineboutique-sample-apps-with-docker-hardened-images-dhi-ca1fad348343), I found out that the `go.mod` was updated recently there https://github.com/GoogleCloudPlatform/microservices-demo/pull/3179 but not the `Dockerfiles`, fixing this here with this PR.

`docker scout compare --ignore-unchanged --to checkout:1.25.4 checkout:1.25.5`:
```none
## Overview
  
                     │                    Analyzed Image                    │                   Comparison Image                   
  ───────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────
   Target            │  checkout:1.25.5                                     │  checkout:1.25.4                                     
     digest          │  5daa71234709                                        │  5261dc954ae0                                        
     tag             │  1.25.5                                              │  1.25.4                                              
     platform        │ linux/amd64                                          │ linux/amd64                                          
     provenance      │ https://github.com/mathieu-benoit/microservices-demo │ https://github.com/mathieu-benoit/microservices-demo 
                     │  31577bd1219a375dbcf185ebed57778c92f2e4a6            │  31577bd1219a375dbcf185ebed57778c92f2e4a6            
     vulnerabilities │    0C     0H     0M     0L                           │    0C     1H     1M     0L                           
                     │           -1     -1                                  │                                                      
     size            │ 6.7 MB (+378 B)                                      │ 6.7 MB                                               
     packages        │ 58                                                   │ 58                                                   
                     │                                                      │

## Packages and Vulnerabilities
  
  
    ⎌    1 packages changed (↑ 1 upgraded, ↓ 0 downgraded)  
        54 packages unchanged
  
  
    - 2 vulnerabilities removed
  
  
     Package  Type    Version  Compared Version  
  
  ↑  stdlib   golang  1.25.5   1.25.4            
     ├─  -  HIGH         CVE-2025-61729  [https://scout.docker.com/v/CVE-2025-61729]  
     │                   7.5    
     └─  -  MEDIUM       CVE-2025-61727  [https://scout.docker.com/v/CVE-2025-61727]  
                         6.5
```
