### PR TITLE
fix: sync kubernetes-manifest images with release versions

### DIFF
--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/adservice:v0.10.5
+        image: adservice
         ports:
         - containerPort: 9555
         env:

--- a/kubernetes-manifests/adservice.yaml
+++ b/kubernetes-manifests/adservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: adservice
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/adservice:v0.10.5
         ports:
         - containerPort: 9555
         env:

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: cartservice
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/cartservice:v0.10.5
         ports:
         - containerPort: 7070
         env:

--- a/kubernetes-manifests/cartservice.yaml
+++ b/kubernetes-manifests/cartservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/cartservice:v0.10.5
+        image: cartservice
         ports:
         - containerPort: 7070
         env:

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -42,7 +42,7 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
-          image: us-central1-docker.pkg.dev/google-samples/microservices-demo/checkoutservice:v0.10.5
+          image: checkoutservice
           ports:
           - containerPort: 5050
           readinessProbe:

--- a/kubernetes-manifests/checkoutservice.yaml
+++ b/kubernetes-manifests/checkoutservice.yaml
@@ -42,7 +42,7 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
-          image: checkoutservice
+          image: us-central1-docker.pkg.dev/google-samples/microservices-demo/checkoutservice:v0.10.5
           ports:
           - containerPort: 5050
           readinessProbe:

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/currencyservice:v0.10.5
+        image: currencyservice
         ports:
         - name: grpc
           containerPort: 7000

--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: currencyservice
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/currencyservice:v0.10.5
         ports:
         - name: grpc
           containerPort: 7000

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/emailservice:v0.10.5
+        image: emailservice
         ports:
         - containerPort: 8080
         env:

--- a/kubernetes-manifests/emailservice.yaml
+++ b/kubernetes-manifests/emailservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: emailservice
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/emailservice:v0.10.5
         ports:
         - containerPort: 8080
         env:

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -44,7 +44,7 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
-          image: us-central1-docker.pkg.dev/google-samples/microservices-demo/frontend:v0.10.5
+          image: frontend
           ports:
           - containerPort: 8080
           readinessProbe:

--- a/kubernetes-manifests/frontend.yaml
+++ b/kubernetes-manifests/frontend.yaml
@@ -44,7 +44,7 @@ spec:
                 - ALL
             privileged: false
             readOnlyRootFilesystem: true
-          image: frontend
+          image: us-central1-docker.pkg.dev/google-samples/microservices-demo/frontend:v0.10.5
           ports:
           - containerPort: 8080
           readinessProbe:

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -77,7 +77,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: loadgenerator
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/loadgenerator:v0.10.5
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/kubernetes-manifests/loadgenerator.yaml
+++ b/kubernetes-manifests/loadgenerator.yaml
@@ -77,7 +77,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/loadgenerator:v0.10.5
+        image: loadgenerator
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/paymentservice:v0.10.5
+        image: paymentservice
         ports:
         - containerPort: 50051
         env:

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: paymentservice
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/paymentservice:v0.10.5
         ports:
         - containerPort: 50051
         env:

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: productcatalogservice
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/productcatalogservice:v0.10.5
         ports:
         - containerPort: 3550
         env:

--- a/kubernetes-manifests/productcatalogservice.yaml
+++ b/kubernetes-manifests/productcatalogservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/productcatalogservice:v0.10.5
+        image: productcatalogservice
         ports:
         - containerPort: 3550
         env:

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image:  us-central1-docker.pkg.dev/google-samples/microservices-demo/recommendationservice:v0.10.5
+        image: recommendationservice
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/kubernetes-manifests/recommendationservice.yaml
+++ b/kubernetes-manifests/recommendationservice.yaml
@@ -43,7 +43,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: recommendationservice
+        image:  us-central1-docker.pkg.dev/google-samples/microservices-demo/recommendationservice:v0.10.5
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -42,7 +42,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: shippingservice
+        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/shippingservice:v0.10.5
         ports:
         - containerPort: 50051
         env:

--- a/kubernetes-manifests/shippingservice.yaml
+++ b/kubernetes-manifests/shippingservice.yaml
@@ -42,7 +42,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-central1-docker.pkg.dev/google-samples/microservices-demo/shippingservice:v0.10.5
+        image: shippingservice
         ports:
         - containerPort: 50051
         env:


### PR DESCRIPTION
### Background 
Previously, the individual YAML manifests in the kubernetes-manifests/ directory used generic image names (e.g., image: paymentservice) without a registry path or version tag. While the consolidated release/kubernetes-manifests.yaml file was correct, anyone attempting to deploy or redeploy a single service using the individual files would encounter ImagePullBackOff errors because Kubernetes could not resolve the image.

### Fixes 
[#3360  ](https://github.com/GoogleCloudPlatform/microservices-demo/issues/3360)

### Change Summary
- Updated all service manifests in the kubernetes-manifests/ directory to use fully qualified image paths.
- Synchronized image tags with the versions specified in release/kubernetes-manifests.yaml (v0.10.5).
- Ensures individual services can be independently deployed using kubectl apply -f <service>.yaml.

### Additional Notes
This change ensures consistency across the repository's deployment options. It specifically solves the issue where developers or users trying to test a specific microservice in isolation were unable to do so using the provided individual manifest files.

### Testing Procedure
1. Navigate to the `kubernetes-manifests/` directory.
2. Attempt to deploy a single service (e.g., `paymentservice`) using its individual manifest: `kubectl apply -f paymentservice.yaml`
3. Verify the deployment status: `kubectl get pods -l app=paymentservice`
4. **Result**: The pod should transition to Running state and successfully pull the image `us-central1-docker.pkg.dev/google-samples/microservices-demo/paymentservice:v0.10.5`

### Related PRs or Issues 
[#3360 ](https://github.com/GoogleCloudPlatform/microservices-demo/issues/3360)


<img width="3456" height="2160" alt="Screen Shot 2026-05-12 at 11 54 15 AM" src="https://github.com/user-attachments/assets/1a517300-2610-4ab6-bc5a-18eb2fe78445" />
