### PR TITLE
Registrar las decisiones arquitectonicas como ADR

### DIFF
--- a/docs/adr/0001-github-flow-como-estrategia-de-ramificacion.md
+++ b/docs/adr/0001-github-flow-como-estrategia-de-ramificacion.md
@@ -1,0 +1,38 @@
+# ADR 0001 — GitHub Flow como estrategia de ramificación
+
+**Estado:** Aceptada · 2026-08-25
+
+## Contexto
+
+El proyecto necesita una estrategia de ramificación, y es un criterio evaluado por sí solo (25 puntos). Las condiciones reales son:
+
+- Equipo de **dos personas**, sin roles separados de desarrollo y operación.
+- Entregas **por fases**, no por versiones de producto.
+- El repositorio base ya trae automatización de construcción y despliegue, que exige una rama principal sana.
+- No hay ambientes múltiples: no existe *staging* propio ni versiones soportadas en paralelo.
+
+Alternativas consideradas:
+
+| Estrategia | Por qué se descarta |
+|---|---|
+| **GitFlow** | Ramas `develop`, `release` y `hotfix` para un equipo de dos personas sin versiones soportadas en paralelo. Sobrecarga de ceremonia sin problema que resuelva |
+| **Trunk-Based Development** | Depende de *feature flags* y de una suite de pruebas madura para integrar directo a `main`. El repositorio no la tiene y el equipo no puede construirla en un semestre |
+| **GitLab Flow** | Introduce ramas por ambiente. El proyecto tiene un solo ambiente |
+
+## Decisión
+
+Se adopta **GitHub Flow**: `main` siempre desplegable, ramas de vida corta con prefijo (`feature/`, `fix/`, `docs/`, `chore/`), e integración exclusivamente por Pull Request revisado por el otro integrante.
+
+La regla se hace cumplir por la plataforma, no por disciplina: protección de rama sobre `main` exigiendo Pull Request y al menos una aprobación.
+
+## Consecuencias
+
+- **+** Es la estrategia más simple que satisface la condición que la automatización necesita: una rama principal siempre sana.
+- **+** El Pull Request genera documentación del proceso de forma automática — evidencia sin trabajo adicional.
+- **+** Habilita el despliegue continuo del [ADR 0008](0008-despliegue-continuo-en-dos-fases.md): si `main` siempre está desplegable, cada merge puede desplegar.
+- **−** Con dos personas, **el autor no puede aprobar su propio Pull Request**. Ambos integrantes deben tener permiso de escritura en el fork o el flujo se bloquea.
+- **−** Sin ramas de release, no hay forma de sostener dos versiones a la vez. No se necesita hoy; sería un problema si el proyecto continuara después del semestre.
+
+## Referencias
+
+Estrategia de ramificación del equipo (GitHub Flow) y la actividad de la materia.

--- a/docs/adr/0002-servicio-nuevo-en-lugar-de-extender-shippingservice.md
+++ b/docs/adr/0002-servicio-nuevo-en-lugar-de-extender-shippingservice.md
@@ -1,0 +1,31 @@
+# ADR 0002 — Servicio nuevo en lugar de extender shippingservice
+
+**Estado:** Aceptada · 2026-08-25
+
+## Contexto
+
+El seguimiento de pedidos necesita persistir los pedidos y consultarlos por número de rastreo. `shippingservice` ya genera ese número (`src/shippingservice/tracker.go`), así que agregarle ahí la persistencia y la consulta parecía la opción de menor esfuerzo.
+
+## Decisión
+
+Se crea un microservicio nuevo, **`orderservice`**, en Go, en lugar de extender `shippingservice`.
+
+Razones:
+
+- **Responsabilidad distinta.** `shippingservice` cotiza y despacha; guardar el historial de pedidos es otra cosa. Mezclarlas produce el acoplamiento que una arquitectura de microservicios existe para evitar.
+- **Estado.** `shippingservice` hoy no tiene estado. Convertirlo en un servicio con estado cambia su naturaleza operativa: pasa a necesitar respaldo, arranque ordenado y una dependencia externa.
+- **Valor para la materia.** Un servicio nuevo obliga a recorrer los 8 pasos de `docs/adding-new-microservice.md` — imagen, manifiestos, Skaffold, Helm, documentación. Una extensión no construye ninguna pieza de despliegue nueva, que es justo lo que el proyecto evalúa.
+
+El repositorio ya trae el molde: `shoppingassistantservice` es un servicio agregado después del diseño original y entregado como componente opcional. Se sigue ese patrón.
+
+## Consecuencias
+
+- **+** Separación de responsabilidades clara; `shippingservice` se mantiene sin estado.
+- **+** Ejercita el ciclo DevOps completo, que es el objetivo real del proyecto.
+- **+** Hay un ejemplo dentro del propio repositorio a copiar en lugar de inventar convenciones.
+- **−** Un servicio más que construir, desplegar, observar y mantener.
+- **−** Un salto de red adicional en el camino del checkout, con su latencia y su modo de falla — que es lo que obliga al [ADR 0006](0006-registro-sincrono-sin-cola-ni-eventos.md).
+
+## Referencias
+
+Propuesta de proyecto §2.1 y el análisis del feature.

