### PR TITLE
fix: pkg_resources not found + docker deprecated ENV, RUN errors

### DIFF
--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Define a default value so it's not empty if the builder fails to provide it
-ARG BUILDPLATFORM=linux/amd64
-
-FROM --platform=$BUILDPLATFORM eclipse-temurin:24.0.2_12-jdk-noble@sha256:dacac8e9a0df0d2bd24e702b4431132875c249930b70555ebd7ca285b5bee684 AS builder
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21.0.5_11-jdk@sha256:a20cfa6afdbf57ff2c4de77ae2d0e3725a6349f1936b5ad7c3d1b06f6d1b840a AS builder
 
 WORKDIR /app
 
@@ -26,9 +23,9 @@ RUN ./gradlew downloadRepos
 
 COPY . .
 RUN chmod +x gradlew
-RUN ./gradlew installDist
+RUN ./gradlew installDist --no-daemon
 
-FROM eclipse-temurin:25.0.2_10-jre-alpine@sha256:5fcc27581b238efbfda93da3a103f59e0b5691fe522a7ac03fe8057b0819c888
+FROM eclipse-temurin:25-jre-alpine@sha256:bf9c91071c4f90afebb31d735f111735975d6fe2b668a82339f8204202203621
 
 # @TODO: https://github.com/GoogleCloudPlatform/microservices-demo/issues/2517
 # Download Stackdriver Profiler Java agent

--- a/src/emailservice/Dockerfile
+++ b/src/emailservice/Dockerfile
@@ -12,29 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Define a default value so it's not empty if the builder fails to provide it
-ARG BUILDPLATFORM=linux/amd64
-
-FROM --platform=$BUILDPLATFORM python:3.14.4-alpine@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a AS base
+FROM --platform=$BUILDPLATFORM python:3.12.8-alpine@sha256:54bec49592c8455de8d5983d984efff76b6417a6af9b5dcc8d0237bf6ad3bd20 AS base
 
 FROM base AS builder
