### PR TITLE
Image Version updated to avoid image pullbackoff error.

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: gcr.io/google-samples/microservices-demo/adservice:latest
+        image: gcr.io/google-samples/microservices-demo/adservice:v0.10.1
         ports:
         - containerPort: 9555
         env:

--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: adservice
+        image: gcr.io/google-samples/microservices-demo/adservice:latest
         ports:
         - containerPort: 9555
         env:

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: cartservice
+        image: gcr.io/google-samples/microservices-demo/cartservice:v0.10.1
         ports:
         - containerPort: 7070
         env:

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -42,7 +42,7 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
-          image: checkoutservice
+          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.10.1
           ports:
           - containerPort: 5050
           readinessProbe:

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: currencyservice
+        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.10.1
         ports:
         - name: grpc
           containerPort: 7000

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: emailservice
+        image: gcr.io/google-samples/microservices-demo/emailservice:v0.10.1
         ports:
         - containerPort: 8080
         env:

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -44,7 +44,7 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
-          image: frontend
+          image: gcr.io/google-samples/microservices-demo/frontend:v0.10.1
           ports:
           - containerPort: 8080
           readinessProbe:

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -127,7 +127,7 @@ metadata:
   labels:
     app: frontend
 spec:
-  type: LoadBalancer
+  type: NodePort
   selector:
     app: frontend
   ports:

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: paymentservice
+        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.10.1
         ports:
         - containerPort: 50051
         env:

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: productcatalogservice
+        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.10.1
         ports:
         - containerPort: 3550
         env:

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: recommendationservice
+        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.10.1
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -42,7 +42,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: shippingservice
+        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.10.1
         ports:
         - containerPort: 50051
         env:


### PR DESCRIPTION
<div _ngcontent-ng-c2167269253="" class="container"><message-content _ngcontent-ng-c2167269253="" _nghost-ng-c1150074581="" id="message-content-id-r_4e3561cb26beaa01" class="ng-star-inserted"><div _ngcontent-ng-c1150074581="" inline-copy-host="" class="markdown markdown-main-panel enable-updated-hr-color" id="model-response-message-contentr_4e3561cb26beaa01" aria-live="polite" aria-busy="false" dir="ltr" style="--animation-duration: 400ms; --fade-animation-function: linear;"><h3 data-path-to-node="3">Background</h3><p data-path-to-node="4">Previously, the Kubernetes manifest files used short image names (e.g., <code data-path-to-node="4" data-index-in-node="72">image: adservice</code>). This configuration caused <code data-path-to-node="4" data-index-in-node="117">ImagePullBackOff</code> errors when deployed on a remote cluster (like AWS EC2) because Kubernetes defaulted to looking for these images on Docker Hub, where they do not exist. The manifests were missing the specific container registry URL.</p><h3 data-path-to-node="5">Fixes</h3><p data-path-to-node="6">Fixes <code data-path-to-node="6" data-index-in-node="6">ImagePullBackOff</code> errors in <code data-path-to-node="6" data-index-in-node="33">kubernetes-manifests</code>.</p><h3 data-path-to-node="7">Change Summary</h3><p data-path-to-node="8">Updated all microservice deployment manifests to use the official Google Container Registry (<code data-path-to-node="8" data-index-in-node="93">gcr.io</code>) paths and pinned them to version <code data-path-to-node="8" data-index-in-node="134">v0.10.1</code> to ensure stability.</p><div class="horizontal-scroll-wrapper"><div class="table-block-component"><response-element class="" ng-version="0.0.0-PLACEHOLDER"><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!---->

| Service Name | Correct Image URL |
| **adservice** | `gcr.io/google-samples/microservices-demo/adservice:v0.10.1` |
| **cartservice** | `gcr.io/google-samples/microservices-demo/cartservice:v0.10.1` |
| **checkoutservice** | `gcr.io/google-samples/microservices-demo/checkoutservice:v0.10.1` |
| **currencyservice** | `gcr.io/google-samples/microservices-demo/currencyservice:v0.10.1` |
| **emailservice** | `gcr.io/google-samples/microservices-demo/emailservice:v0.10.1` |
| **frontend** | `gcr.io/google-samples/microservices-demo/frontend:v0.10.1` |
| **paymentservice** | `gcr.io/google-samples/microservices-demo/paymentservice:v0.10.1` |
| **productcatalog** | `gcr.io/google-samples/microservices-demo/productcatalogservice:v0.10.1` |
| **recommendation** | `gcr.io/google-samples/microservices-demo/recommendationservice:v0.10.1` |
| **shippingservice** | `gcr.io/google-samples/microservices-demo/shippingservice:v0.10.1` |

</div><div _ngcontent-ng-c2422099954="" hide-from-message-actions="" class="table-footer hide-from-message-actions"><!----><button _ngcontent-ng-c2422099954="" mat-icon-button="" mattooltip="Copy table" aria-label="Copy table" data-test-id="copy-table-button" class="mdc-icon-button mat-mdc-icon-button mat-mdc-button-base mat-mdc-tooltip-trigger copy-button mat-unthemed ng-star-inserted" mat-ripple-loader-uninitialized="" mat-ripple-loader-class-name="mat-mdc-button-ripple" mat-ripple-loader-centered="" jslog="276666;track:generic_click,impression;BardVeMetadataKey:[[&quot;r_4e3561cb26beaa01&quot;,&quot;c_168583daf2e0b50c&quot;,null,null,null,null,null,null,1,null,null,null,0]]"><span class="mat-mdc-button-persistent-ripple mdc-icon-button__ripple"></span><mat-icon _ngcontent-ng-c2422099954="" role="img" fonticon="content_copy" class="mat-icon notranslate gds-icon-l google-symbols mat-ligature-font mat-icon-no-color" aria-hidden="true" data-mat-icon-type="font" data-mat-icon-name="content_copy"></mat-icon><span class="mat-focus-indicator"></span><span class="mat-mdc-button-touch-target"></span></button><!----><!----></div></div><!----></table-block><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----></response-element></div></div><h3 data-path-to-node="10">Additional Notes</h3><p data-path-to-node="11">The <code data-path-to-node="11" data-index-in-node="4">redis</code> image remains as <code data-path-to-node="11" data-index-in-node="27">redis:alpine</code> because it is a standard image available on the public Docker Hub.</p><h3 data-path-to-node="12">Testing Procedure</h3><ol start="1" data-path-to-node="13"><li><p data-path-to-node="13,0,0">Apply the updated manifests: <code data-path-to-node="13,0,0" data-index-in-node="29">kubectl apply -f ./kubernetes-manifests</code></p></li><li><p data-path-to-node="13,1,0">Monitor pod status: <code data-path-to-node="13,1,0" data-index-in-node="20">kubectl get pods</code></p></li><li><p data-path-to-node="13,2,0">Verify that all pods transition from <code data-path-to-node="13,2,0" data-index-in-node="37">ImagePullBackOff</code> or <code data-path-to-node="13,2,0" data-index-in-node="57">Pending</code> to <code data-path-to-node="13,2,0" data-index-in-node="68">Running</code> state.</p></li><li><p data-path-to-node="13,3,0">(Optional) Access the frontend via NodePort or LoadBalancer to confirm the application is live.</p></li></ol><h3 data-path-to-node="14">Related PRs or Issues</h3><p data-path-to-node="15">N/A</p></div></message-content><!----></div>