--- a/docs/adr/0003-conservar-el-tracking-id-aleatorio.md
+++ b/docs/adr/0003-conservar-el-tracking-id-aleatorio.md
@@ -1,0 +1,29 @@
+# ADR 0003 — Conservar el tracking ID aleatorio, solo persistirlo
+
+**Estado:** Aceptada · 2026-08-25
+
+## Contexto
+
+`CreateTrackingId` en `src/shippingservice/tracker.go` arma el número de rastreo con `math/rand` y no lo guarda en ningún lado. La lectura inicial fue que "el número es falso" y que había que rediseñarlo — por ejemplo derivándolo del `order_id`, o moviendo su generación a otro servicio.
+
+Eso habría implicado modificar `ShipOrder` y `ShipOrderResponse`, es decir, tocar un contrato gRPC que consumen servicios que nadie más va a editar.
+
+## Decisión
+
+**El número de rastreo se conserva aleatorio.** Lo que cambia es que ahora se persiste.
+
+`shippingservice` sigue generándolo exactamente igual que hoy; `checkoutservice` lo recibe y se lo entrega a `orderservice` junto con el resto del pedido, que lo usa como llave de consulta.
+
+**No se modifican `ShipOrder` ni `ShipOrderResponse`.**
+
+## Consecuencias
+
+- **+** El defecto real nunca fue la aleatoriedad sino la ausencia de persistencia. Un identificador aleatorio persistido es una llave de consulta perfectamente válida.
+- **+** El contrato existente queda intacto y el radio de impacto del cambio se reduce al mínimo: se agrega un servicio al proto, no se modifica ninguno.
+- **+** `shippingservice` no se toca en absoluto.
+- **−** El formato tiene **poca entropía** (`XX-NDDD-NDDDDDDD`), así que los números son adivinables. Combinado con el [ADR 0009](0009-consulta-anonima-sin-autenticacion.md), eso significa que un tercero podría enumerar pedidos. Se acepta para la demostración y se mitiga no devolviendo datos personales en la consulta.
+- **−** No hay garantía formal de unicidad. Con el volumen de una demo el riesgo de colisión es despreciable, pero existe.
+
+## Referencias
+
+Propuesta de proyecto §2.2.