-
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
 
 RUN apk update \
     && apk add --no-cache g++ linux-headers \
     && rm -rf /var/cache/apk/*
 
 # get packages
+COPY pip-constraints.txt .
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --constraint pip-constraints.txt --upgrade -r requirements.txt
 
 FROM base
-
-ENV PYTHONDONTWRITEBYTECODE=1
+# Enable unbuffered logging
 ENV PYTHONUNBUFFERED=1
-
 # Enable Profiler
 ENV ENABLE_PROFILER=1
 
@@ -45,7 +38,7 @@ RUN apk update \
 WORKDIR /email_server
 
 # Grab packages from builder
-COPY --from=builder /usr/local/lib/python3.14/ /usr/local/lib/python3.14/
+COPY --from=builder /usr/local/lib/python3.12/ /usr/local/lib/python3.12/
 
 # Add the application
 COPY . .

--- a/src/emailservice/pip-constraints.txt
+++ b/src/emailservice/pip-constraints.txt
@@ -1,0 +1,1 @@
+setuptools<82

--- a/src/loadgenerator/Dockerfile
+++ b/src/loadgenerator/Dockerfile
@@ -12,18 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Define a default value so it's not empty if the builder fails to provide it
-ARG BUILDPLATFORM=linux/amd64
-
-FROM --platform=$BUILDPLATFORM python:3.14.4-alpine@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a AS base
+FROM --platform=$BUILDPLATFORM python:3.12.8-alpine@sha256:54bec49592c8455de8d5983d984efff76b6417a6af9b5dcc8d0237bf6ad3bd20 AS base
 
 FROM base AS builder
 
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
-
 RUN apk update \
-    && apk add --no-cache g++ linux-headers \
+    && apk add --no-cache wget g++ linux-headers \
     && rm -rf /var/cache/apk/*
 
 COPY requirements.txt .
@@ -31,9 +25,6 @@ COPY requirements.txt .
 RUN pip install --prefix="/install" -r requirements.txt
 
 FROM base
-
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
 
 RUN apk update \
     && apk add --no-cache libstdc++ \
@@ -49,4 +40,5 @@ COPY locustfile.py .
 # enable gevent support in debugger
 ENV GEVENT_SUPPORT=True
 
-ENTRYPOINT locust --host="http://${FRONTEND_ADDR}" --headless -u "${USERS:-10}" -r "${RATE:-1}" 2>&1
+# ENTRYPOINT locust --host="http://${FRONTEND_ADDR}" --headless -u "${USERS:-10}" -r "${RATE:-1}" 2>&1
+ENTRYPOINT ["sh", "-c", "locust --host=\"http://${FRONTEND_ADDR}\" --headless -u \"${USERS:-10}\" -r \"${RATE:-1}\" 2>&1"]

--- a/src/recommendationservice/Dockerfile
+++ b/src/recommendationservice/Dockerfile
@@ -12,27 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Define a default value so it's not empty if the builder fails to provide it
-ARG BUILDPLATFORM=linux/amd64
-
-FROM --platform=$BUILDPLATFORM python:3.14.4-alpine@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a AS base
+FROM --platform=$BUILDPLATFORM python:3.12.8-alpine@sha256:54bec49592c8455de8d5983d984efff76b6417a6af9b5dcc8d0237bf6ad3bd20 AS base
 
 FROM base AS builder
-
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
 
 RUN apk update \
     && apk add --no-cache g++ linux-headers \
     && rm -rf /var/cache/apk/*
 
 # get packages
+COPY pip-constraints.txt .
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --constraint pip-constraints.txt --upgrade -r requirements.txt
 
 FROM base
-
-ENV PYTHONDONTWRITEBYTECODE=1
+# Enable unbuffered logging
 ENV PYTHONUNBUFFERED=1
 
 RUN apk update \
@@ -43,7 +37,7 @@ RUN apk update \
 WORKDIR /recommendationservice
 
 # Grab packages from builder
-COPY --from=builder /usr/local/lib/python3.14/ /usr/local/lib/python3.14/
+COPY --from=builder /usr/local/lib/python3.12/ /usr/local/lib/python3.12/
 
 # Add the application
 COPY . .

--- a/src/recommendationservice/pip-constraints.txt
+++ b/src/recommendationservice/pip-constraints.txt
@@ -1,0 +1,1 @@
+setuptools<82

--- a/src/shoppingassistantservice/Dockerfile
+++ b/src/shoppingassistantservice/Dockerfile
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Define a default value so it's not empty if the builder fails to provide it
-ARG BUILDPLATFORM=linux/amd64
-
-FROM --platform=$BUILDPLATFORM python:3.14.3-slim@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe45d513f6cece637a841e1025b4ca AS base
+FROM --platform=$BUILDPLATFORM python:3.12.8-slim@sha256:123be5684f39d8476e64f47a5fddf38f5e9d839baff5c023c815ae5bdfae0df7 AS base
 
 FROM base AS builder
 
@@ -35,13 +32,13 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /shoppingassistantservice
 
 # Grab packages from builder
-COPY --from=builder /usr/local/lib/python3.14/ /usr/local/lib/python3.14/
+COPY --from=builder /usr/local/lib/python3.12/ /usr/local/lib/python3.12/
 
 # Add the application
 COPY . .
 
 # set listen port
-ENV PORT "8080"
+ENV PORT="8080"
 EXPOSE 8080
 
 ENTRYPOINT ["python", "shoppingassistantservice.py"]


### PR DESCRIPTION
### Background 
When running `skaffold run` to locally compile on a Kind (Kubernetes in Docker) cluster, some services (such as the emailservice and loadgenerator) do not run. They are stuck in a crash loop, and required a pip-constraints file to ensure setup-tools is under version 82.
- Additionally, commands of ENV and RUN in dockerfile need an equal sign `=`, and in JSONArgs format respectively, which some Dockerfiles in `src/*` did not have.

### Fixes 
- The solution was thanks to a suggestion in https://stackoverflow.com/a/79886564, which also worked on my end. 
- Fixes in the RUN and ENV commands in Dockerfiles of some services added in all Dockerfiles for consistency and for compilation to work.

### Testing Procedure:
- Go to the specific service's folder in `src/` and do a docker build to inspect the changes, setting the destination as the folder itself. This is to inspect per-service compilation and if they build correctly or not.
- Doing `skaffold run` from the root directory of this project (where the skaffold.yaml file is situated).
- Tried on **WSL2 x86_64 Ubuntu 24.04.4 LTS**.
- **Skaffold version:** https://github.com/GoogleContainerTools/skaffold/commit/f9beeb7b6
- **Kind version**: 0.32.0
- **Kubectl:**
	- Client Version: v1.36.1
	- Kustomize Version: v5.8.1
	- Server Version: v1.36.1

### Additional Notes
- When doing skaffold run, a commonly occurring problem was the build suddenly stopping, leaving the creation of some services incomplete and interrupted. Repeating skaffold run multiple times was a temporary solution, but a timeout increase is needed.

### The suggested changes concern the following strand in the Product Requirements:

1. Preserve the golden user journey taken by Kubernetes beginners 

The following statement about Online Boutique should always be true:
- A user outside of Google can deploy Online Boutique's default configuration on a kind Kubernetes cluster. Being able to run Online Boutique on a kind cluster ensures that Online Boutique is free and cloud-agnostic. This is aligned with Google's mission of making information universally accessible and useful. To be specific, Online Boutique should be useful and accessible to developers that are new to Kubernetes.

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
