### PR TITLE
chore: fix legacy ENV syntax in Dockerfile

### DIFF
--- a/src/shoppingassistantservice/Dockerfile
+++ b/src/shoppingassistantservice/Dockerfile
@@ -41,7 +41,7 @@ COPY --from=builder /usr/local/lib/python3.14/ /usr/local/lib/python3.14/
 COPY . .
 
 # set listen port
-ENV PORT "8080"
+ENV PORT="8080"
 EXPOSE 8080
 
 ENTRYPOINT ["python", "shoppingassistantservice.py"]


### PR DESCRIPTION
### Background 
The `Dockerfile` for the `shoppingassistantservice` was using the legacy space-separated format for `ENV` instructions. This triggered a `LegacyKeyValueFormat` warning during the `docker build` process.

### Fixes 
* Fixes build-time syntax warning `LegacyKeyValueFormat` in the `shopping-assistant-service`.

### Change Summary
* Updated `ENV` declarations in the service's `Dockerfile` to use the recommended `key=value` format.
* Specifically addressed the warning at **line 44** identified during the build process.

### Additional Notes
This change is purely a syntax update to comply with modern Docker best practices. It does not alter the environment variable values or the service's runtime behavior.

### Testing Procedure
1. Execute the build command:
   ```bash
   cd src/shoppingassistantservice/
   docker build -t shopping-assistant-service:1.0.0 .