--- a/docs/adr/0004-redis-con-el-pedido-serializado-como-un-valor.md
+++ b/docs/adr/0004-redis-con-el-pedido-serializado-como-un-valor.md
@@ -1,0 +1,44 @@
+# ADR 0004 — Redis, con el pedido serializado como un solo valor
+
+**Estado:** Aceptada · 2026-08-25
+
+## Contexto
+
+`orderservice` necesita guardar pedidos. El patrón de acceso es uno solo: *"dame el pedido con este número de rastreo"*. No hay listados, ni búsquedas por otro campo, ni reportes.
+
+Alternativas: una base relacional (PostgreSQL, Cloud SQL), un almacén de documentos, o Redis.
+
+El repositorio impone además una restricción dura en `docs/product-requirements.md`: el despliegue por defecto debe funcionar en un clúster local sin nube y sin agregar pasos al *quickstart*.
+
+## Decisión
+
+Se despliega una instancia de **Redis dedicada (`redis-orders`)**, replicando lo que `kustomize/base/cartservice.yaml` hace con `redis-cart`: imagen `redis:alpine`, volumen `emptyDir`, servicio interno del clúster.
+
+**El pedido completo se serializa y se guarda como un solo valor**, bajo la llave del número de rastreo:
+
+```
+llave:  "OS-4A9F21"
+valor:  { order_id, tracking_id, fecha_compra,
+          shipping_address, shipping_cost,
+          items: [ { product_id, cantidad, costo }, ... ] }
+```
+
+Los artículos viven **dentro** del pedido, no en registros aparte. Una escritura al comprar, una lectura al consultar, cero uniones.
+
+**Los nombres e imágenes de producto no se guardan:** se resuelven contra `productcatalogservice` al pintar la pantalla, igual que ya hace la vista del carrito (`src/frontend/handlers.go:285`).
+
+## Consecuencias
+
+- **+** Redis ya está en el repositorio: no introduce tecnología ni pasos nuevos.
+- **+** El acceso por llave directa es exactamente para lo que Redis sirve.
+- **+** Corre gratis en local; no exige Cloud SQL, Spanner ni AlloyDB.
+- **+** No se duplican datos que son propiedad de `productcatalogservice`, así que un cambio de catálogo no deja el pedido mostrando información obsoleta.
+- **−** **`emptyDir` no sobrevive a la eliminación o recreación del pod.** Los pedidos se pierden. Es aceptable porque la demostración ocurre dentro de una sesión, pero no se presenta como almacenamiento duradero.
+- **−** La pantalla de rastreo depende de `productcatalogservice` en tiempo de lectura. Si un producto desapareciera del catálogo, hay que degradar mostrando el `product_id` en lugar de fallar.
+- **−** No hay consultas por otro campo. Un "mis pedidos" futuro exigiría un índice adicional o cambiar de almacén.
+
+Si una fase posterior exige durabilidad, la evolución prevista es sustituir `emptyDir` por un volumen persistente o un almacén gestionado.
+
+## Referencias
+
+Propuesta de proyecto §2.3 y §2.3.1.

--- a/docs/adr/0005-estado-derivado-del-tiempo-no-almacenado.md
+++ b/docs/adr/0005-estado-derivado-del-tiempo-no-almacenado.md
@@ -1,0 +1,32 @@
+# ADR 0005 — El estado del pedido se deriva del tiempo, no se almacena
+
+**Estado:** Aceptada · 2026-08-25
+
+## Contexto
+
+El pedido debe recorrer los estados `CREADO → PAGADO → EN_PREPARACIÓN → EN_TRÁNSITO → ENTREGADO`. La pregunta real de diseño es **quién los hace avanzar**, porque en Online Boutique nadie envía nada de verdad: `shippingservice` no habla con ninguna paquetería.
+
+Alternativas:
+
+- Un proceso en segundo plano que actualice periódicamente los registros en Redis.
+- Derivar el estado del tiempo transcurrido desde la compra, calculándolo al momento de la consulta.
+
+## Decisión
+
+**El estado se deriva del tiempo transcurrido desde la fecha de compra, y se calcula en el momento de la consulta.** No se almacena.
+
+La duración de cada etapa es configurable por variable de entorno, de modo que en una demostración el pedido recorra el ciclo completo en minutos en lugar de días.
+
+Consecuencia sobre el modelo de datos: el pedido se escribe **una sola vez** y nunca se modifica. Después del alta, el almacén es de solo lectura.
+
+## Consecuencias
+
+- **+** No agrega un proceso más que desplegar, vigilar y depurar.
+- **+** Es una **función pura** de dos entradas —fecha de compra y momento actual—, así que se prueba unitariamente sin levantar Redis ni el clúster. Encaja directo en el CI heredado.
+- **+** Sin escrituras en segundo plano no hay condiciones de carrera sobre el registro.
+- **−** El estado no puede alterarse manualmente: no hay forma de marcar un pedido como cancelado o retrasado. Coherente con el alcance, que excluye cancelaciones.
+- **−** **Con duraciones cortas, todo pedido viejo aparece como `ENTREGADO`.** Si la tienda queda accesible públicamente y alguien la revisa horas después, no verá progreso alguno. Hay que elegir duraciones acordes al modo de revisión, o mostrar la línea de tiempo con marcas de tiempo para que el avance se lea aunque ya haya terminado.
+
+## Referencias
+
+Propuesta de proyecto §2.4 y el flujo de usuario del seguimiento.

