### PR TITLE
fix(paymentservice): use local Node headers

### DIFF
--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -28,6 +28,8 @@ WORKDIR /usr/src/app
 
 COPY package*.json ./
 
+ENV npm_config_nodedir=/usr/local
+
 RUN npm install --only=production
 
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b


### PR DESCRIPTION
Configure npm to use the Node headers already available in the Node.js Alpine image.
Prevent node-gyp from downloading Node headers during the paymentservice image build.
Improve paymentservice build reliability.
