### PR TITLE
Pin busybox image version for reproducible builds

### DIFF
--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -145,7 +145,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: busybox:latest
+        image: busybox:1.36.1
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"


### PR DESCRIPTION
### Background

The init container in the `loadgenerator` deployment was using the `busybox:latest` image tag. Using the `latest` tag can lead to non-deterministic deployments and unexpected behavior when upstream images change.

### Fixes

N/A

### Change Summary

* Replaced `busybox:latest` with a pinned image version:

  ```yaml
  image: busybox:1.36.1
  ```
* Improves deployment reproducibility and version consistency.

### Additional Notes

This change follows container image best practices by avoiding the use of mutable `latest` tags in Kubernetes manifests.

### Testing Procedure

* Verified the manifest changes locally using:

  ```bash
  git diff
  ```
* Confirmed that only the intended image tag was updated.

### Related PRs or Issues

N/A