--- a/docs/adr/0006-registro-sincrono-sin-cola-ni-eventos.md
+++ b/docs/adr/0006-registro-sincrono-sin-cola-ni-eventos.md
@@ -1,0 +1,37 @@
+# ADR 0006 — Registro síncrono desde checkoutservice, sin cola ni eventos
+
+**Estado:** Aceptada · 2026-08-25
+
+## Contexto
+
+`checkoutservice` debe registrar el pedido en `orderservice` al completar la compra. Hoy `PlaceOrder` arma un `OrderResult`, lo manda por correo, lo devuelve y lo olvida (`src/checkoutservice/main.go:265`).
+
+Alternativas para el registro:
+
+- **Publicar un evento** en una cola o *broker*, que `orderservice` consuma de forma asíncrona.
+- **Llamada gRPC síncrona** desde `checkoutservice`, como las otras seis que ya hace.
+
+La primera da entrega garantizada; la segunda no introduce infraestructura nueva.
+
+## Decisión
+
+**Una sola llamada gRPC síncrona nueva en `PlaceOrder`**, justo después de armar el `OrderResult` y antes de responder.
+
+El registro **no puede tumbar la compra**: se intenta con un tiempo límite corto y hasta **tres intentos con espera incremental**, únicamente ante errores transitorios. `RecordOrder` es **idempotente por número de rastreo**, así que repetir la llamada no crea pedidos duplicados.
+
+Si `orderservice` sigue sin responder, se deja una advertencia estructurada en el log, una métrica y el error en la traza; después la compra se completa igual. Es el mismo criterio que el repositorio aplica al correo de confirmación: una función secundaria no debe provocar que el cliente repita una compra que ya pudo haber sido cobrada.
+
+## Consecuencias
+
+- **+** No agrega *broker*, cola ni consumidor: ninguna pieza de infraestructura nueva que desplegar y mantener.
+- **+** Sigue el patrón que `checkoutservice` ya usa con sus otras seis dependencias — nada nuevo que aprender.
+- **+** El fallo queda observable en log, métrica y traza, en lugar de desaparecer.
+- **−** **Si los tres intentos fallan, ese pedido no podrá rastrearse nunca.** No hay cola ni *outbox* que lo recupere. La garantía de "pedido recuperable" aplica a la operación normal, no a la degradada.
+- **−** Es una falla **silenciosa para el cliente**: la compra se completa sin avisar que el rastreo no va a funcionar. Por eso el SLI de tasa de registro del **plan de observabilidad** es el más importante de los cuatro: es lo único que vuelve visible esta limitación.
+- **−** Agrega latencia al checkout en el peor caso (tiempo límite × 3 intentos). Hay que dimensionar el límite para que no se note.
+
+Si el SLI de registro baja del objetivo, la evolución prevista es un *outbox* — y sería un ADR nuevo que reemplace a este.
+
+## Referencias
+
+Propuesta de proyecto §2.6 y el plan de observabilidad y SLIs.

--- a/docs/adr/0007-componente-opcional-con-kill-switch.md
+++ b/docs/adr/0007-componente-opcional-con-kill-switch.md
@@ -1,0 +1,38 @@
+# ADR 0007 — Entrega como componente opcional con kill switch
+
+**Estado:** Aceptada · 2026-08-25
+
+## Contexto
+
+`docs/product-requirements.md` exige que todo cambio preserve el despliegue por defecto sobre un clúster local, no complique el recorrido de demostración y no agregue pasos obligatorios al *quickstart*. Textualmente, las extensiones "deberían agregarse como un Kustomize Component al que los usuarios opten por entrar".
+
+Además, el proyecto necesita poder desplegar las **dos variantes** —con y sin el feature— para verificar el criterio de aceptación #8.
+
+## Decisión
+
+La funcionalidad completa vive en `kustomize/components/order-tracking/`, siguiendo la estructura de `kustomize/components/shopping-assistant/`. **Nada se agrega a `kustomize/base/`.**
+
+El componente hace dos cosas:
+
+1. Aporta los recursos nuevos: `orderservice` y `redis-orders`.
+2. **Parcha los Deployments de `frontend` y `checkoutservice`** inyectando `ENABLE_ORDER_TRACKING=true` y `ORDER_SERVICE_ADDR`.
+
+La variable la lee el código al arrancar, igual que `ENABLE_ASSISTANT` en `src/frontend/handlers.go:48`. Sin ella, el frontend no registra las rutas y `checkoutservice` no crea el cliente gRPC.
+
+En Helm, la misma regla con `orderTracking.enabled: false` por defecto.
+
+Para el ciclo de desarrollo se agrega un **perfil de Skaffold** llamado `order-tracking`, siguiendo el patrón del perfil `network-policies` que ya existe: `skaffold run` levanta la tienda limpia, `skaffold run -p order-tracking` la levanta con el feature.
+
+## Consecuencias
+
+- **+** Cumple el requisito de producto del repositorio base sin discusión.
+- **+** El criterio de aceptación #8 es verificable: `kubectl apply -k .` sin el componente despliega la tienda exactamente igual que hoy.
+- **+** **El mecanismo es además un interruptor de emergencia en producción.** Como la variable vive en el Deployment, un `kubectl set env` dispara un *rolling restart* y en ~30 segundos la tienda vuelve al comportamiento base — sin revertir un commit, sin reconstruir imágenes y sin redesplegar. Es el nivel 1 de **estrategia-de-rollback**.
+- **+** El interruptor existe también en el ciclo de desarrollo y en el pipeline, no solo en el despliegue final.
+- **−** Hay **dos rutas de manifiestos** en el repositorio (`kustomize/` para `kubectl apply -k`, `kubernetes-manifests/` para Skaffold) y el componente hay que conectarlo a las dos. Es la trampa que documenta la §2.8.1 de la propuesta.
+- **−** El código de `frontend` y `checkoutservice` queda con ramas condicionales que hay que probar en los dos estados.
+- **−** Apagar el feature con `kubectl set env` deja el clúster distinto de lo que dice `main`: crea deriva de configuración, y obliga a seguirlo siempre con un PR de reversión.
+
+## Referencias
+
+Propuesta de proyecto §2.8 y §2.8.1, y la estrategia de rollback.

