### PR TITLE
feat(currencyservice): reimplement in C++ with contract tests

### DIFF
--- a/kubernetes-manifests/currencyservice.yaml
+++ b/kubernetes-manifests/currencyservice.yaml
@@ -50,8 +50,6 @@ spec:
         env:
         - name: PORT
           value: "7000"
-        - name: DISABLE_PROFILER
-          value: "1"
         readinessProbe:
           grpc:
             port: 7000

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -38,7 +38,9 @@ build:
   - image: paymentservice
     context: src/paymentservice
   - image: currencyservice
-    context: src/currencyservice
+    context: src
+    docker:
+      dockerfile: currencyservice-cpp/Dockerfile
   - image: cartservice
     context: src/cartservice/src
     docker:

--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -1,0 +1,6 @@
+# macOS extended-attribute sidecar files created on mounted volumes
+._*
+**/._*
+
+# Build artifacts — not needed in image
+currencyservice-cpp/build/

--- a/src/currencyservice-cpp/CMakeLists.txt
+++ b/src/currencyservice-cpp/CMakeLists.txt
@@ -1,0 +1,118 @@
+cmake_minimum_required(VERSION 3.16)
+project(currencyservice CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# ---------------------------------------------------------------------------
+# Dependencies
+#
+# macOS (Homebrew):
+#   brew install grpc protobuf nlohmann-json
+#   cmake -B build -DCMAKE_PREFIX_PATH=$(brew --prefix)
+#
+# Ubuntu / Debian (apt):
+#   apt-get install -y libgrpc++-dev libprotobuf-dev \
+#                      protobuf-compiler-grpc nlohmann-json3-dev
+#   cmake -B build
+#
+# gRPC: try CMake CONFIG mode first (Homebrew / vcpkg install the cmake
+# config files in a standard search path).  On Debian/Ubuntu the config
+# files live in /usr/lib/<multiarch>/cmake/grpc/, which is NOT on CMake's
+# default search path, so we fall back to pkg-config there.
+# ---------------------------------------------------------------------------
+
+find_package(gRPC CONFIG QUIET)
+if(gRPC_FOUND)
+    message(STATUS "gRPC ${gRPC_VERSION} found via CMake config")
+    set(GRPC_LINK_TARGET gRPC::grpc++)
+    get_target_property(GRPC_CPP_PLUGIN gRPC::grpc_cpp_plugin LOCATION)
+else()
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(GRPCPP REQUIRED IMPORTED_TARGET grpc++)
+    message(STATUS "gRPC ${GRPCPP_VERSION} found via pkg-config")
+    set(GRPC_LINK_TARGET PkgConfig::GRPCPP)
+    find_program(GRPC_CPP_PLUGIN grpc_cpp_plugin REQUIRED)
+endif()
+
+# Protobuf
+find_package(Protobuf REQUIRED)
+if(NOT Protobuf_PROTOC_EXECUTABLE)
+    find_program(Protobuf_PROTOC_EXECUTABLE protoc REQUIRED)
+endif()
+message(STATUS "protoc: ${Protobuf_PROTOC_EXECUTABLE}")
+message(STATUS "grpc_cpp_plugin: ${GRPC_CPP_PLUGIN}")
+
+# nlohmann_json — header-only; both Homebrew and apt provide the cmake config
+find_package(nlohmann_json REQUIRED)
+
+# ---------------------------------------------------------------------------
+# Proto code generation
+# ---------------------------------------------------------------------------
+
+# Can be overridden at configure time:
+#   cmake -DPROTO_SRC_DIR=/absolute/path/to/proto ...
+if(NOT DEFINED PROTO_SRC_DIR)
+    set(PROTO_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../currencyservice/proto")
+endif()
+message(STATUS "Proto source dir: ${PROTO_SRC_DIR}")
+set(PROTO_GEN_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+file(MAKE_DIRECTORY
+    "${PROTO_GEN_DIR}"
+    "${PROTO_GEN_DIR}/grpc/health/v1"
+)
+
+add_custom_command(
+    OUTPUT
+        "${PROTO_GEN_DIR}/demo.pb.cc"
+        "${PROTO_GEN_DIR}/demo.pb.h"
+        "${PROTO_GEN_DIR}/demo.grpc.pb.cc"
+        "${PROTO_GEN_DIR}/demo.grpc.pb.h"
+    COMMAND "${Protobuf_PROTOC_EXECUTABLE}"
+        "--proto_path=${PROTO_SRC_DIR}"
+        "--cpp_out=${PROTO_GEN_DIR}"
+        "--grpc_out=${PROTO_GEN_DIR}"
+        "--plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN}"
+        "demo.proto"
+    DEPENDS "${PROTO_SRC_DIR}/demo.proto"
+    COMMENT "Generating C++ stubs for demo.proto"
+    VERBATIM
+)
+
+add_custom_command(
+    OUTPUT
+        "${PROTO_GEN_DIR}/grpc/health/v1/health.pb.cc"
+        "${PROTO_GEN_DIR}/grpc/health/v1/health.pb.h"
+        "${PROTO_GEN_DIR}/grpc/health/v1/health.grpc.pb.cc"
+        "${PROTO_GEN_DIR}/grpc/health/v1/health.grpc.pb.h"
+    COMMAND "${Protobuf_PROTOC_EXECUTABLE}"
+        "--proto_path=${PROTO_SRC_DIR}"
+        "--cpp_out=${PROTO_GEN_DIR}"
+        "--grpc_out=${PROTO_GEN_DIR}"
+        "--plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN}"
+        "grpc/health/v1/health.proto"
+    DEPENDS "${PROTO_SRC_DIR}/grpc/health/v1/health.proto"
+    COMMENT "Generating C++ stubs for health.proto"
+    VERBATIM
+)
+
+# ---------------------------------------------------------------------------
+# Server binary
+# ---------------------------------------------------------------------------
+
+add_executable(server
+    server.cc
+    "${PROTO_GEN_DIR}/demo.pb.cc"
+    "${PROTO_GEN_DIR}/demo.grpc.pb.cc"
+    "${PROTO_GEN_DIR}/grpc/health/v1/health.pb.cc"
+    "${PROTO_GEN_DIR}/grpc/health/v1/health.grpc.pb.cc"
+)
+
+target_include_directories(server PRIVATE "${PROTO_GEN_DIR}")
+
+target_link_libraries(server PRIVATE
+    ${GRPC_LINK_TARGET}
+    protobuf::libprotobuf
+    nlohmann_json::nlohmann_json
+)

--- a/src/currencyservice-cpp/Dockerfile
+++ b/src/currencyservice-cpp/Dockerfile
@@ -1,0 +1,61 @@
+# Multi-stage build for the C++ currencyservice reimplementation.
+#
+# Build context must be the src/ directory so both service directories
+# are available:
+#   docker build -t currencyservice-cpp \
+#     -f src/currencyservice-cpp/Dockerfile src/
+
+# ---------------------------------------------------------------------------
+# Stage 1: build
+# ---------------------------------------------------------------------------
+FROM ubuntu:22.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        pkg-config \
+        libgrpc++-dev \
+        libprotobuf-dev \
+        protobuf-compiler-grpc \
+        nlohmann-json3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Proto files come from the Node.js service directory (shared source of truth)
+COPY currencyservice/proto/       proto/currencyservice/proto/
+
+# Currency data and C++ sources
+COPY currencyservice/data/        data/
+COPY currencyservice-cpp/CMakeLists.txt \
+     currencyservice-cpp/server.cc \
+     ./
+
+RUN cmake -B build -DCMAKE_BUILD_TYPE=Release \
+    -DPROTO_SRC_DIR=/build/proto/currencyservice/proto \
+    && cmake --build build --parallel "$(nproc)"
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime — minimal image with only what's needed to run
+# ---------------------------------------------------------------------------
+FROM ubuntu:22.04 AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgrpc++1 \
+        libprotobuf23 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /build/build/server   /usr/local/bin/server
+COPY --from=builder /build/data/          /app/data/
+
+EXPOSE 7000
+
+ENV PORT=7000
+
+ENTRYPOINT ["/usr/local/bin/server"]

--- a/src/currencyservice-cpp/server.cc
+++ b/src/currencyservice-cpp/server.cc
@@ -1,0 +1,211 @@
+// C++ reimplementation of currencyservice.
+//
+// Spec: src/currencyservice/currencyservice-spec.md
+// Contract tests: src/currencyservice/tests/test_currency_contract.py
+//
+// Behaviour differences from the Node.js original (all documented as xfail
+// in the test suite — they will flip to xpass here):
+//   - Unknown currency codes return INVALID_ARGUMENT instead of silent zeros.
+//   - Negative Money amounts produce the mathematically correct result because
+//     the carry() helper uses trunc() instead of floor(), which correctly
+//     handles negative intermediate values without double-subtracting the
+//     fractional part (§6.5 of the spec).
+
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include <grpcpp/grpcpp.h>
+#include <nlohmann/json.hpp>
+
+// Generated proto headers (produced by CMake custom commands)
+#include "demo.grpc.pb.h"
+#include "demo.pb.h"
+#include "grpc/health/v1/health.grpc.pb.h"
+#include "grpc/health/v1/health.pb.h"
+
+using grpc::InsecureServerCredentials;
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerContext;
+using grpc::Status;
+using grpc::StatusCode;
+
+using hipstershop::CurrencyConversionRequest;
+using hipstershop::CurrencyService;
+using hipstershop::Empty;
+using hipstershop::GetSupportedCurrenciesResponse;
+using hipstershop::Money;
+
+using grpc::health::v1::Health;
+using grpc::health::v1::HealthCheckRequest;
+using grpc::health::v1::HealthCheckResponse;
+
+// ---------------------------------------------------------------------------
+// Exchange-rate table — loaded once at startup from currency_conversion.json.
+// Keys are ISO 4217 codes; values are EUR-based rates (1 EUR = N units).
+// ---------------------------------------------------------------------------
+
+static std::map<std::string, double> g_rates;
+
+static void LoadRates(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open()) {
+        throw std::runtime_error("cannot open currency data file: " + path);
+    }
+    nlohmann::json j;
+    f >> j;
+    for (auto& [key, val] : j.items()) {
+        g_rates[key] = std::stod(val.get<std::string>());
+    }
+    std::clog << "[currencyservice] loaded " << g_rates.size()
+              << " currency rates from " << path << "\n";
+}
+
+// ---------------------------------------------------------------------------
+// Two-step EUR-pivot conversion algorithm (§3.2, §3.3 of spec).
+//
+// Intermediate values are IEEE 754 doubles, matching V8's arithmetic.
+//
+// KEY DIFFERENCE FROM NODE.JS:
+//   The original _carry() uses Math.floor() which for negative inputs rounds
+//   toward −∞, causing the fractional part to be subtracted twice from units.
+//   Here we use std::trunc() which rounds toward zero for both positive and
+//   negative values.  For positive amounts trunc == floor, so all existing
+//   passing contract tests continue to pass.  For negative amounts the result
+//   is mathematically correct (spec §6.5 bug fixed).
+//
+//   std::fmod() is used throughout to replicate JavaScript's % operator, which
+//   also has sign-of-dividend semantics (same as C's fmod).
+// ---------------------------------------------------------------------------
+
+struct Intermediate { double units = 0.0, nanos = 0.0; };
+
+static Intermediate Carry(Intermediate m) {
+    constexpr double kFS = 1e9;
+    m.nanos += std::fmod(m.units, 1.0) * kFS;                  // fractional units → nanos
+    m.units  = std::trunc(m.units) + std::trunc(m.nanos / kFS); // carry overflow
+    m.nanos  = std::fmod(m.nanos, kFS);                          // keep remainder
+    return m;
+}
+
+// Throws std::invalid_argument for unknown currency codes.
+static Money ConvertMoney(const Money& from, const std::string& to_code) {
+    auto it_from = g_rates.find(from.currency_code());
+    if (it_from == g_rates.end()) {
+        throw std::invalid_argument("unknown source currency: " + from.currency_code());
+    }
+    auto it_to = g_rates.find(to_code);
+    if (it_to == g_rates.end()) {
+        throw std::invalid_argument("unknown target currency: " + to_code);
+    }
+    const double rate_from = it_from->second;
+    const double rate_to   = it_to->second;
+
+    // Step 1: source currency → EUR
+    Intermediate euros;
+    euros.units = static_cast<double>(from.units()) / rate_from;
+    euros.nanos = static_cast<double>(from.nanos()) / rate_from;
+    euros = Carry(euros);
+    euros.nanos = std::round(euros.nanos);  // Math.round after step 1 (§3.3)
+
+    // Step 2: EUR → target currency
+    Intermediate result;
+    result.units = euros.units * rate_to;
+    result.nanos = euros.nanos * rate_to;
+    result = Carry(result);
+
+    Money out;
+    out.set_units(static_cast<int64_t>(std::trunc(result.units)));
+    out.set_nanos(static_cast<int32_t>(std::trunc(result.nanos)));
+    out.set_currency_code(to_code);
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// gRPC service implementations
+// ---------------------------------------------------------------------------
+
+class CurrencyServiceImpl final : public CurrencyService::Service {
+public:
+    Status GetSupportedCurrencies(ServerContext*,
+                                   const Empty*,
+                                   GetSupportedCurrenciesResponse* resp) override {
+        for (const auto& [code, _] : g_rates) {
+            resp->add_currency_codes(code);
+        }
+        return Status::OK;
+    }
+
+    Status Convert(ServerContext*,
+                   const CurrencyConversionRequest* req,
+                   Money* resp) override {
+        try {
+            *resp = ConvertMoney(req->from(), req->to_code());
+            return Status::OK;
+        } catch (const std::invalid_argument& e) {
+            return Status(StatusCode::INVALID_ARGUMENT, e.what());
+        } catch (const std::exception& e) {
+            return Status(StatusCode::INTERNAL, e.what());
+        }
+    }
+};
+
+// Health check — always returns SERVING (matches Node.js behaviour, §2.3).
+class HealthServiceImpl final : public Health::Service {
+public:
+    Status Check(ServerContext*,
+                 const HealthCheckRequest*,
+                 HealthCheckResponse* resp) override {
+        resp->set_status(HealthCheckResponse::SERVING);
+        return Status::OK;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+int main() {
+    const char* port_env = std::getenv("PORT");
+    if (!port_env || port_env[0] == '\0') {
+        std::cerr << "[currencyservice] PORT environment variable is not set\n";
+        return 1;
+    }
+    const std::string addr = std::string("[::]:") + port_env;
+
+    // Data file: $CURRENCY_DATA_PATH, else "data/currency_conversion.json"
+    // relative to the working directory (matches Node.js behaviour when the
+    // fixture runs both servers from the currencyservice source directory).
+    std::string data_path = "data/currency_conversion.json";
+    if (const char* p = std::getenv("CURRENCY_DATA_PATH")) {
+        data_path = p;
+    }
+    try {
+        LoadRates(data_path);
+    } catch (const std::exception& e) {
+        std::cerr << "[currencyservice] " << e.what() << "\n";
+        return 1;
+    }
+
+    CurrencyServiceImpl currency_svc;
+    HealthServiceImpl   health_svc;
+
+    ServerBuilder builder;
+    builder.AddListeningPort(addr, InsecureServerCredentials());
+    builder.RegisterService(&currency_svc);
+    builder.RegisterService(&health_svc);
+
+    std::unique_ptr<Server> server(builder.BuildAndStart());
+    if (!server) {
+        std::cerr << "[currencyservice] failed to bind on " << addr << "\n";
+        return 1;
+    }
+    std::clog << "[currencyservice] gRPC server listening on " << addr << "\n";
+    server->Wait();
+}

--- a/src/currencyservice/currencyservice-spec.md
+++ b/src/currencyservice/currencyservice-spec.md
@@ -1,0 +1,420 @@
+# currencyservice-spec.md
+
+Source-of-truth specification for reimplementing `currencyservice` in C++.
+Derived from the Node.js implementation in `src/currencyservice/`.
+
+---
+
+## 1. Service Purpose
+
+`currencyservice` is a gRPC microservice in the Online Boutique (Hipster Shop)
+demo application. It serves two business functions:
+
+- **Currency listing** — return the set of ISO 4217 currency codes the service
+  can work with.
+- **Currency conversion** — convert a monetary amount expressed as a `Money`
+  proto from one currency to another, using EUR as the pivot/intermediate
+  currency.
+
+The service is stateless at the request level; all exchange-rate data is loaded
+from a static JSON file bundled inside the container image. No external network
+calls are made during normal operation.
+
+---
+
+## 2. API Contract
+
+### 2.1 Proto packages and files
+
+| File | Package |
+|---|---|
+| `proto/demo.proto` | `hipstershop` |
+| `proto/grpc/health/v1/health.proto` | `grpc.health.v1` |
+
+### 2.2 `hipstershop.CurrencyService`
+
+#### `GetSupportedCurrencies`
+
+```protobuf
+rpc GetSupportedCurrencies(Empty) returns (GetSupportedCurrenciesResponse) {}
+```
+
+| Direction | Message | Fields |
+|---|---|---|
+| Request | `Empty` | _(none)_ |
+| Response | `GetSupportedCurrenciesResponse` | `repeated string currency_codes = 1` |
+
+Returns the list of 3-letter ISO 4217 codes for which exchange rates are
+available. Derived at runtime from the keys of `currency_conversion.json`
+(currently 33 currencies; see §4).
+
+#### `Convert`
+
+```protobuf
+rpc Convert(CurrencyConversionRequest) returns (Money) {}
+```
+
+| Direction | Message | Fields |
+|---|---|---|
+| Request | `CurrencyConversionRequest` | `Money from = 1`, `string to_code = 2` |
+| Response | `Money` | `string currency_code = 1`, `int64 units = 2`, `int32 nanos = 3` |
+
+Converts the amount in `from` to the currency identified by `to_code`.
+Returns a `Money` whose `currency_code` equals `to_code`.
+
+#### `Money` message (shared type)
+
+```protobuf
+message Money {
+    string currency_code = 1;   // ISO 4217, e.g. "USD"
+    int64  units = 2;           // whole monetary units
+    int32  nanos = 3;           // fractional units * 10^9
+                                // range: -999,999,999 .. +999,999,999
+}
+```
+
+Sign rules (from proto comments):
+- If `units > 0`, `nanos` must be ≥ 0.
+- If `units == 0`, `nanos` may be any sign.
+- If `units < 0`, `nanos` must be ≤ 0.
+
+### 2.3 `grpc.health.v1.Health`
+
+```protobuf
+rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+```
+
+The handler always responds with `status = SERVING` without inspecting the
+request's `service` field or checking any internal state.
+
+---
+
+## 3. Core Business Logic
+
+### 3.1 Exchange-rate data model
+
+`data/currency_conversion.json` maps each currency code to its exchange rate
+**relative to EUR** — i.e., how many units of that currency equal 1 EUR.
+
+```json
+{
+  "EUR": "1.0",
+  "USD": "1.1305",
+  "JPY": "126.40",
+  ...
+}
+```
+
+All rates are stored as strings in the JSON file but are used as floating-point
+numbers in arithmetic. The data is sourced from the European Central Bank.
+EUR itself is present with a rate of `"1.0"`.
+
+### 3.2 `_carry` — decimal normalization
+
+```
+_carry(amount):
+    fractionSize = 10^9
+    amount.nanos  += (amount.units % 1) * fractionSize   // move fractional units into nanos
+    amount.units   = floor(amount.units) + floor(amount.nanos / fractionSize)  // carry nanos overflow into units
+    amount.nanos   = amount.nanos % fractionSize          // keep remainder
+    return amount
+```
+
+Purpose: after floating-point multiplication or division, `units` may have a
+fractional part and `nanos` may exceed `10^9`. `_carry` normalizes both fields.
+
+### 3.3 `Convert` algorithm
+
+Given `from` (Money) and `to_code` (string):
+
+**Step 1 — convert from source currency to EUR**
+
+```
+rate_from = data[from.currency_code]          // units of from-currency per EUR
+euros.units = from.units / rate_from
+euros.nanos = from.nanos / rate_from
+euros = _carry(euros)
+euros.nanos = round(euros.nanos)              // nearest integer (Math.round)
+```
+
+**Step 2 — convert from EUR to target currency**
+
+```
+rate_to = data[to_code]                       // units of to-currency per EUR
+result.units = euros.units * rate_to
+result.nanos = euros.nanos * rate_to
+result = _carry(result)
+result.units = floor(result.units)            // truncate towards zero
+result.nanos = floor(result.nanos)            // truncate towards zero
+result.currency_code = to_code
+return result
+```
+
+**Rounding policy summary:**
+
+| Step | Operation |
+|---|---|
+| After step 1 `_carry` | `Math.round(euros.nanos)` |
+| After step 2 `_carry` | `Math.floor(result.units)`, `Math.floor(result.nanos)` |
+
+### 3.4 `GetSupportedCurrencies` algorithm
+
+Return `Object.keys(data)` — the list of currency codes present in the JSON
+file, in insertion order (JSON key order as parsed by V8). No sorting is
+applied by the server.
+
+---
+
+## 4. Dependencies
+
+### 4.1 External services called
+
+None. The service makes no outbound network calls during normal request handling.
+
+### 4.2 Environment variables
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `PORT` | **Yes** | _(none; crashes if absent)_ | TCP port the gRPC server binds on. Kubernetes manifests set this to `7000`. |
+| `DISABLE_PROFILER` | No | unset | If set to any non-empty value, Google Cloud Profiler is not started. |
+| `ENABLE_TRACING` | No | unset | Set to `"1"` to enable OpenTelemetry trace export. |
+| `COLLECTOR_SERVICE_ADDR` | No | unset | URL of the OTLP gRPC trace collector. Used only when `ENABLE_TRACING=1`. |
+| `OTEL_SERVICE_NAME` | No | `"currencyservice"` | Service name label in OpenTelemetry traces. |
+
+### 4.3 Static data file
+
+`data/currency_conversion.json` — bundled inside the container image at build
+time. Contains 33 currency exchange rates vs. EUR. The file is loaded via
+Node.js `require()`, which means it is parsed once and cached for the lifetime
+of the process; there is no hot-reload mechanism.
+
+### 4.4 Key npm dependencies
+
+| Package | Version | Role |
+|---|---|---|
+| `@grpc/grpc-js` | 1.14.3 | gRPC server runtime |
+| `@grpc/proto-loader` | 0.8.0 | Runtime proto file loading |
+| `pino` | 10.3.1 | Structured JSON logging |
+| `@google-cloud/profiler` | 6.0.4 | GCP continuous profiling (optional) |
+| `@opentelemetry/sdk-node` | 0.214.0 | OTel tracing SDK (optional) |
+| `@opentelemetry/exporter-otlp-grpc` | 0.26.0 | OTLP gRPC trace export |
+| `@opentelemetry/instrumentation-grpc` | 0.214.0 | Auto-instrument gRPC calls for trace propagation |
+
+### 4.5 Proto loading
+
+Protos are loaded at startup with `protoLoader.loadSync` using these options:
+
+```js
+{ keepCase: true, longs: String, enums: String, defaults: true, oneofs: true }
+```
+
+`keepCase: true` means proto field names are used as-is (snake_case), not
+camelCased. In the C++ reimplementation, proto field accessors follow the
+standard Protobuf C++ naming conventions.
+
+---
+
+## 5. Data Flow
+
+### 5.1 Server startup
+
+1. Check `DISABLE_PROFILER`; start Google Cloud Profiler if not disabled.
+2. Register gRPC OpenTelemetry instrumentation (always, for trace context propagation).
+3. Check `ENABLE_TRACING`; if `"1"`, configure and start the OTel SDK with the
+   OTLP gRPC exporter pointed at `COLLECTOR_SERVICE_ADDR`.
+4. Load `demo.proto` and `health.proto` from disk.
+5. Create a `grpc.Server`, register `CurrencyService` and `Health` services.
+6. Bind on `[::]:${PORT}` with insecure credentials (no TLS).
+7. Start serving.
+
+### 5.2 `GetSupportedCurrencies` request
+
+```
+Client                          currencyservice
+  |                                   |
+  |-- GetSupportedCurrencies(Empty) ->|
+  |                                   |-- require('./data/currency_conversion.json')
+  |                                   |   (cached after first load)
+  |                                   |-- Object.keys(data) -> ["EUR","USD","JPY", ...]
+  |<-- GetSupportedCurrenciesResponse |
+  |    { currency_codes: [...] }      |
+```
+
+### 5.3 `Convert` request
+
+```
+Client                                    currencyservice
+  |                                            |
+  |-- Convert({ from: {USD, 300, 0},           |
+  |             to_code: "EUR" })  ----------->|
+  |                                            |-- load data (cached)
+  |                                            |-- euros = _carry({
+  |                                            |     units: 300 / 1.1305,
+  |                                            |     nanos: 0   / 1.1305
+  |                                            |   })
+  |                                            |-- euros.nanos = round(euros.nanos)
+  |                                            |-- result = _carry({
+  |                                            |     units: euros.units * 1.0,
+  |                                            |     nanos: euros.nanos * 1.0
+  |                                            |   })
+  |                                            |-- result.units = floor(result.units)
+  |                                            |-- result.nanos = floor(result.nanos)
+  |                                            |-- result.currency_code = "EUR"
+  |<-- Money { "EUR", 265, 367543 }  ----------|
+```
+
+### 5.4 `Check` (health) request
+
+```
+Client                    currencyservice
+  |                            |
+  |-- Check({}) -------------->|
+  |<-- { status: SERVING } ----|
+```
+
+No internal checks are performed; the response is always `SERVING`.
+
+---
+
+## 6. Edge Cases and Error Handling
+
+### 6.1 `Convert` error path
+
+The entire `convert` handler body is wrapped in a `try/catch`:
+
+```js
+} catch (err) {
+  logger.error(`conversion request failed: ${err}`);
+  callback(err.message);   // BUG: passes string, not an Error/gRPC status
+}
+```
+
+**Bug:** `callback(err.message)` passes a plain string as the first argument
+instead of an `Error` object with a gRPC status code. The gRPC-js library
+interprets a string error as a generic status 2 (UNKNOWN). The C++
+reimplementation should use a proper gRPC `Status` with an appropriate code
+(e.g., `INVALID_ARGUMENT` for bad input).
+
+### 6.2 Unknown currency codes (unvalidated)
+
+Neither `from.currency_code` nor `to_code` is validated against the known set
+before use. If an unknown code is passed:
+
+- `data[unknown_code]` evaluates to `undefined` in JavaScript.
+- Division or multiplication by `undefined` yields `NaN`.
+- `_carry` propagates `NaN` through all arithmetic without throwing.
+- The callback is called with `{units: NaN, nanos: NaN, currency_code: to_code}`.
+- The `try/catch` does **not** trigger because no exception is thrown.
+- The gRPC response will contain `NaN` serialized as `0` for numeric proto
+  fields (proto3 default), returning a silently incorrect zero-amount response.
+
+**C++ recommendation:** validate both `from.currency_code` and `to_code` against
+the data map before performing arithmetic; return `NOT_FOUND` or
+`INVALID_ARGUMENT` status if either is absent.
+
+### 6.3 Missing or null `from` field
+
+If the client sends a `CurrencyConversionRequest` with `from` omitted, proto3
+defaults apply and `from` will be a zeroed `Money`. Division of `0 / rate`
+is `0`, so the conversion will return a zero `Money` rather than an error.
+
+### 6.4 EUR-to-EUR conversion
+
+Works correctly: dividing by `1.0` and multiplying by `1.0` leaves the value
+unchanged (modulo floating-point rounding through `_carry`).
+
+### 6.5 Negative amounts
+
+The proto spec allows negative `Money` values (negative `units` with
+correspondingly negative `nanos`). The `_carry` function uses `Math.floor`,
+which rounds towards negative infinity. In JavaScript, `%` on negative numbers
+preserves the sign of the dividend. The C++ implementation should be careful
+to replicate this exact floor/remainder behavior for negative amounts, or
+explicitly document that negative amounts are out of scope.
+
+### 6.6 Large amounts and floating-point precision
+
+`int64 units` can represent values up to ~9.2 × 10^18. JavaScript `Number`
+(IEEE 754 double) has ~15–16 significant decimal digits. For large values of
+`units`, the intermediate floating-point calculation will lose precision.
+The C++ implementation may use integer arithmetic or 128-bit floats to improve
+accuracy, but must document any behavioral difference.
+
+### 6.7 Health check always reports SERVING
+
+The `Check` handler unconditionally returns `SERVING`. It does not check
+whether the JSON data file loaded successfully, whether the server is under
+load, or any other internal signal. The C++ implementation should match this
+behavior unless health-check semantics are explicitly improved.
+
+### 6.8 Port misconfiguration
+
+If `PORT` is unset or empty, `server.bindAsync('[::]:undefined', ...)` will
+fail. The Node.js process logs the error and exits. The C++ implementation
+should validate the port at startup and exit with a clear error message.
+
+---
+
+## 7. Test Coverage Gaps
+
+`package.json` defines the test script as:
+
+```json
+"test": "echo \"Error: no test specified\" && exit 1"
+```
+
+**There are zero tests in this service.** The following behaviors have no
+automated coverage and must be tested in the C++ reimplementation:
+
+| Behavior | Priority |
+|---|---|
+| `GetSupportedCurrencies` returns all 33 expected currency codes | High |
+| `Convert` USD → EUR with known rate produces correct result | High |
+| `Convert` EUR → USD with known rate produces correct result | High |
+| `Convert` non-EUR → non-EUR (two-step via EUR pivot) | High |
+| `Convert` EUR → EUR (identity conversion) | High |
+| `Convert` same source and target currency (identity) | High |
+| `Convert` with unknown `from.currency_code` returns error | High |
+| `Convert` with unknown `to_code` returns error | High |
+| `Convert` with zero `units` and zero `nanos` | Medium |
+| `Convert` with fractional `nanos` (non-zero nanos, zero units) | Medium |
+| `Convert` carry propagation: nanos overflow into units after multiply | Medium |
+| `Convert` carry propagation: fractional units folded into nanos | Medium |
+| `Convert` negative `Money` amounts | Medium |
+| `Convert` maximum `int64` `units` value (precision boundary) | Low |
+| `Check` always returns `SERVING` | Low |
+| Server startup fails cleanly when `PORT` is unset | Low |
+| Server startup with `ENABLE_TRACING=1` and valid collector address | Low |
+
+---
+
+## 8. Supported Currencies (reference)
+
+The following 33 currencies are in `currency_conversion.json` as of the
+current commit. Rates are EUR-based (1 EUR = N units):
+
+| Code | Rate | Code | Rate |
+|---|---|---|---|
+| EUR | 1.0 | HRK | 7.4210 |
+| USD | 1.1305 | RUB | 74.4208 |
+| JPY | 126.40 | TRY | 6.1247 |
+| BGN | 1.9558 | AUD | 1.6072 |
+| CZK | 25.592 | BRL | 4.2682 |
+| DKK | 7.4609 | CAD | 1.5128 |
+| GBP | 0.85970 | CNY | 7.5857 |
+| HUF | 315.51 | HKD | 8.8743 |
+| PLN | 4.2996 | IDR | 15999.40 |
+| RON | 4.7463 | ILS | 4.0875 |
+| SEK | 10.5375 | INR | 79.4320 |
+| CHF | 1.1360 | KRW | 1275.05 |
+| ISK | 136.80 | MXN | 21.7999 |
+| NOK | 9.8040 | MYR | 4.6289 |
+| | | NZD | 1.6679 |
+| | | PHP | 59.083 |
+| | | SGD | 1.5349 |
+| | | THB | 36.012 |
+| | | ZAR | 16.0583 |
+
+---
+
+*Generated 2026-05-29 from `src/currencyservice/` at commit `5096a85`.*

--- a/src/currencyservice/requirements.txt
+++ b/src/currencyservice/requirements.txt
@@ -1,0 +1,22 @@
+# Contract test dependencies for currencyservice
+#
+# Setup:
+#   npm install --omit=dev --ignore-scripts   # install Node.js service deps
+#   pip install -r requirements.txt           # install Python test deps
+#   pytest tests/test_currency_contract.py -v
+#
+# --ignore-scripts skips the pprof native build (only needed by the GCP
+# profiler, which is disabled via DISABLE_PROFILER=1 during tests).
+#
+# Python >= 3.9 required.
+
+# gRPC runtime and code-generation toolchain
+grpcio>=1.60.0,<2.0.0
+grpcio-tools>=1.60.0,<2.0.0
+
+# Standard gRPC health-checking stubs (avoids naming conflict with generated
+# grpc/health/v1/ output directory vs the installed `grpc` Python package)
+grpcio-health-checking>=1.60.0,<2.0.0
+
+# Test runner
+pytest>=8.0.0,<9.0.0

--- a/src/currencyservice/tests/test_currency_contract.py
+++ b/src/currencyservice/tests/test_currency_contract.py
@@ -1,0 +1,741 @@
+"""
+Contract tests for currencyservice (Node.js implementation).
+
+Starts the original Node.js service as a subprocess, then exercises every
+behavior listed in §7 of currencyservice-spec.md.
+
+Tests marked @pytest.mark.xfail document *known bugs* in the Node.js service
+that the C++ reimplementation must fix.  Against Node.js they record an
+"expected failure" (xfail); against the fixed C++ service they will become
+"unexpected passes" (xpass), signalling the bug is resolved.
+
+Run:
+    pip install -r requirements.txt
+    pytest tests/test_currency_contract.py -v
+"""
+
+import math
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+import grpc
+import pytest
+from grpc_tools import protoc
+from grpc_health.v1 import health_pb2, health_pb2_grpc
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_SERVICE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+_PROTO_DIR = os.path.join(_SERVICE_DIR, "proto")
+
+# ---------------------------------------------------------------------------
+# Exchange rates (§8) — EUR-based: 1 EUR = N units of the named currency.
+# Source: data/currency_conversion.json (European Central Bank snapshot).
+# ---------------------------------------------------------------------------
+
+RATES: dict[str, float] = {
+    "EUR": 1.0,
+    "USD": 1.1305,
+    "JPY": 126.40,
+    "BGN": 1.9558,
+    "CZK": 25.592,
+    "DKK": 7.4609,
+    "GBP": 0.85970,
+    "HUF": 315.51,
+    "PLN": 4.2996,
+    "RON": 4.7463,
+    "SEK": 10.5375,
+    "CHF": 1.1360,
+    "ISK": 136.80,
+    "NOK": 9.8040,
+    "HRK": 7.4210,
+    "RUB": 74.4208,
+    "TRY": 6.1247,
+    "AUD": 1.6072,
+    "BRL": 4.2682,
+    "CAD": 1.5128,
+    "CNY": 7.5857,
+    "HKD": 8.8743,
+    "IDR": 15999.40,
+    "ILS": 4.0875,
+    "INR": 79.4320,
+    "KRW": 1275.05,
+    "MXN": 21.7999,
+    "MYR": 4.6289,
+    "NZD": 1.6679,
+    "PHP": 59.083,
+    "SGD": 1.5349,
+    "THB": 36.012,
+    "ZAR": 16.0583,
+}
+
+EXPECTED_CURRENCIES: frozenset[str] = frozenset(RATES.keys())
+
+# ---------------------------------------------------------------------------
+# Proto generation (runs once at import time)
+#
+# grpc_tools.protoc compiles demo.proto into a temp directory which is then
+# prepended to sys.path so the generated modules can be imported normally.
+# The health service uses the grpcio-health-checking package stubs to avoid a
+# naming conflict between the generated grpc/health/v1/ directory tree and the
+# already-installed `grpc` Python package.
+# ---------------------------------------------------------------------------
+
+_GENERATED_DIR = tempfile.mkdtemp(prefix="currency_protos_")
+
+_rc = protoc.main([
+    "grpc_tools.protoc",
+    f"--proto_path={_PROTO_DIR}",
+    f"--python_out={_GENERATED_DIR}",
+    f"--grpc_python_out={_GENERATED_DIR}",
+    "demo.proto",
+])
+if _rc != 0:
+    raise RuntimeError(f"protoc failed for demo.proto (exit {_rc})")
+
+sys.path.insert(0, _GENERATED_DIR)
+import demo_pb2          # noqa: E402  (generated, not on disk before import)
+import demo_pb2_grpc     # noqa: E402
+
+Money = demo_pb2.Money
+Empty = demo_pb2.Empty
+CurrencyConversionRequest = demo_pb2.CurrencyConversionRequest
+GetSupportedCurrenciesResponse = demo_pb2.GetSupportedCurrenciesResponse
+
+# True when exercising a non-Node.js binary (e.g. the C++ reimplementation).
+# Drives conditional xfail/skip markers so the same file works against both.
+_ALT_BIN = bool(os.environ.get("CURRENCY_SERVICE_BIN") or os.environ.get("CURRENCY_SERVICE_URL"))
+# True when connecting to a pre-running service — process-startup tests are skipped.
+_EXTERNAL_SVC = bool(os.environ.get("CURRENCY_SERVICE_URL"))
+
+
+def _make_request(from_code: str, units: int, nanos: int, to_code: str) -> CurrencyConversionRequest:
+    """Construct a CurrencyConversionRequest.
+
+    The proto field is named 'from', which is a Python keyword, so we pass
+    it via **{} unpacking rather than as a direct keyword argument.
+    """
+    money = Money(currency_code=from_code, units=units, nanos=nanos)
+    return CurrencyConversionRequest(**{"from": money, "to_code": to_code})
+
+
+# ---------------------------------------------------------------------------
+# JavaScript-exact arithmetic (§3.2, §3.3)
+#
+# The Node.js _carry() function uses JavaScript's % operator, which has
+# the same sign as the *dividend* (i.e. fmod semantics, not Python's %).
+# We therefore use math.fmod throughout to stay bit-for-bit identical to the
+# IEEE 754 double arithmetic performed by V8.
+# ---------------------------------------------------------------------------
+
+def _js_carry(units: float, nanos: float) -> tuple[float, float]:
+    """Python replica of the Node.js _carry() helper (server.js:117-123)."""
+    fraction_size = 1_000_000_000
+    nanos += math.fmod(units, 1) * fraction_size
+    units = math.floor(units) + math.floor(nanos / fraction_size)
+    nanos = math.fmod(nanos, fraction_size)
+    return units, nanos
+
+
+def expected_convert(
+    from_units: int,
+    from_nanos: int,
+    from_code: str,
+    to_code: str,
+) -> tuple[int, int, str]:
+    """Return (units, nanos, currency_code) using the exact JS two-step algorithm.
+
+    Step 1 — source currency → EUR:
+        divide units and nanos by data[from_code], _carry, Math.round nanos.
+    Step 2 — EUR → target currency:
+        multiply by data[to_code], _carry, Math.floor units and nanos.
+
+    The asymmetric rounding (round after step 1, floor after step 2) is an
+    intentional property of the original implementation documented in §3.3.
+    """
+    rate_from = RATES[from_code]
+    rate_to = RATES[to_code]
+
+    # Step 1: from_currency → EUR
+    eu, en = from_units / rate_from, from_nanos / rate_from
+    eu, en = _js_carry(eu, en)
+    en = round(en)  # Math.round — nearest integer, ties to +inf
+
+    # Step 2: EUR → to_currency
+    ru, rn = eu * rate_to, en * rate_to
+    ru, rn = _js_carry(ru, rn)
+
+    # Final truncation (Math.floor, not Math.round)
+    return int(math.floor(ru)), int(math.floor(rn)), to_code
+
+
+# ---------------------------------------------------------------------------
+# Server lifecycle fixtures
+# ---------------------------------------------------------------------------
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def node_server():
+    """Start the currency service and yield its gRPC address (host:port).
+
+    Three modes, selected by environment variables:
+
+    1. Default — Node.js:
+           pytest tests/ -v
+
+    2. Local C++ binary:
+           CURRENCY_SERVICE_BIN=/path/to/build/server pytest tests/ -v
+
+    3. Already-running service (e.g. a Docker container):
+           CURRENCY_SERVICE_URL=localhost:7001 pytest tests/ -v
+       No subprocess is spawned; the fixture just waits for the address to
+       become ready and tears down nothing.
+    """
+    # Mode 3: connect to a pre-running service.
+    url = os.environ.get("CURRENCY_SERVICE_URL")
+    if url:
+        ch = grpc.insecure_channel(url)
+        deadline = time.monotonic() + 20.0
+        while time.monotonic() < deadline:
+            try:
+                grpc.channel_ready_future(ch).result(timeout=1.0)
+                break
+            except grpc.FutureTimeoutError:
+                pass
+        else:
+            pytest.fail(f"Service at {url} did not become ready within 20 s")
+        ch.close()
+        yield url
+        return
+
+    # Modes 1 & 2: spawn a subprocess.
+    port = _free_port()
+    env = os.environ.copy()
+    env["PORT"] = str(port)
+    env.pop("ENABLE_TRACING", None)
+
+    alt_bin = os.environ.get("CURRENCY_SERVICE_BIN")
+    if alt_bin:
+        cmd = [os.path.abspath(alt_bin)]
+        cwd = _SERVICE_DIR   # data/ is found relative to here
+    else:
+        cmd = ["node", "server.js"]
+        cwd = _SERVICE_DIR
+        env["DISABLE_PROFILER"] = "1"
+
+    proc = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    addr = f"localhost:{port}"
+    channel = grpc.insecure_channel(addr)
+    deadline = time.monotonic() + 20.0
+    ready = False
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            _, stderr = proc.communicate()
+            pytest.fail(
+                f"currencyservice process exited unexpectedly: {stderr.decode()}"
+            )
+        try:
+            grpc.channel_ready_future(channel).result(timeout=1.0)
+            ready = True
+            break
+        except grpc.FutureTimeoutError:
+            pass
+
+    if not ready:
+        proc.terminate()
+        pytest.fail(f"currencyservice did not become ready on {addr} within 20 s")
+
+    yield addr
+
+    channel.close()
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+@pytest.fixture(scope="session")
+def channel(node_server):
+    ch = grpc.insecure_channel(node_server)  # node_server is now host:port
+    yield ch
+    ch.close()
+
+
+@pytest.fixture(scope="session")
+def stub(channel):
+    return demo_pb2_grpc.CurrencyServiceStub(channel)
+
+
+@pytest.fixture(scope="session")
+def health_stub(channel):
+    return health_pb2_grpc.HealthStub(channel)
+
+
+# ---------------------------------------------------------------------------
+# §7 item 1 — GetSupportedCurrencies returns all 33 expected currency codes
+# ---------------------------------------------------------------------------
+
+class TestGetSupportedCurrencies:
+    def test_returns_all_33_currency_codes(self, stub):
+        response = stub.GetSupportedCurrencies(Empty())
+        assert isinstance(response, GetSupportedCurrenciesResponse)
+        returned = set(response.currency_codes)
+        assert returned == EXPECTED_CURRENCIES, (
+            f"Missing: {EXPECTED_CURRENCIES - returned}, "
+            f"Extra: {returned - EXPECTED_CURRENCIES}"
+        )
+
+    def test_returns_exactly_33_codes(self, stub):
+        response = stub.GetSupportedCurrencies(Empty())
+        assert len(response.currency_codes) == 33
+
+    def test_all_codes_are_three_letter_strings(self, stub):
+        response = stub.GetSupportedCurrencies(Empty())
+        for code in response.currency_codes:
+            assert isinstance(code, str) and len(code) == 3, (
+                f"Unexpected currency code format: {code!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# §7 items 2–6 — Convert: core positive-amount cases
+# ---------------------------------------------------------------------------
+
+class TestConvertPositiveAmounts:
+    """§7 items 2–6: standard conversions with positive amounts."""
+
+    def _assert_convert(self, stub, fu, fn, fc, tc):
+        """Call Convert and assert the result matches expected_convert()."""
+        exp_u, exp_n, exp_code = expected_convert(fu, fn, fc, tc)
+        result = stub.Convert(_make_request(fc, fu, fn, tc))
+        assert result.currency_code == exp_code
+        assert result.units == exp_u, (
+            f"{fc} {fu}.{fn:09d} → {tc}: "
+            f"units {result.units} != expected {exp_u}"
+        )
+        assert result.nanos == exp_n, (
+            f"{fc} {fu}.{fn:09d} → {tc}: "
+            f"nanos {result.nanos} != expected {exp_n}"
+        )
+
+    # §7 item 2 — USD → EUR
+    def test_convert_usd_to_eur(self, stub):
+        self._assert_convert(stub, 300, 0, "USD", "EUR")
+
+    # §7 item 3 — EUR → USD
+    def test_convert_eur_to_usd(self, stub):
+        self._assert_convert(stub, 100, 0, "EUR", "USD")
+
+    # §7 item 4 — non-EUR to non-EUR (two-step pivot via EUR)
+    def test_convert_usd_to_jpy_two_step_pivot(self, stub):
+        """USD → EUR → JPY exercises both legs of the pivot algorithm (§3.3)."""
+        self._assert_convert(stub, 100, 0, "USD", "JPY")
+
+    # §7 item 5 — EUR → EUR identity
+    def test_convert_eur_to_eur_identity(self, stub):
+        """EUR → EUR must return the original amount unchanged (rate 1.0 both legs)."""
+        self._assert_convert(stub, 50, 0, "EUR", "EUR")
+
+    # §7 item 6 — same source and target currency (non-EUR)
+    def test_convert_same_currency_identity(self, stub):
+        """USD → USD: floating-point round-trip should still reproduce the input."""
+        self._assert_convert(stub, 100, 0, "USD", "USD")
+
+    # Additional representative pairs
+    def test_convert_chf_to_eur(self, stub):
+        self._assert_convert(stub, 300, 0, "CHF", "EUR")
+
+    def test_convert_eur_to_gbp(self, stub):
+        self._assert_convert(stub, 200, 0, "EUR", "GBP")
+
+    def test_convert_inr_to_usd(self, stub):
+        self._assert_convert(stub, 5000, 0, "INR", "USD")
+
+
+# ---------------------------------------------------------------------------
+# §7 item 9 — zero amount
+# ---------------------------------------------------------------------------
+
+class TestConvertZeroAmount:
+    def test_zero_units_and_nanos_returns_zero(self, stub):
+        """Converting a zero Money must return zero in the target currency (§7 item 9)."""
+        result = stub.Convert(_make_request("USD", 0, 0, "EUR"))
+        assert result.currency_code == "EUR"
+        assert result.units == 0
+        assert result.nanos == 0
+
+
+# ---------------------------------------------------------------------------
+# §7 item 10 — non-zero nanos, zero units
+# ---------------------------------------------------------------------------
+
+class TestConvertNanosOnly:
+    def test_nanos_input_converts_correctly(self, stub):
+        """0.5 USD (units=0, nanos=500_000_000) should convert to correct EUR nanos (§7 item 10)."""
+        exp_u, exp_n, exp_code = expected_convert(0, 500_000_000, "USD", "EUR")
+        result = stub.Convert(_make_request("USD", 0, 500_000_000, "EUR"))
+        assert result.currency_code == exp_code
+        assert result.units == exp_u
+        assert result.nanos == exp_n
+
+    def test_nanos_at_max_boundary(self, stub):
+        """nanos=999_999_999 (just under 1 full unit) should convert without overflow in step 1."""
+        exp_u, exp_n, exp_code = expected_convert(0, 999_999_999, "USD", "EUR")
+        result = stub.Convert(_make_request("USD", 0, 999_999_999, "EUR"))
+        assert result.currency_code == exp_code
+        assert result.units == exp_u
+        assert result.nanos == exp_n
+
+
+# ---------------------------------------------------------------------------
+# §7 item 11 — carry propagation: nanos overflow into units after step-2 multiply
+# ---------------------------------------------------------------------------
+
+class TestConvertCarryNanosToUnits:
+    def test_nanos_overflow_carries_into_units(self, stub):
+        """EUR 0.999999999 → USD: multiplying nanos by USD rate pushes value over 1e9,
+        so _carry must increment units by 1 (§7 item 11, §3.2).
+        """
+        # 999_999_999 nanos * 1.1305 ≈ 1_130_499_988  which is > 1e9
+        exp_u, exp_n, exp_code = expected_convert(0, 999_999_999, "EUR", "USD")
+        assert exp_u == 1, (
+            f"Pre-check: expected units=1 after carry, got {exp_u}"
+        )
+        result = stub.Convert(_make_request("EUR", 0, 999_999_999, "USD"))
+        assert result.units == exp_u
+        assert result.nanos == exp_n
+        assert result.currency_code == exp_code
+
+
+# ---------------------------------------------------------------------------
+# §7 item 12 — carry propagation: fractional units fold into nanos (step-1 carry)
+# ---------------------------------------------------------------------------
+
+class TestConvertCarryUnitsToNanos:
+    def test_fractional_units_fold_into_nanos(self, stub):
+        """1 USD ≈ 0.884 EUR: dividing by the USD rate produces a fractional units
+        value which _carry must move into nanos, leaving units=0 (§7 item 12, §3.2).
+        """
+        exp_u, exp_n, exp_code = expected_convert(1, 0, "USD", "EUR")
+        assert exp_u == 0, (
+            f"Pre-check: 1 USD should yield 0 whole EUR units, got {exp_u}"
+        )
+        result = stub.Convert(_make_request("USD", 1, 0, "EUR"))
+        assert result.units == exp_u
+        assert result.nanos == exp_n
+        assert result.currency_code == exp_code
+
+
+# ---------------------------------------------------------------------------
+# §7 item 13 — negative Money amounts
+# ---------------------------------------------------------------------------
+
+class TestConvertNegativeAmounts:
+    @pytest.mark.skipif(
+        _ALT_BIN,
+        reason="C++ uses trunc-based carry so it returns the correct result, not the buggy one",
+    )
+    def test_negative_units_returns_expected_buggy_result(self, stub):
+        """Negative amounts expose a known flaw in _carry for negative values (§6.5).
+
+        The JS _carry() uses Math.floor (rounds toward −∞) combined with fmod
+        (sign of dividend), which causes the fractional part to be subtracted
+        *twice* for negative inputs.  E.g. -10 USD → EUR yields units=-11 rather
+        than the mathematically correct ≈ -8.85.
+        """
+        exp_u, exp_n, _ = expected_convert(-10, 0, "USD", "EUR")
+        assert exp_u == -11, f"Helper must reproduce the known buggy value -11, got {exp_u}"
+        result = stub.Convert(_make_request("USD", -10, 0, "EUR"))
+        assert result.units == exp_u
+        assert result.nanos == exp_n
+        assert result.currency_code == "EUR"
+
+    @pytest.mark.xfail(
+        not _ALT_BIN,   # xfail against Node.js; passes (xpass→pass) against C++
+        reason=(
+            "Known bug: _carry() double-subtracts the fractional part for negative "
+            "amounts (§6.5).  Node.js returns units=-11; the C++ reimplementation "
+            "uses trunc-based carry and returns the correct units=-8."
+        ),
+        strict=False,   # xpass is reported as XPASS (not failure) when C++ is correct
+    )
+    def test_negative_units_correct_result(self, stub):
+        """Assert the *correct* mathematical result for a negative conversion.
+
+        -10 USD / 1.1305 ≈ -8.846 EUR  →  units=-8, nanos in (-999999999, 0].
+        Node.js returns units=-11 (double-subtraction bug); C++ returns -8.
+        """
+        result = stub.Convert(_make_request("USD", -10, 0, "EUR"))
+        assert result.units == -8
+        assert -999_999_999 <= result.nanos <= 0
+
+
+# ---------------------------------------------------------------------------
+# §7 items 7–8 — unknown currency codes (known-failing bug, §6.2)
+# ---------------------------------------------------------------------------
+
+class TestConvertUnknownCurrencyCodes:
+    """§7 items 7–8: behaviour when an unknown currency code is supplied.
+
+    In the Node.js implementation, data[unknown_code] returns undefined, and
+    dividing or multiplying by undefined produces NaN.  NaN propagates silently
+    through _carry without throwing, so the try/catch is never triggered.  The
+    proto3 serializer coerces NaN int64/int32 fields to 0, producing a silent
+    zero-amount response instead of a gRPC error (§6.2).
+
+    The xfail tests below assert the CORRECT behaviour (a gRPC error status).
+    The C++ reimplementation must return INVALID_ARGUMENT or NOT_FOUND for
+    unknown codes to make these xfail tests pass (xpass).
+    """
+
+    @pytest.mark.skipif(
+        _ALT_BIN,
+        reason="C++ raises INVALID_ARGUMENT for unknown codes, not silent zeros",
+    )
+    def test_unknown_from_code_silently_returns_zero(self, stub):
+        """Documents the actual (buggy) Node.js output: zeros, no error raised."""
+        result = stub.Convert(_make_request("XYZ", 100, 0, "EUR"))
+        assert result.units == 0
+        assert result.nanos == 0
+        assert result.currency_code == "EUR"
+
+    @pytest.mark.skipif(
+        _ALT_BIN,
+        reason="C++ raises INVALID_ARGUMENT for unknown codes, not silent zeros",
+    )
+    def test_unknown_to_code_silently_returns_zero(self, stub):
+        """Documents the actual (buggy) Node.js output when to_code is unknown."""
+        result = stub.Convert(_make_request("EUR", 100, 0, "XYZ"))
+        assert result.units == 0
+        assert result.nanos == 0
+
+    @pytest.mark.xfail(
+        not _ALT_BIN,   # xfail against Node.js; passes against C++
+        reason=(
+            "Known bug (§6.2): Node.js silently returns zeros for unknown "
+            "from.currency_code instead of raising a gRPC error.  "
+            "C++ returns INVALID_ARGUMENT."
+        ),
+        strict=False,
+    )
+    def test_unknown_from_code_raises_grpc_error(self, stub):
+        with pytest.raises(grpc.RpcError) as exc_info:
+            stub.Convert(_make_request("XYZ", 100, 0, "EUR"))
+        assert exc_info.value.code() in (
+            grpc.StatusCode.INVALID_ARGUMENT,
+            grpc.StatusCode.NOT_FOUND,
+        )
+
+    @pytest.mark.xfail(
+        not _ALT_BIN,   # xfail against Node.js; passes against C++
+        reason=(
+            "Known bug (§6.2): Node.js silently returns zeros for unknown "
+            "to_code instead of raising a gRPC error.  "
+            "C++ returns INVALID_ARGUMENT."
+        ),
+        strict=False,
+    )
+    def test_unknown_to_code_raises_grpc_error(self, stub):
+        with pytest.raises(grpc.RpcError) as exc_info:
+            stub.Convert(_make_request("EUR", 100, 0, "XYZ"))
+        assert exc_info.value.code() in (
+            grpc.StatusCode.INVALID_ARGUMENT,
+            grpc.StatusCode.NOT_FOUND,
+        )
+
+
+# ---------------------------------------------------------------------------
+# §7 item 14 — large int64 units (floating-point precision boundary)
+# ---------------------------------------------------------------------------
+
+class TestConvertLargeAmounts:
+    def test_large_units_convert_without_crash(self, stub):
+        """int64 max-range units should not crash the service (§7 item 14).
+
+        IEEE 754 double has ~15–16 significant digits; large unit values will
+        lose precision but must not raise an exception or return a gRPC error.
+        We verify that the service responds and that result fields are integers.
+        """
+        # 10^15 units — well within int64 range but beyond double precision
+        large_units = 10 ** 15
+        result = stub.Convert(_make_request("USD", large_units, 0, "EUR"))
+        assert result.currency_code == "EUR"
+        assert isinstance(result.units, int)
+        assert isinstance(result.nanos, int)
+
+
+# ---------------------------------------------------------------------------
+# §7 item 15 — health check always returns SERVING
+# ---------------------------------------------------------------------------
+
+class TestHealthCheck:
+    def test_check_returns_serving_with_empty_service(self, health_stub):
+        """Health.Check({}) must respond SERVING regardless of service field (§7 item 15)."""
+        response = health_stub.Check(health_pb2.HealthCheckRequest())
+        assert response.status == health_pb2.HealthCheckResponse.SERVING
+
+    def test_check_returns_serving_with_named_service(self, health_stub):
+        """Health.Check with a named service must also respond SERVING."""
+        response = health_stub.Check(
+            health_pb2.HealthCheckRequest(service="hipstershop.CurrencyService")
+        )
+        assert response.status == health_pb2.HealthCheckResponse.SERVING
+
+    def test_check_returns_serving_with_unknown_service(self, health_stub):
+        """Health.Check never inspects the service field — always returns SERVING."""
+        response = health_stub.Check(
+            health_pb2.HealthCheckRequest(service="nonexistent.Service")
+        )
+        assert response.status == health_pb2.HealthCheckResponse.SERVING
+
+
+# ---------------------------------------------------------------------------
+# §7 item 16 — server startup without PORT (process-level test)
+# ---------------------------------------------------------------------------
+
+class TestServerStartup:
+    @pytest.mark.skipif(_EXTERNAL_SVC, reason="Cannot test process startup against a pre-running service")
+    def test_server_fails_without_port_env_var(self):
+        """Server should fail or refuse connections when PORT is not set (§6.8, §7 item 16).
+
+        Node.js: interpolates undefined into '[::]:undefined', grpc.Server fails to bind.
+        C++:     explicitly checks for PORT and exits 1 immediately.
+        Both: the process exits within a few seconds.
+        """
+        alt_bin = os.environ.get("CURRENCY_SERVICE_BIN")
+        env = {k: v for k, v in os.environ.items() if k != "PORT"}
+        if alt_bin:
+            cmd = [os.path.abspath(alt_bin)]
+            cwd = _SERVICE_DIR
+        else:
+            env["DISABLE_PROFILER"] = "1"
+            cmd = ["node", "server.js"]
+            cwd = _SERVICE_DIR
+        proc = subprocess.Popen(
+            cmd, cwd=cwd, env=env,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        try:
+            proc.wait(timeout=8)
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            proc.wait()
+            return  # still alive — acceptable (Node.js edge case)
+        assert proc.returncode is not None
+
+
+# ---------------------------------------------------------------------------
+# §7 item 17 — service starts and serves when ENABLE_TRACING=1
+#              (tracing enabled but collector unreachable — must not block startup)
+# ---------------------------------------------------------------------------
+
+class TestTracingStartup:
+    @pytest.mark.skipif(
+        _ALT_BIN or _EXTERNAL_SVC,
+        reason="ENABLE_TRACING is a Node.js / OpenTelemetry SDK concern; not applicable to C++ or pre-running services",
+    )
+    def test_service_starts_with_tracing_enabled_no_collector(self):
+        """Server must start and serve requests even when ENABLE_TRACING=1 and
+        no OTLP collector is reachable (§7 item 17).  Trace export failures must
+        be non-fatal (the OTel SDK retries in the background).
+        """
+        port = _free_port()
+        env = os.environ.copy()
+        env["PORT"] = str(port)
+        env["DISABLE_PROFILER"] = "1"
+        env["ENABLE_TRACING"] = "1"
+        env["COLLECTOR_SERVICE_ADDR"] = "localhost:4317"  # nothing listening here
+
+        proc = subprocess.Popen(
+            ["node", "server.js"],
+            cwd=_SERVICE_DIR,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            ch = grpc.insecure_channel(f"localhost:{port}")
+            deadline = time.monotonic() + 15.0
+            ready = False
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    _, stderr = proc.communicate()
+                    pytest.fail(f"Server exited early with tracing enabled: {stderr.decode()}")
+                try:
+                    grpc.channel_ready_future(ch).result(timeout=1.0)
+                    ready = True
+                    break
+                except grpc.FutureTimeoutError:
+                    pass
+
+            assert ready, f"Server with ENABLE_TRACING=1 did not become ready on port {port}"
+
+            # Verify it still serves a basic request
+            local_stub = demo_pb2_grpc.CurrencyServiceStub(ch)
+            response = local_stub.GetSupportedCurrencies(Empty())
+            assert len(response.currency_codes) == 33
+        finally:
+            ch.close()
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+# ---------------------------------------------------------------------------
+# Asymmetric rounding property (§3.3) — explicit verification
+# ---------------------------------------------------------------------------
+
+class TestAsymmetricRounding:
+    """Directly verify that step-1 uses Math.round and step-2 uses Math.floor.
+
+    This is the key algorithmic property that distinguishes the currencyservice
+    from a naive implementation.  We test it with a value engineered so the
+    two rounding modes produce different nanos.
+    """
+
+    def test_step1_uses_round_not_floor(self, stub):
+        """After dividing by rate_from, nanos are rounded (not floored).
+
+        CHF 300.0 → EUR: dividing 0 nanos by CHF rate produces a non-integer
+        intermediate EUR nanos that differs between round() and floor().
+        The expected value was verified against the live Node.js service.
+        """
+        exp_u, exp_n, exp_code = expected_convert(300, 0, "CHF", "EUR")
+        result = stub.Convert(_make_request("CHF", 300, 0, "EUR"))
+        assert result.units == exp_u
+        assert result.nanos == exp_n
+        assert result.currency_code == exp_code
+
+    def test_step2_uses_floor_not_round(self, stub):
+        """After multiplying EUR amount by rate_to, units and nanos are floored.
+
+        EUR 1.0 → USD: multiplying 1 unit by 1.1305 produces 1.1305.
+        _carry isolates 0.1305 * 1e9 = 130_500_000 into nanos.
+        floor(130_500_000.xxx) keeps the value rather than rounding up.
+        """
+        exp_u, exp_n, exp_code = expected_convert(1, 0, "EUR", "USD")
+        result = stub.Convert(_make_request("EUR", 1, 0, "USD"))
+        assert result.units == exp_u
+        assert result.nanos == exp_n
+        assert result.currency_code == exp_code


### PR DESCRIPTION
## Summary

- Replaces the Node.js `currencyservice` with a C++ reimplementation (`src/currencyservice-cpp/`) that fixes two known bugs in the original:
  - **Negative-amount carry bug**: JS `Math.floor` on negative values double-subtracts the fractional part; C++ uses `std::trunc` instead
  - **Unknown currency codes**: Node.js silently returns zero; C++ returns `INVALID_ARGUMENT` gRPC status
- Adds a `currencyservice-spec.md` documenting all service behaviors (including known Node.js bugs) as a source of truth
- Adds a 30-test pytest contract suite (`tests/test_currency_contract.py`) runnable against Node.js, a local C++ binary, or a Docker container

## Test plan

- [ ] Run contract tests against Node.js: `pytest tests/test_currency_contract.py -v` → 27 passed, 3 xfailed
- [ ] Build C++ binary locally: `cmake -B build && cmake --build build` (requires grpc++, protobuf, nlohmann-json)
- [ ] Run contract tests against C++ binary: `CURRENCY_SERVICE_BIN=build/server pytest tests/test_currency_contract.py -v` → 26 passed, 4 skipped
- [ ] Build Docker image: `docker build -t currencyservice -f src/currencyservice-cpp/Dockerfile src/`
- [ ] Run contract tests against container: `CURRENCY_SERVICE_URL=localhost:7001 pytest tests/test_currency_contract.py -v` → 25 passed, 5 skipped
- [ ] Deploy with skaffold: `skaffold run` (image now built from `currencyservice-cpp/Dockerfile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)