### PR TITLE
Update cartservice Dockerfile to support ARM64

### DIFF
--- a/src/cartservice/src/Dockerfile
+++ b/src/cartservice/src/Dockerfile
@@ -14,10 +14,12 @@
 
 # Define a default value so it's not empty if the builder fails to provide it
 ARG BUILDPLATFORM=linux/amd64
+ARG TARGETPLATFORM=linux/amd64
+ARG TARGETARCH=amd64
 
 # https://mcr.microsoft.com/product/dotnet/sdk
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0.100-noble@sha256:c7445f141c04f1a6b454181bd098dcfa606c61ba0bd213d0a702489e5bd4cd71 AS builder
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 WORKDIR /app
 COPY cartservice.csproj .
 RUN dotnet restore cartservice.csproj \
@@ -33,7 +35,7 @@ RUN dotnet publish cartservice.csproj \
     -o /cartservice
 
 # https://mcr.microsoft.com/product/dotnet/runtime-deps
-FROM mcr.microsoft.com/dotnet/runtime-deps:10.0.0-noble-chiseled@sha256:b857c8cb8d929183cfe4c6dd9994abba92a2639dd2dbaf06005379f815991604
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/dotnet/runtime-deps:10.0.0-noble-chiseled@sha256:b857c8cb8d929183cfe4c6dd9994abba92a2639dd2dbaf06005379f815991604
 
 WORKDIR /app
 COPY --from=builder /cartservice .


### PR DESCRIPTION
### Background 
cartservice failed to start on MacOS with ARM64 arch with the following error:
```
rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2
```

### Fixes 
https://github.com/GoogleCloudPlatform/microservices-demo/issues/3435

### Change Summary
Use $TARGETPLATFORM when fetching runtime image, and include appropriate default values for BUILDPLATFORM, TARGETPLATFORM, and TARGETARCH.

### Testing Procedure
* Ran `skaffold run` which started service successfully
*  Ran `kubectl port-forward deployment/frontend 8080:8080` and confirmed that service seem to work normally.