### PR TITLE
ci: restrict self-hosted PR jobs to same-repo pull requests

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -33,6 +33,13 @@ concurrency:
 
 jobs:
   code-tests:
+    # Only run on the privileged self-hosted runner for same-repo pull requests.
+    # Fork PRs must not execute untrusted code here: these runners are persistent
+    # GCE VMs whose attached service account (GKE/GCR/GCS) is reachable through the
+    # metadata server regardless of whether GitHub secrets are forwarded. This
+    # matches the documented requirement to branch directly off the repository
+    # rather than from a fork.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, is-enabled]
     steps:
     - uses: actions/checkout@v6
@@ -59,6 +66,10 @@ jobs:
         dotnet test src/cartservice/
 
   deployment-tests:
+    # Same-repo pull requests only (see code-tests). Never build/deploy
+    # attacker-controlled fork code to the shared GKE cluster from the
+    # service-account-bearing self-hosted runner.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, is-enabled]
     needs: code-tests
     strategy:


### PR DESCRIPTION
Continuous Integration - Pull Request (`.github/workflows/ci-pr.yaml`) runs `code-tests` and `deployment-tests` on the persistent self-hosted GCE VM runners (`runs-on: [self-hosted, is-enabled]`). Both jobs execute pull-request code: `code-tests` runs `go test` / `dotnet test`, and `deployment-tests` checks out `github.event.pull_request.head.sha` and runs `skaffold run` against the PR's `skaffold.yaml` and Dockerfiles.

The Google Cloud access these jobs use (GKE `get-credentials`, `gcloud auth configure-docker`, image push, GCS) comes from the runner VM's attached service account, reachable from the workload through the GCE metadata server. It does not come from forwarded GitHub Actions secrets. The workflow README notes that contributors must branch directly off the repository because "the GitHub secrets necessary for these tests aren't copied over when you fork" - but that protection does not apply here, because the credential is the runner VM identity rather than a GitHub secret.

As a result a pull request opened from a fork can run attacker-controlled code on the privileged self-hosted runner and read the service-account token from the metadata server, which has GKE access plus Artifact Registry/GCR push and GCS create on the CI project.

This change gates both jobs on `github.event.pull_request.head.repo.full_name == github.repository`, so the privileged self-hosted jobs run only for same-repo pull requests. That codifies the existing documented policy (branch off the repo, not a fork) and stops untrusted fork code from executing on the runner. Internal-branch PRs are unaffected.

A fuller alternative, if you want to keep running CI on external contributions, is to move fork PR builds to ephemeral GitHub-hosted runners and perform the GKE deploy in a separate, environment-gated job with required reviewers and no fork-head checkout. The job-level guard here is the minimal fix and can stand on its own.