### PR TITLE
fix(adservice): copy settings before Gradle initialization

### DIFF
--- a/src/adservice/Dockerfile
+++ b/src/adservice/Dockerfile
@@ -19,7 +19,7 @@ FROM --platform=$BUILDPLATFORM eclipse-temurin:24.0.2_12-jdk-noble@sha256:dacac8
 
 WORKDIR /app
 
-COPY ["build.gradle", "gradlew", "./"]
+COPY ["build.gradle", "settings.gradle", "gradlew", "./"]
 COPY gradle gradle
 RUN chmod +x gradlew
 RUN ./gradlew downloadRepos


### PR DESCRIPTION
## Summary

- copy `settings.gradle` before the first Gradle invocation in the adservice Docker build
- ensure Gradle initializes with the `hipstershop` root project name so `installDist` matches the existing entrypoint

## Validation

- verified `settings.gradle` declares `rootProject.name = 'hipstershop'`
- verified the Dockerfile copies `settings.gradle` before every Gradle invocation
- verified the entrypoint uses `/app/build/install/hipstershop/bin/AdService`
- clean container build unavailable because the local Docker daemon is not running; local Gradle build unavailable because no Java runtime is installed

Resolves GoogleCloudPlatform/microservices-demo#3506