### PR TITLE
feat: structured health check endpoints with dependency status

### DIFF
--- a/src/frontend/healthcheck/healthcheck.go
+++ b/src/frontend/healthcheck/healthcheck.go
@@ -1,0 +1,191 @@
+// Package healthcheck provides structured health check endpoints that report
+// per-dependency status with an overall service health roll-up.
+//
+// Each dependency checker runs with a timeout and contributes to the aggregate
+// status:
+//
+//	healthy   — all dependencies are reachable
+//	degraded  — at least one non-critical dependency is down
+//	unhealthy — at least one critical dependency is down
+package healthcheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+)
+
+// Status represents the health state of a service or dependency.
+type Status string
+
+const (
+	StatusHealthy   Status = "healthy"
+	StatusDegraded  Status = "degraded"
+	StatusUnhealthy Status = "unhealthy"
+)
+
+// DependencyCheck defines a single dependency health probe.
+type DependencyCheck struct {
+	// Name is a human-readable identifier (e.g. "product-catalog", "redis").
+	Name string
+	// Critical marks the dependency as required for the service to function.
+	// If a critical dependency is unhealthy the overall status is unhealthy.
+	Critical bool
+	// Check performs the actual health probe. Return nil for healthy.
+	Check func(ctx context.Context) error
+}
+
+// DependencyResult is the probe result for a single dependency.
+type DependencyResult struct {
+	Name     string `json:"name"`
+	Status   Status `json:"status"`
+	Critical bool   `json:"critical"`
+	Latency  string `json:"latency"`
+	Error    string `json:"error,omitempty"`
+}
+
+// HealthResponse is the JSON body returned by the health endpoint.
+type HealthResponse struct {
+	Status       Status             `json:"status"`
+	Service      string             `json:"service"`
+	Version      string             `json:"version"`
+	Timestamp    string             `json:"timestamp"`
+	Dependencies []DependencyResult `json:"dependencies"`
+}
+
+// Checker holds the configuration for the structured health check.
+type Checker struct {
+	ServiceName  string
+	Version      string
+	Dependencies []DependencyCheck
+	Timeout      time.Duration // per-dependency timeout
+}
+
+// NewChecker creates a Checker with sensible defaults.
+func NewChecker(serviceName, version string) *Checker {
+	return &Checker{
+		ServiceName: serviceName,
+		Version:     version,
+		Timeout:     3 * time.Second,
+	}
+}
+
+// AddDependency registers a dependency health check.
+func (c *Checker) AddDependency(dep DependencyCheck) {
+	c.Dependencies = append(c.Dependencies, dep)
+}
+
+// AddGRPCDependency is a convenience helper that checks whether a gRPC
+// client connection is in a READY or IDLE state.
+func (c *Checker) AddGRPCDependency(name string, conn *grpc.ClientConn, critical bool) {
+	c.AddDependency(DependencyCheck{
+		Name:     name,
+		Critical: critical,
+		Check: func(ctx context.Context) error {
+			if conn == nil {
+				return fmt.Errorf("connection is nil")
+			}
+			state := conn.GetState()
+			if state == connectivity.Ready || state == connectivity.Idle {
+				return nil
+			}
+			return fmt.Errorf("connection state: %s", state.String())
+		},
+	})
+}
+
+// Run executes all dependency checks concurrently and returns the aggregate
+// response.
+func (c *Checker) Run(ctx context.Context) HealthResponse {
+	results := make([]DependencyResult, len(c.Dependencies))
+	var wg sync.WaitGroup
+
+	for i, dep := range c.Dependencies {
+		wg.Add(1)
+		go func(idx int, d DependencyCheck) {
+			defer wg.Done()
+
+			checkCtx, cancel := context.WithTimeout(ctx, c.Timeout)
+			defer cancel()
+
+			start := time.Now()
+			err := d.Check(checkCtx)
+			latency := time.Since(start)
+
+			result := DependencyResult{
+				Name:     d.Name,
+				Critical: d.Critical,
+				Latency:  latency.Round(time.Millisecond).String(),
+			}
+			if err != nil {
+				result.Status = StatusUnhealthy
+				result.Error = err.Error()
+			} else {
+				result.Status = StatusHealthy
+			}
+			results[idx] = result
+		}(i, dep)
+	}
+
+	wg.Wait()
+
+	// Determine overall status
+	overall := StatusHealthy
+	for _, r := range results {
+		if r.Status == StatusUnhealthy {
+			if r.Critical {
+				overall = StatusUnhealthy
+				break // critical failure = unhealthy, no need to continue
+			}
+			if overall != StatusUnhealthy {
+				overall = StatusDegraded
+			}
+		}
+	}
+
+	return HealthResponse{
+		Status:       overall,
+		Service:      c.ServiceName,
+		Version:      c.Version,
+		Timestamp:    time.Now().UTC().Format(time.RFC3339),
+		Dependencies: results,
+	}
+}
+
+// Handler returns an http.HandlerFunc that serves the structured health check.
+func (c *Checker) Handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		resp := c.Run(r.Context())
+
+		w.Header().Set("Content-Type", "application/json")
+		switch resp.Status {
+		case StatusHealthy:
+			w.WriteHeader(http.StatusOK)
+		case StatusDegraded:
+			w.WriteHeader(http.StatusOK) // still serving, but degraded
+		case StatusUnhealthy:
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+
+		json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// LivenessHandler returns a simple liveness probe (always 200 if the process
+// is running). Use this for Kubernetes livenessProbe.
+func LivenessHandler(serviceName string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{
+			"status":  "alive",
+			"service": serviceName,
+		})
+	}
+}