--- a/docs/adr/0008-despliegue-continuo-en-dos-fases.md
+++ b/docs/adr/0008-despliegue-continuo-en-dos-fases.md
@@ -1,0 +1,44 @@
+# ADR 0008 — Despliegue continuo en dos fases sobre el mismo workflow
+
+**Estado:** Aceptada · 2026-08-27
+
+## Contexto
+
+La etapa *Desplegar* del ciclo DevOps se resolvía con "corremos Skaffold en la laptop", que es un desarrollador ejecutando un comando, no despliegue continuo. Es el corazón de lo que la materia evalúa.
+
+Dos hallazgos delimitan el problema:
+
+- Los workflows de despliegue heredados (`deploy-pr.yaml`, y el job `deployment-tests` de `ci-main.yaml`) apuntan a un proveedor de identidad y a un clúster de Google (`prs-gke-cluster`) que el equipo no controla, así que **fallan siempre tal como vienen**.
+- Pero `ci-main.yaml` **no es inservible**: es una pipeline de CD completa. Lo único atado a Google son cinco valores.
+
+Restricciones: la ventana de la prueba gratuita de Google Cloud es limitada, y activarla ahora para desplegar en noviembre la desperdicia.
+
+## Decisión
+
+**Cada integración a `main` despliega sola**, mediante un workflow propio (`cd-main.yaml`) construido en **dos fases sobre el mismo archivo**:
+
+| | Fase A — ya | Fase B — cerca de la demo |
+|---|---|---|
+| Runner | Self-hosted en la máquina del equipo | `ubuntu-24.04` |
+| Clúster | Docker Desktop local | GKE zonal, nodo spot |
+| Registro | Ninguno | Artifact Registry |
+
+Entre una y otra cambian el *runner* y cinco valores. Los pasos de despliegue, espera, verificación y rollback son idénticos.
+
+Los workflows heredados **se desactivan pasándolos a `workflow_dispatch`, no se borran**: son la referencia de la que sale `cd-main.yaml`.
+
+## Consecuencias
+
+- **+** El proyecto tiene entrega continua real desde la primera semana, sin cuenta de nube y sin consumir crédito.
+- **+** Cuando llegue la fase B, el pipeline ya estará probado. Migrar es cambiar configuración, no escribir un pipeline bajo presión.
+- **+** En la fase A **no hace falta registro de imágenes**: Docker Desktop comparte su almacén con el clúster y Skaffold reconoce `docker-desktop` como clúster local.
+- **+** Habilita el rollback automático y vuelve medibles tres de las cuatro métricas DORA.
+- **+** Demuestra que el destino de despliegue es **configuración, no arquitectura**, que es un argumento fuerte para la materia.
+- **−** Un *runner* self-hosted en un repositorio público es un riesgo real. Obliga a tres mitigaciones no negociables: disparo solo por `push` a `main`, Environment con revisor requerido y `permissions: contents: read`.
+- **−** En la fase A no hay tienda si la máquina está apagada. La fase B lo resuelve.
+- **−** El nodo *spot* de la fase B puede ser reclamado. Hay que recrearlo sin `--spot` la semana de la entrega.
+- **−** Dependencia de la ventana de la prueba gratuita para la fase B.
+
+## Referencias
+
+Diseño del pipeline de despliegue continuo, la comparativa de nubes y la propuesta §3.5.

