### PR TITLE
Bump grpc to 1.79.3 - CVE-2026-33186

### DIFF
--- a/src/shippingservice/go.mod
+++ b/src/shippingservice/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/profiler v0.4.3
 	github.com/sirupsen/logrus v1.9.4
 	golang.org/x/net v0.52.0
-	google.golang.org/grpc v1.79.2
+	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.11
 )
 


### PR DESCRIPTION
### Background 
The grpc package v1.79.2 has CVE-2026-33186 vulnerability, upgrading to v1.79.3

### Fixes 
<!-- Link the issue(s) this PR fixes-->
### Change Summary
<!-- Short summary of the changes submitted -->

### Additional Notes
<!-- Any remaining concerns -->

### Testing Procedure
<!-- If applicable, write how to test for reviewers-->

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
