### PR TITLE
fix: tolerate transient paymentservice liveness failures

### DIFF
--- a/helm-chart/templates/paymentservice.yaml
+++ b/helm-chart/templates/paymentservice.yaml
@@ -95,6 +95,7 @@ spec:
         livenessProbe:
           grpc:
             port: 50051
+          failureThreshold: 5
         resources:
           {{- toYaml .Values.paymentService.resources | nindent 10 }}
 ---

--- a/kubernetes-manifests/paymentservice.yaml
+++ b/kubernetes-manifests/paymentservice.yaml
@@ -57,6 +57,7 @@ spec:
         livenessProbe:
           grpc:
             port: 50051
+          failureThreshold: 5
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
### Background

`paymentservice` uses a gRPC liveness probe with Kubernetes defaults. With a 1-second probe timeout, a short network latency spike can cause consecutive liveness failures and restart the container even when the application is only temporarily slow.

I reproduced the behavior described in #3475 by injecting 2 seconds of network latency for a bounded 35-second window.

### Fixes

Relates to #3475

### Change Summary

- Increase the `paymentservice` liveness `failureThreshold` from the default 3 to 5.
- Apply the same change to the Kubernetes manifest and Helm template.
- Keep readiness behavior unchanged so temporary degradation is still detected quickly.

### Additional Notes

This is a small configuration change intended to make liveness less aggressive during transient network degradation. It does not change the liveness timeout or disable liveness checks.

### Testing Procedure

Validated locally with:

- `kubectl apply --dry-run=client -f kubernetes-manifests/paymentservice.yaml`
- `helm template online-boutique ./helm-chart`

Runtime test on a local Kubernetes cluster:

- Baseline: `failureThreshold: 3`
- Injected latency: 2 seconds for 35 seconds
- Observed liveness/readiness probe failures and container restarts
- Test configuration: `failureThreshold: 5`
- Same bounded latency injection
- Readiness and liveness failures were observed, but the pod recovered with `RESTARTS=0`

### Related PRs or Issues

#3475