--- a/docs/adr/0009-consulta-anonima-sin-autenticacion.md
+++ b/docs/adr/0009-consulta-anonima-sin-autenticacion.md
@@ -1,0 +1,32 @@
+# ADR 0009 — La consulta de seguimiento es anónima
+
+**Estado:** Aceptada · 2026-08-25
+
+## Contexto
+
+Consultar un pedido exige decidir quién puede verlo. Online Boutique **no tiene login real**: usa una *cookie* de sesión anónima, y no existe entidad de usuario en ningún servicio.
+
+Alternativas: construir identidad de usuario (fuera de proporción para el alcance), atar la consulta a la cookie de sesión, o permitir la consulta a quien tenga el número de rastreo.
+
+Atar la consulta a la cookie rompería el escenario central de la demostración: hacer un pedido en una computadora, copiar el número, y consultarlo desde otro dispositivo.
+
+## Decisión
+
+**La consulta es anónima: quien tenga el número de rastreo, ve el pedido.** No requiere sesión, cookie ni haber comprado.
+
+Es el mismo modelo que usa el rastreo de cualquier paquetería real: el número se comparte con quien uno quiera.
+
+Queda explícitamente fuera del alcance el historial "mis pedidos" por usuario, que sí dependería de identidad.
+
+## Consecuencias
+
+- **+** Habilita el escenario de la demostración —otra persona, otro dispositivo, otra red— sin construir autenticación.
+- **+** Mantiene el alcance acotado a lo que cabe en el semestre.
+- **+** Es coherente con cómo funciona el rastreo en el mundo real.
+- **−** **Los pedidos son enumerables.** Combinado con el formato de baja entropía del [ADR 0003](0003-conservar-el-tracking-id-aleatorio.md), un tercero podría adivinar números y ver pedidos ajenos.
+- **−** Mitigación adoptada: **la pantalla de seguimiento no muestra dirección, correo ni datos personales** — solo estado, artículos y fecha. Conviene además que la respuesta del RPC de consulta tampoco los devuelva, no solo que la vista no los pinte.
+- **−** En un producto real esto exigiría un identificador de alta entropía y limitación de intentos. Se declara como limitación aceptada de la demostración, no como diseño recomendable.
+
+## Referencias
+
+Propuesta de proyecto §1.3, el flujo de usuario y los mockups del frontend.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,57 @@
+# Decisiones — ADRs del proyecto
+
+Registro de las decisiones arquitectónicas del proyecto, una por nota. Un **ADR** (*Architecture Decision Record*) captura **qué** se decidió, **por qué**, y **qué consecuencias** trae — incluidas las malas.
+
+El razonamiento sale de la propuesta de proyecto del equipo, que se entrega por separado. Lo que aporta este formato es que cada decisión quede **en el repositorio**, encontrable, fechada y con estado propio.
+
+## Las decisiones
+
+| # | Decisión | Estado | Referencia |
+|---|---|---|---|
+| [0001](0001-github-flow-como-estrategia-de-ramificacion.md) | GitHub Flow como estrategia de ramificación | Aceptada | **estrategia-de-ramificacion** |
+| [0002](0002-servicio-nuevo-en-lugar-de-extender-shippingservice.md) | Servicio nuevo en lugar de extender `shippingservice` | Aceptada | Propuesta §2.1 |
+| [0003](0003-conservar-el-tracking-id-aleatorio.md) | Conservar el tracking ID aleatorio, solo persistirlo | Aceptada | Propuesta §2.2 |
+| [0004](0004-redis-con-el-pedido-serializado-como-un-valor.md) | Redis, con el pedido serializado como un solo valor | Aceptada | Propuesta §2.3 |
+| [0005](0005-estado-derivado-del-tiempo-no-almacenado.md) | El estado se deriva del tiempo, no se almacena | Aceptada | Propuesta §2.4 |
+| [0006](0006-registro-sincrono-sin-cola-ni-eventos.md) | Registro síncrono desde `checkoutservice`, sin cola | Aceptada | Propuesta §2.6 |
+| [0007](0007-componente-opcional-con-kill-switch.md) | Componente opcional con *kill switch* | Aceptada | Propuesta §2.8 |
+| [0008](0008-despliegue-continuo-en-dos-fases.md) | Despliegue continuo en dos fases | Aceptada | **pipeline-de-despliegue-continuo** |
+| [0009](0009-consulta-anonima-sin-autenticacion.md) | La consulta de seguimiento es anónima | Aceptada | Propuesta §1.3 |
+
+## Las reglas
+
+- **Una decisión, un archivo.** Si necesitas la palabra "y" para titularlo, probablemente son dos.
+- **Numeración correlativa.** El número nunca se reusa, aunque el ADR quede reemplazado.
+- **Los ADR no se editan.** Cuando una decisión cambia, se escribe uno nuevo que dice *"reemplaza al 000N"*, y el viejo pasa a estado **Reemplazada por 000M**. El rastro de cómo evolucionó el pensamiento es parte del valor.
+- **Las consecuencias negativas son obligatorias.** Un ADR sin la sección de lo que se está pagando no sirve para nada.
+- **Prueba para saber si algo merece ADR:** ¿había una alternativa real que alguien pudo haber elegido, y la elección tiene consecuencias que se van a sentir después? Si no, es detalle de implementación y va en el README.
+
+## Plantilla
+
+```markdown
+# ADR 00NN — <la decisión, en una frase>
+
+**Estado:** Propuesta | Aceptada | Reemplazada por 00MM · AAAA-MM-DD
+
+## Contexto
+La situación, las restricciones y las alternativas que se consideraron.
+
+## Decisión
+Qué se eligió, en voz activa.
+
+## Consecuencias
++ Lo que se gana.
+− Lo que se paga.
+
+## Referencias
+```
+
+## Fechas
+
+Reflejan **cuándo quedó registrada** la decisión, no necesariamente cuándo se discutió por primera vez. Los ADR 0001 a 0007 y el 0009 documentan decisiones que ya estaban tomadas en la **propuesta de proyecto**; el 0008 se registró junto con el diseño del pipeline.
+
+## Páginas relacionadas
+
+- **propuesta-de-proyecto** — la fuente del razonamiento de la mayoría de estos ADR
+- **pipeline-de-despliegue-continuo** · **estrategia-de-rollback** · **observabilidad-y-slis** · **seguridad-en-el-pipeline**
+- **portafolio-de-evidencias** — los ADR son evidencia de la etapa *Planear*