--- a/src/frontend/healthcheck/healthcheck_test.go
+++ b/src/frontend/healthcheck/healthcheck_test.go
@@ -1,0 +1,126 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestAllHealthy(t *testing.T) {
+	c := NewChecker("test-svc", "0.1.0")
+	c.AddDependency(DependencyCheck{
+		Name:     "db",
+		Critical: true,
+		Check:    func(ctx context.Context) error { return nil },
+	})
+	c.AddDependency(DependencyCheck{
+		Name:     "cache",
+		Critical: false,
+		Check:    func(ctx context.Context) error { return nil },
+	})
+
+	resp := c.Run(context.Background())
+	if resp.Status != StatusHealthy {
+		t.Errorf("expected healthy, got %s", resp.Status)
+	}
+	if len(resp.Dependencies) != 2 {
+		t.Errorf("expected 2 dependencies, got %d", len(resp.Dependencies))
+	}
+}
+
+func TestCriticalUnhealthy(t *testing.T) {
+	c := NewChecker("test-svc", "0.1.0")
+	c.AddDependency(DependencyCheck{
+		Name:     "db",
+		Critical: true,
+		Check:    func(ctx context.Context) error { return fmt.Errorf("connection refused") },
+	})
+	c.AddDependency(DependencyCheck{
+		Name:     "cache",
+		Critical: false,
+		Check:    func(ctx context.Context) error { return nil },
+	})
+
+	resp := c.Run(context.Background())
+	if resp.Status != StatusUnhealthy {
+		t.Errorf("expected unhealthy, got %s", resp.Status)
+	}
+}
+
+func TestNonCriticalUnhealthy(t *testing.T) {
+	c := NewChecker("test-svc", "0.1.0")
+	c.AddDependency(DependencyCheck{
+		Name:     "db",
+		Critical: true,
+		Check:    func(ctx context.Context) error { return nil },
+	})
+	c.AddDependency(DependencyCheck{
+		Name:     "cache",
+		Critical: false,
+		Check:    func(ctx context.Context) error { return fmt.Errorf("timeout") },
+	})
+
+	resp := c.Run(context.Background())
+	if resp.Status != StatusDegraded {
+		t.Errorf("expected degraded, got %s", resp.Status)
+	}
+}
+
+func TestHandlerReturns503WhenUnhealthy(t *testing.T) {
+	c := NewChecker("test-svc", "0.1.0")
+	c.AddDependency(DependencyCheck{
+		Name:     "db",
+		Critical: true,
+		Check:    func(ctx context.Context) error { return fmt.Errorf("down") },
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	c.Handler()(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestHandlerReturns200WhenHealthy(t *testing.T) {
+	c := NewChecker("test-svc", "0.1.0")
+	c.AddDependency(DependencyCheck{
+		Name:     "db",
+		Critical: true,
+		Check:    func(ctx context.Context) error { return nil },
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	c.Handler()(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestTimeoutRespected(t *testing.T) {
+	c := NewChecker("test-svc", "0.1.0")
+	c.Timeout = 50 * time.Millisecond
+	c.AddDependency(DependencyCheck{
+		Name:     "slow",
+		Critical: true,
+		Check: func(ctx context.Context) error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(5 * time.Second):
+				return nil
+			}
+		},
+	})
+
+	resp := c.Run(context.Background())
+	if resp.Status != StatusUnhealthy {
+		t.Errorf("expected unhealthy due to timeout, got %s", resp.Status)
+	}
+}

--- a/src/frontend/main.go
+++ b/src/frontend/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/profiler"
+	"github.com/GoogleCloudPlatform/microservices-demo/src/frontend/healthcheck"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -159,6 +160,18 @@ func main() {
 	r.PathPrefix(baseUrl + "/static/").Handler(http.StripPrefix(baseUrl+"/static/", http.FileServer(http.Dir("./static/"))))
 	r.HandleFunc(baseUrl+"/robots.txt", func(w http.ResponseWriter, _ *http.Request) { fmt.Fprint(w, "User-agent: *\nDisallow: /") })
 	r.HandleFunc(baseUrl+"/_healthz", func(w http.ResponseWriter, _ *http.Request) { fmt.Fprint(w, "ok") })
+
+	// Structured health check with dependency status
+	hc := healthcheck.NewChecker("frontend", "1.0.0")
+	hc.AddGRPCDependency("product-catalog", svc.productCatalogSvcConn, true)
+	hc.AddGRPCDependency("currency", svc.currencySvcConn, true)
+	hc.AddGRPCDependency("cart", svc.cartSvcConn, true)
+	hc.AddGRPCDependency("recommendation", svc.recommendationSvcConn, false)
+	hc.AddGRPCDependency("checkout", svc.checkoutSvcConn, true)
+	hc.AddGRPCDependency("shipping", svc.shippingSvcConn, false)
+	hc.AddGRPCDependency("ad", svc.adSvcConn, false)
+	r.HandleFunc(baseUrl+"/health", hc.Handler()).Methods(http.MethodGet)
+	r.HandleFunc(baseUrl+"/livez", healthcheck.LivenessHandler("frontend")).Methods(http.MethodGet)
 	r.HandleFunc(baseUrl+"/product-meta/{ids}", svc.getProductByID).Methods(http.MethodGet)
 	r.HandleFunc(baseUrl+"/bot", svc.chatBotHandler).Methods(http.MethodPost)
 


### PR DESCRIPTION
## Summary
- Add reusable `healthcheck` Go package with three-state model (healthy/degraded/unhealthy) and per-dependency probing
- Critical dependencies (product-catalog, currency, cart, checkout) cause unhealthy status; non-critical (recommendation, shipping, ad) cause degraded
- Concurrent dependency checks with configurable timeout, gRPC connection state helper
- Wire `/health` (structured JSON) and `/livez` (simple liveness) endpoints into the frontend service
- Unit tests covering all status transitions, HTTP status codes, and timeout behavior

## Test plan
- [ ] Run `go test ./healthcheck/...` to verify all unit tests pass
- [ ] Deploy to staging and verify `/health` returns JSON with all dependency statuses
- [ ] Stop a non-critical service (ad) and confirm `/health` returns degraded (200)
- [ ] Stop a critical service (cart) and confirm `/health` returns unhealthy (503)
- [ ] Verify `/livez` always returns 200 as long as the process is running
- [ ] Confirm K8s readinessProbe can use `/health` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)