### PR DESCRIPTION
Agrega `docs/adr/` con las nueve decisiones arquitectónicas del proyecto,
una por archivo, en formato ADR (Architecture Decision Record).

El razonamiento ya estaba tomado y documentado; lo que aporta este cambio
es que cada decisión quede en el repositorio, encontrable, fechada y con
estado propio, en lugar de vivir solo dentro de un documento largo.

## Qué incluye

| ADR | Decisión |
|---|---|
| 0001 | GitHub Flow como estrategia de ramificación |
| 0002 | Servicio nuevo en lugar de extender `shippingservice` |
| 0003 | Conservar el tracking ID aleatorio, solo persistirlo |
| 0004 | Redis, con el pedido serializado como un solo valor |
| 0005 | El estado se deriva del tiempo, no se almacena |
| 0006 | Registro síncrono desde `checkoutservice`, sin cola ni eventos |
| 0007 | Componente opcional de Kustomize con kill switch |
| 0008 | Despliegue continuo en dos fases |
| 0009 | La consulta de seguimiento es anónima |

Más `docs/adr/README.md` con el índice, las reglas del formato y la
plantilla para las decisiones que vengan.

## Formato

Cada ADR tiene Estado, Contexto, Decisión y Consecuencias — positivas
**y** negativas. La sección de consecuencias negativas es obligatoria:
un ADR que no dice qué se está pagando no sirve.

Los ADR no se editan. Cuando una decisión cambie, se escribe uno nuevo
que reemplaza al anterior y el viejo pasa a estado "Reemplazada por".

## Qué NO incluye

La propuesta de proyecto, el portafolio de evidencias y la estrategia de
ramificación se entregan por Canvas, no por el repositorio.